### PR TITLE
fix: use actual listen addr to build RegistryInfo

### DIFF
--- a/pkg/remote/remotesvr/server.go
+++ b/pkg/remote/remotesvr/server.go
@@ -30,7 +30,7 @@ import (
 type Server interface {
 	Start() chan error
 	Stop() error
-	ListenAddr() net.Addr
+	Address() net.Addr
 }
 
 type server struct {
@@ -96,7 +96,7 @@ func (s *server) Stop() (err error) {
 	return
 }
 
-func (s *server) ListenAddr() net.Addr {
+func (s *server) Address() net.Addr {
 	if s.listener != nil {
 		return s.listener.Addr()
 	}

--- a/pkg/remote/remotesvr/server.go
+++ b/pkg/remote/remotesvr/server.go
@@ -30,6 +30,7 @@ import (
 type Server interface {
 	Start() chan error
 	Stop() error
+	ListenAddr() net.Addr
 }
 
 type server struct {
@@ -76,8 +77,12 @@ func (s *server) buildListener() (ln net.Listener, err error) {
 		os.Chmod(addr.String(), os.ModePerm)
 	}
 
-	s.opt.Logger.Infof("KITEX: server listen at: %s", addr.String())
-	return s.transSvr.CreateListener(addr)
+	if ln, err = s.transSvr.CreateListener(addr); err != nil {
+		s.opt.Logger.Errorf("KITEX: server listen at %s failed, err=%v", addr.String(), err)
+	} else {
+		s.opt.Logger.Infof("KITEX: server listen at %s", ln.Addr().String())
+	}
+	return
 }
 
 // Stop stops the server gracefully.
@@ -89,4 +94,11 @@ func (s *server) Stop() (err error) {
 		s.listener = nil
 	}
 	return
+}
+
+func (s *server) ListenAddr() net.Addr {
+	if s.listener != nil {
+		return s.listener.Addr()
+	}
+	return nil
 }

--- a/pkg/remote/remotesvr/server_test.go
+++ b/pkg/remote/remotesvr/server_test.go
@@ -32,13 +32,21 @@ import (
 func TestServerStart(t *testing.T) {
 	isCreateListener := false
 	isBootstrapped := false
+	var ln net.Listener
 	transSvr := &mocks.MockTransServer{
 		CreateListenerFunc: func(addr net.Addr) (listener net.Listener, err error) {
 			isCreateListener = true
-			return nil, nil
+			ln, err = net.Listen("tcp", ":8888")
+			return ln, err
 		},
 		BootstrapServerFunc: func() (err error) {
 			isBootstrapped = true
+			return nil
+		},
+		ShutdownFunc: func() (err error) {
+			if ln != nil {
+				ln.Close()
+			}
 			return nil
 		},
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -179,7 +179,7 @@ func (s *server) Run() (err error) {
 		go onServerStart[i]()
 	}
 	s.Lock()
-	s.buildRegistryInfo(s.svr.ListenAddr())
+	s.buildRegistryInfo(s.svr.Address())
 	s.Unlock()
 
 	if err = s.waitSignal(errCh); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -179,7 +179,7 @@ func (s *server) Run() (err error) {
 		go onServerStart[i]()
 	}
 	s.Lock()
-	s.buildRegistryInfo()
+	s.buildRegistryInfo(s.svr.ListenAddr())
 	s.Unlock()
 
 	if err = s.waitSignal(errCh); err != nil {
@@ -363,12 +363,13 @@ func (s *server) newSvrTransHandler() (handler remote.ServerTransHandler, err er
 	return transPl, nil
 }
 
-func (s *server) buildRegistryInfo() {
+func (s *server) buildRegistryInfo(lAddr net.Addr) {
 	if s.opt.RegistryInfo == nil {
 		s.opt.RegistryInfo = &registry.Info{}
 	}
 	info := s.opt.RegistryInfo
-	info.Addr = s.opt.RemoteOpt.Address
+	// notice: lAddr may be nil when listen failed
+	info.Addr = lAddr
 	if info.ServiceName == "" {
 		info.ServiceName = s.opt.Svr.ServiceName
 	}


### PR DESCRIPTION
Use `WithServiceAddr` to set listen address, but sometimes the actual address is not equal to the set address, like #100.
This PR fix the problem, the actual address will be set to RegistryInfo.