### PR TITLE
fix: correct genertic call name

### DIFF
--- a/pkg/serviceinfo/serviceinfo.go
+++ b/pkg/serviceinfo/serviceinfo.go
@@ -31,9 +31,9 @@ const (
 
 const (
 	// GenericService name
-	GenericService = "$GenericService" // private as "$"
+	GenericService = "_GenericService_" // private as "_xxx_"
 	// GenericMethod name
-	GenericMethod = "$GenericCall"
+	GenericMethod = "_GenericCall_"
 )
 
 // ServiceInfo to record meta info of service


### PR DESCRIPTION
invalid character "$" in generic service and method name for metrics key