### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,8 @@ on: pull_request
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,6 +2,10 @@ name: reviewdog
 on: [pull_request]
 jobs:
   staticcheck:
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     name: runner / staticcheck
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows.

### Background

GitHub provides a [feature](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) to set permissions for the GITHUB_TOKEN. I have implemented a [GitHub App](https://github.com/apps/step-security) to automatically calculate the right permissions for a given workflow.  

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows.  

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. Please try it out on other repos and share your feedback. Thanks!