### PR TITLE
ci: remove gofmt, better error reporting on gofumpt check

### DIFF
--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -22,10 +22,9 @@ jobs:
 
       - name: Lint
         run: |
-          test -z "$(gofmt -s -l .)"
           go vet -stdmethods=false $(go list ./...)
           go install mvdan.cc/gofumpt@latest
-          test -z "$(gofumpt -s -l .)"
+          test -z "$(gofumpt -s -l -extra .)"  || echo "Please run 'gofumpt -l -w -extra .'"
 
       - name: Unit Test
         run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...


### PR DESCRIPTION
gofumpt does a stricter format check, so gofmt is not necessary.