### PR TITLE
Fail fast

### DIFF
--- a/tool/cmd/kitex/args.go
+++ b/tool/cmd/kitex/args.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	logger "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -159,7 +158,8 @@ func (a *arguments) checkServiceName() {
 func (a *arguments) checkPath() {
 	pathToGo, err := exec.LookPath("go")
 	if err != nil {
-		logger.Fatalln(err)
+		log.Warn(err)
+		os.Exit(1)
 	}
 
 	gosrc := filepath.Join(util.GetGOPATH(), "src")

--- a/tool/cmd/kitex/args.go
+++ b/tool/cmd/kitex/args.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	logger "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -156,8 +157,13 @@ func (a *arguments) checkServiceName() {
 }
 
 func (a *arguments) checkPath() {
+	pathToGo, err := exec.LookPath("go")
+	if err != nil {
+		logger.Fatalln(err)
+	}
+
 	gosrc := filepath.Join(util.GetGOPATH(), "src")
-	gosrc, err := filepath.Abs(gosrc)
+	gosrc, err = filepath.Abs(gosrc)
 	if err != nil {
 		log.Warn("Get GOPATH/src path failed:", err.Error())
 		os.Exit(1)
@@ -196,7 +202,7 @@ func (a *arguments) checkPath() {
 			}
 			a.PackagePrefix = filepath.Join(a.ModuleName, a.PackagePrefix, generator.KitexGenPath)
 		} else {
-			if err = initGoMod(a.ModuleName); err != nil {
+			if err = initGoMod(pathToGo, a.ModuleName); err != nil {
 				log.Warn("Init go mod failed:", err.Error())
 				os.Exit(1)
 			}
@@ -210,16 +216,13 @@ func (a *arguments) checkPath() {
 	a.OutputPath = curpath
 }
 
-func initGoMod(module string) error {
+func initGoMod(pathToGo, module string) error {
 	if util.Exists("go.mod") {
 		return nil
 	}
-	gg, err := exec.LookPath("go")
-	if err != nil {
-		return err
-	}
+
 	cmd := &exec.Cmd{
-		Path:   gg,
+		Path:   pathToGo,
 		Args:   []string{"go", "mod", "init", module},
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,

--- a/tool/internal/pkg/util/util.go
+++ b/tool/internal/pkg/util/util.go
@@ -74,13 +74,7 @@ func WriteToFile(filename string, data []byte) {
 
 // GetGOPATH retrieves the GOPATH from environment variables or the `go env` command.
 func GetGOPATH() string {
-	buildContext := build.Default
-	goPath := buildContext.GOPATH
-	if len(goPath) > 0 {
-		return goPath
-	}
-
-	goPath = os.Getenv("GOPATH")
+	goPath := os.Getenv("GOPATH")
 	// If there are many path in GOPATH, pick up the first one.
 	if GoPaths := strings.Split(goPath, ":"); len(GoPaths) > 1 {
 		return GoPaths[0]
@@ -93,6 +87,10 @@ func GetGOPATH() string {
 	}
 
 	goPath = strings.TrimSpace(string(output))
+	if len(goPath) == 0 {
+		buildContext := build.Default
+		goPath = buildContext.GOPATH
+	}
 
 	if len(goPath) == 0 {
 		panic("GOPATH not found")

--- a/tool/internal/pkg/util/util.go
+++ b/tool/internal/pkg/util/util.go
@@ -19,7 +19,6 @@ import (
 	"go/build"
 	"go/format"
 	"io/ioutil"
-	logger "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,7 +88,8 @@ func GetGOPATH() string {
 	// GOPATH not set through environment variables, try to get one by executing "go env GOPATH"
 	output, err := exec.Command("go", "env", "GOPATH").Output()
 	if err != nil {
-		logger.Fatalln(err)
+		log.Warn(err)
+		os.Exit(1)
 	}
 
 	goPath = strings.TrimSpace(string(output))

--- a/tool/internal/pkg/util/util.go
+++ b/tool/internal/pkg/util/util.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"go/build"
 	"go/format"
 	"io/ioutil"
 	"os"
@@ -73,20 +74,27 @@ func WriteToFile(filename string, data []byte) {
 
 // GetGOPATH retrieves the GOPATH from environment variables or the `go env` command.
 func GetGOPATH() string {
-	GoPath := os.Getenv("GOPATH")
+	buildContext := build.Default
+	goPath := buildContext.GOPATH
+	if len(goPath) > 0 {
+		return goPath
+	}
+
+	goPath = os.Getenv("GOPATH")
 	// If there are many path in GOPATH, pick up the first one.
-	if GoPaths := strings.Split(GoPath, ":"); len(GoPaths) > 1 {
+	if GoPaths := strings.Split(goPath, ":"); len(GoPaths) > 1 {
 		return GoPaths[0]
 	}
 	// GOPATH not set through environment variables, try to get one by executing "go env GOPATH"
 	output, err := exec.Command("go", "env", "GOPATH").Output()
 	if err == nil {
-		GoPath = strings.TrimSpace(string(output))
+		goPath = strings.TrimSpace(string(output))
 	}
-	if GoPath == "" {
+
+	if goPath == "" {
 		panic("GOPATH not found")
 	}
-	return GoPath
+	return goPath
 }
 
 // Exists reports whether a file exists.

--- a/tool/internal/pkg/util/util.go
+++ b/tool/internal/pkg/util/util.go
@@ -19,6 +19,7 @@ import (
 	"go/build"
 	"go/format"
 	"io/ioutil"
+	logger "log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,11 +88,13 @@ func GetGOPATH() string {
 	}
 	// GOPATH not set through environment variables, try to get one by executing "go env GOPATH"
 	output, err := exec.Command("go", "env", "GOPATH").Output()
-	if err == nil {
-		goPath = strings.TrimSpace(string(output))
+	if err != nil {
+		logger.Fatalln(err)
 	}
 
-	if goPath == "" {
+	goPath = strings.TrimSpace(string(output))
+
+	if len(goPath) == 0 {
 		panic("GOPATH not found")
 	}
 	return goPath


### PR DESCRIPTION
Hi, 在`tool/cmd/kitex/args.go:159`方法中我看到有通过依赖`go`环境去获取`GOPATH`，这个认为应该是在所有环境检测的基础，虽然用户会通过`go get -u xxx`形式去安装`kitex`, 但是对于直接安装二进制文件的开发者来说，在没有安装`go`环境下，执行`kitext xx.thrift`(这里以生成thrift为例子)则会在获取`GOPATH`时才报错，没有对error做处理，而是通过`GOPATH`是否有值来判断，我觉得应该遵循Fail fast原则，这样能够很精确的让使用者知道问题在哪，而且会少走一些不必要的逻辑。
## case
用户没有安装`go`环境

* 改进前报错
```
panic: GOPATH not found

goroutine 1 [running]:
github.com/cloudwego/kitex/tool/internal/pkg/util.GetGOPATH(0xc000077dd8, 0x40d7db)
	/Users/xxx/goland/go/kitex/tool/internal/pkg/util/util.go:87 +0x1c6
main.(*arguments).checkPath(0xb7f400)
	/Users/xxx/goland/go/kitex/tool/cmd/kitex/args.go:159 +0x37
main.(*arguments).parseArgs(0xb7f400)
	/Users/xxx/goland/go/kitex/tool/cmd/kitex/args.go:122 +0x216
main.main()
	/Users/xxx/goland/go/kitex/tool/cmd/kitex/main.go:64 +0xba
```
> 问题分析
该问题本质是没有安装`go`环境导致，但给使用者传达的信息是找不到`GOPATH`，这就造成了错误的信息传递。

* 改进后
```
exec: "go": executable file not found in $PATH
```