### PR TITLE
fix(lbcache): store result before triggering a ticker

### DIFF
--- a/pkg/loadbalance/lbcache/cache.go
+++ b/pkg/loadbalance/lbcache/cache.go
@@ -156,11 +156,11 @@ func (b *BalancerFactory) Get(ctx context.Context, target rpcinfo.EndpointInfo) 
 			b:      b,
 			target: desc,
 		}
-		// add self into sharedTicker
-		bl.sharedTicker = getSharedTicker(bl, b.opts.RefreshInterval)
 		// store the res when init
 		bl.res.Store(res)
 		b.cache.Store(desc, bl)
+		// add self into sharedTicker
+		bl.sharedTicker = getSharedTicker(bl, b.opts.RefreshInterval)
 		return bl, nil
 	})
 	if err != nil {


### PR DESCRIPTION
Fix a bug that if a ticker is added before storing the result, it may get a chance to refresh at instant and then encouter a nil pointer exception when trying to load a previous result from the atomic value.