### PR TITLE
feat: use merged flush for mux

### DIFF
--- a/pkg/remote/trans/netpollmux/mux_conn.go
+++ b/pkg/remote/trans/netpollmux/mux_conn.go
@@ -127,7 +127,8 @@ func newMuxConn(connection netpoll.Connection) muxConn {
 				}
 			}
 		}
-		err = writer.Flush()
+	}, func() {
+		err := writer.Flush()
 		if err != nil {
 			connection.Close()
 			return


### PR DESCRIPTION
**优化思路：**
多路复用时，KiteX 会有多个 Goroutine 会往单个连接中写入数据，但是只有一个 Goroutine（sharedQueue.ForEach） 负责遍历 queue 去执行真正的 Flush，是一个典型的生产者消费者模型。当负责 Flush 的 Goroutine 出现性能瓶颈时候，由于是 PingPong 模型，会导致生产者端也出现性能瓶颈，最后降低了整体的 QPS 并导致 latency 升高。

之前的实现是对一个分片上的 buffergetter 进行合并包处理发送，新的优化针对整个 queue 上所有包进行合并发送。在高并发下，可以显著地减少 Flush 的次数，以提升“消费者”处理的速度。

**优化前：**
```
【Client QPS】平均: 170162, 最大QPS: 171031
【Client 延迟】PCT50: 566us, PCT90: 855us, PCT99: 1481us, PCT999: 2245us
【CPU占用】平均: 259.49%, 最大: 261.98%
【内存占用】平均: 44359.00KB
```

**优化后：**
```
【Client QPS】平均: 209609, 最大QPS: 213569
【Client 延迟】PCT50: 434us, PCT90: 671us, PCT99: 1414us, PCT999: 2257us
【CPU占用】平均: 245.20%, 最大: 248.99%
【内存占用】平均: 44588.00KB
```

优化效果：QPS 提升 (21-17)/17=23%，PCT90 降低 (855-671)/855=21% 。在 kitex-benchmark Protobuf 测试中，最高能够到 28.8w QPS (原先为 25.4w)。