### PR TITLE
docs: add use guide for Connection Multiplexing

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -200,8 +200,6 @@ func WithLongConnection(cfg connpool.IdleConfig) Option {
 }
 
 // WithMuxConnection specifies the transport type to be mux.
-// IMPORTANT: this option is not stable, and will be changed or removed in the future!!!
-// We don't promise compatibility for this option in future versions!!!
 func WithMuxConnection(connNum int) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push("WithMuxConnection")

--- a/docs/guide/basic-features/connection_type.md
+++ b/docs/guide/basic-features/connection_type.md
@@ -1,10 +1,10 @@
 # Connection Type
 
-Kitex provides **Short Connection**,  **Long Connection Pool** and **Connection Multiplexing** for different business scenarios. Kitex uses Long Connection Pool by default after >= v0.0.2, but it is still suggested to adjust Pool Config with your need.
+Kitex provides **Short Connection**,  **Long Connection Pool** and **Connection Multiplexing** for different business scenarios. Kitex uses Long Connection Pool by default after v0.0.2, but adjusting the Pool Config according to your need is suggested.
 
 ## Short Connection
 
-Every request need to create connection, the performance is bad, so it is not suggested normally. But sometimes Short Connection must be enabled, it depends on your need. For example, use Long Connection may block process if the server side is Python framework.
+Every request needs to create a connection, the performance is bad, so it is not suggested normally.
 
 Enable Short Connection：
 
@@ -24,7 +24,7 @@ connpool2.IdleConfig{
 }
 ```
 
-But it is suggested to adjust the pool config with your need, you can config it as below:
+Adjusting the Pool Config according to your need is suggested, config as below:
 
 ```
 xxxCli := xxxservice.NewClient("destServiceName", client.WithLongConnection(connpool.IdleConfig{10, 1000, time.Minute}))
@@ -34,14 +34,14 @@ Parameter description:
 
 - `MaxIdlePerAddress`: the maximum number of idle connections per downstream instance
 - `MaxIdleGlobal`: the global maximum number of idle connections
-- `MaxIdleTimeout`: the idle duration of the connection, connection that exceed this duration would be closed (minimum value is 3s, default value is 30s)
+- `MaxIdleTimeout`: the idle duration of the connection, a connection that exceeds this duration would be closed (minimum value is 3s, the default value is 30s)
 
 ### Internal Implementation
 
 Each downstream address corresponds to a connection pool, the connection pool is a ring composed of connections, and the size of the ring is `MaxIdlePerAddress`.
 
 When getting a connection of downstream address, proceed as follows:
-1. Try to fetch a connection from the ring, if fetching failed (no idle connections remained), then try to  establish a new connection. In other words, the number of connections may exceed `MaxIdlePerAddress`
+1. Try to fetch a connection from the ring, if fetching failed (no idle connections remained), then try to establish a new connection. In other words, the number of connections may exceed `MaxIdlePerAddress`
 2. If fetching succeed, then checking whether the idle time of the connection (since the last time it was placed in the connection pool) has exceeded `MaxIdleTimeout`, if yes, would close this connection and create a new connection
 
 When the connection is ready to be returned after used, proceed as follows:
@@ -55,21 +55,21 @@ When the connection is ready to be returned after used, proceed as follows:
 The setting of parameters is suggested as follows:
 - `MaxIdlePerAddress`: the minimum value is 1, otherwise long connections would degenerate to short connections
   - What value should be set should be determined according to the throughput of downstream address. The approximate estimation formula is: `MaxIdlePerAddress = qps_per_dest_host*avg_response_time_sec`
-  - For example, the cost of each request is 100ms, and the request spread to each downstream address is 100QPS, the value is suggested to set to 10, because each connection handles 10 requests per second, 100QPS requires 10 connections to handled
+  - For example, the cost of each request is 100ms, and the request spread to each downstream address is 100QPS, the value is suggested to set to 10, because each connection handles 10 requests per second, 100QPS requires 10 connections to handle
   - In the actual scenario, the fluctuation of traffic is also necessary to be considered. Pay attention, the connection within MaxIdleTimeout will be recycled if it is not used
-  - Summary: this value be set too large or too small would lead to degenerating to short connection
+  - Summary: this value be set too large or too small would lead to degenerating to the short connection
 - `MaxIdleGlobal`: should be larger than the total number of `downstream targets number * MaxIdlePerAddress`
   - Notice: this value is not very valuable, it is suggested to set it to a super large value. In subsequent versions, considers discarding this parameter and providing a new interface
 - `MaxIdleTimeout`: since the server will clean up inactive connections within 10min, the client also needs to clean up long-idle connections in time to avoid using invalid connections. This value cannot exceed 10min when the downstream is also a Kitex service
 
 ## Connection Multiplexing
 
-Client invoke Server only need one connection normally when enable Connection Multiplexing. Connection Multiplexing not only reduces the number of connections, but also performs better than Connection Pool.
+The client invokes the Server only need one connection normally when enabling Connection Multiplexing. Connection Multiplexing not only reduces the number of connections but also performs better than Connection Pool.
 
 Special Note:
 
-1. Connection Multiplexing here is just for Thrift and Kitex Protobuf protocol. If you choose gRPC protocol, it is Connection Multiplexing mode.
-2. When the client enable connection multiplexing, the server must also be enable, otherwise it will lead request timeout. The server side has no restrictions on the client to enable connection multiplexing, it can accept requests for short connection, long connection pool and connection multiplexing.
+1. Connection Multiplexing here is just for Thrift and Kitex Protobuf protocol. If you choose the gRPC protocol, it is Connection Multiplexing mode.
+2. When the client enables connection multiplexing, the server must also be enabled, otherwise, it will lead to request timeout. The server side has no restrictions on the client to enable connection multiplexing, it can accept requests for short connection, long connection pool, and connection multiplexing.
 
 - Server Side Enable:
 
@@ -82,7 +82,7 @@ Special Note:
 - Client Side Enable:
   option: `WithMuxConnection`
 
-  1-2 connection is enough normaly, it is no need to config more.
+  1-2 connection is enough normally, it is no need to config more.
 
   ```go
   xxxCli := NewClient("destServiceName", client.WithMuxConnection(1))
@@ -96,14 +96,13 @@ Connection pooling defines the `Reporter` interface for connection pool status m
 Users should implement the interface themselves and inject it by `SetReporter`.
 
 ```go
-// Reporter report status of connection pool.
+// Reporter report status of the connection pool.
 type Reporter interface {
    ConnSucceed(poolType ConnectionPoolType, serviceName string, addr net.Addr)
    ConnFailed(poolType ConnectionPoolType, serviceName string, addr net.Addr)
    ReuseSucceed(poolType ConnectionPoolType, serviceName string, addr net.Addr)
 }
 
-// SetReporter set the common reporter of connection pool, that can only be set once.
+// SetReporter set the common reporter of a connection pool, that can only be set once.
 func SetReporter(r Reporter)
 ```
-

--- a/docs/guide/basic-features/connection_type.md
+++ b/docs/guide/basic-features/connection_type.md
@@ -34,7 +34,7 @@ Parameter description:
 
 - `MaxIdlePerAddress`: the maximum number of idle connections per downstream instance
 - `MaxIdleGlobal`: the global maximum number of idle connections
-- `MaxIdleTimeout`: the idle duration of the connection, a connection that exceeds this duration would be closed (minimum value is 3s, the default value is 30s)
+- `MaxIdleTimeout`: the idle duration of the connection. A connection that has been idle for more than MaxIdleTimeout will be closed (minimum value is 3s, the default value is 30s)
 
 ### Internal Implementation
 
@@ -42,7 +42,7 @@ Each downstream address corresponds to a connection pool, the connection pool is
 
 When getting a connection of downstream address, proceed as follows:
 1. Try to fetch a connection from the ring, if fetching failed (no idle connections remained), then try to establish a new connection. In other words, the number of connections may exceed `MaxIdlePerAddress`
-2. If fetching succeed, then checking whether the idle time of the connection (since the last time it was placed in the connection pool) has exceeded `MaxIdleTimeout`, if yes, would close this connection and create a new connection
+2. If fetching succeed, then check whether the idle time of the connection (since the last time it was placed in the connection pool) has exceeded MaxIdleTimeout. If yes, this connection will be closed and a new connection will be created.
 
 When the connection is ready to be returned after used, proceed as follows:
 
@@ -68,7 +68,7 @@ The client invokes the Server only need one connection normally when enabling Co
 
 Special Note:
 
-1. Connection Multiplexing here is just for Thrift and Kitex Protobuf protocol. If you choose the gRPC protocol, it is Connection Multiplexing mode.
+1. Connection Multiplexing here is just for Thrift and Kitex Protobuf protocol. If you choose the gRPC protocol, it utilizes Connection Multiplexing mode by default.
 2. When the client enables connection multiplexing, the server must also be enabled, otherwise, it will lead to request timeout. The server side has no restrictions on the client to enable connection multiplexing, it can accept requests for short connection, long connection pool, and connection multiplexing.
 
 - Server Side Enable:

--- a/docs/guide/basic-features/connection_type_cn.md
+++ b/docs/guide/basic-features/connection_type_cn.md
@@ -4,7 +4,7 @@ Kitex 支持短连接、长连接池、连接多路复用，用户可以根据�
 
 ## 短连接
 
-每次请求都会创建一次连接，性能不佳，通常不建议使用。但部分场景必须使用短连接，比如，服务端是 Python 框架，长连接可能导致Block进程。
+每次请求都会创建一次连接，性能不佳，通常不建议使用。但部分场景必须使用短连接，如上游实例数过多时，会增加下游服务的负担，请根据情况来选择。
 
 配置短连接：
 
@@ -85,7 +85,7 @@ xxxCli := xxxservice.NewClient("destServiceName", client.WithLongConnection(conn
 - Client 配置
   option: `WithMuxConnection`
 
-  建议配置  **1-2 个连接即可**
+  建议配置**1-2 个连接**
   
   ```go
   xxxCli := NewClient("destServiceName", client.WithMuxConnection(1))

--- a/docs/guide/basic-features/connection_type_cn.md
+++ b/docs/guide/basic-features/connection_type_cn.md
@@ -1,21 +1,33 @@
-# 连接池
+# 连接类型
 
-Kitex 提供了短连接和长连接两种连接池，用户可以根据自己的业务场景来选择。
+Kitex 支持短连接、长连接池、连接多路复用，用户可以根据自己的业务场景来选择。>= v0.0.2 默认配置了连接池，但建议用户还是根据实际情况调整连接池的大小。
 
 ## 短连接
 
-在不做任何设置的情况下，默认就是短连接。
+每次请求都会创建一次连接，性能不佳，通常不建议使用。但部分场景必须使用短连接，比如，服务端是 Python 框架，长连接可能导致Block进程。
 
-## 长连接
+配置短连接：
 
-在初始化 client 的时候，增加一个 Option：
+```go
+xxxCli := xxxservice.NewClient("destServiceName", client.WithShortConnection())
+```
+
+## 长连接池
+
+Kitex >= v0.0.2 默认配置了连接池，配置参数如下：
 
 ```
-client.WithLongConnection(connpool.IdleConfig{
-    MaxIdlePerAddress: 10,
-    MaxIdleGlobal:     1000,
-    MaxIdleTimeout:    60 * time.Second,
-})
+connpool2.IdleConfig{
+   MaxIdlePerAddress: 10,
+   MaxIdleGlobal:     100,
+   MaxIdleTimeout:    time.Minute,
+}
+```
+
+建议用户根据实际情况调整连接池大小，配置方式如下：
+
+```
+xxxCli := xxxservice.NewClient("destServiceName", client.WithLongConnection(connpool.IdleConfig{10, 1000, time.Minute}))
 ```
 
 其中：
@@ -52,6 +64,33 @@ client.WithLongConnection(connpool.IdleConfig{
 - `MaxIdleGlobal` 表示总的空闲连接数应大于 `下游目标总数*MaxIdlePerAddress`，超出部分是为了限制未能从连接池中获取连接而主动新建连接的总数量
     - 注意：该值存在的价值不大，建议设置为一个较大的值，在后续版本中考虑废弃该参数并提供新的接口
 - `MaxIdleTimeout` 表示连接空闲时间，由于 server 在 10min 内会清理不活跃的连接，因此 client 端也需要及时清理空闲较久的连接，避免使用无效的连接，该值在下游也为 Kitex 时不可超过 10min
+
+## 连接多路复用
+
+开启连接多路复用，Client 访问 Server 常规只需要**1个连接**即可，相比连接池极限测试吞吐表现更好（目前的极限测试配置了2个连接），且能大大减少连接数量。
+
+特别说明：
+
+1. 这里的连接多路复用是针对于 Thrift 和 Kitex Protobuf，如果配置 gRPC 协议，默认是连接多路复用。
+2. Client 开启连接多路复用，Server 必须也开启，否则会导致请求超时；Server 开启连接多路复用对 Client 没有限制，可以接受短连接、长连接池、连接多路复用的请求。
+
+- Server 配置
+
+  option: `WithMuxTransport`
+
+  ```go
+  svr := xxxservice.NewServer(handler, server.WithMuxTransport())
+  ```
+  
+- Client 配置
+  option: `WithMuxConnection`
+
+  建议配置  **1-2 个连接即可**
+  
+  ```go
+  xxxCli := NewClient("destServiceName", client.WithMuxConnection(1))
+  ```
+  
 
 ## 状态监控
 

--- a/docs/guide/basic-features/message_type.md
+++ b/docs/guide/basic-features/message_type.md
@@ -35,7 +35,7 @@ struct Response {
 
 service EchoService {
     Response Echo(1: Request req); // pingpong method
-    oneway void Echo(1: Request req); // oneway method
+    oneway void VisitOneway(1: Request req); // oneway method
 }
 ```
 
@@ -67,10 +67,12 @@ import (
 type handler struct {}
 
 func (handler) Echo(ctx context.Context, req *echo.Request) (r *echo.Response, err error) {
+    // ...
     return &echo.Response{ Msg: "world" }
 }
 
-func (handler) Echo1(ctx context.Context, req *echo.Request) (err error) {
+func (handler) VisitOneway(ctx context.Context, req *echo.Request) (err error) {
+    // ...
     return nil
 }
 
@@ -96,7 +98,7 @@ import (
 )
 
 func main() {
-    cli, err := echoservice.NewClient("p.s.m")
+    cli, err := echoservice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -123,7 +125,7 @@ import (
 )
 
 func main() {
-    cli, err := echoservice.NewClient("p.s.m")
+    cli, err := echoservice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -269,7 +271,7 @@ import (
 }
 
 func main() {
-    cli, err := echoseervice.NewClient("p.s.m")
+    cli, err := echoseervice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -298,7 +300,7 @@ import (
 }
 
 func main() {
-    cli, err := echoseervice.NewClient("p.s.m")
+    cli, err := echoseervice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -329,7 +331,7 @@ import (
 }
 
 func main() {
-    cli, err := echoseervice.NewClient("p.s.m")
+    cli, err := echoseervice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }

--- a/docs/guide/basic-features/message_type_cn.md
+++ b/docs/guide/basic-features/message_type_cn.md
@@ -35,7 +35,7 @@ struct Response {
 
 service EchoService {
     Response Echo(1: Request req); // pingpong method
-    oneway void Echo(1: Request req); // oneway method
+    oneway void VisitOneway(1: Request req); // oneway method
 }
 ```
 
@@ -67,10 +67,12 @@ import (
 type handler struct {}
 
 func (handler) Echo(ctx context.Context, req *echo.Request) (r *echo.Response, err error) {
+    // ...
     return &echo.Response{ Msg: "world" }
 }
 
-func (handler) Echo1(ctx context.Context, req *echo.Request) (err error) {
+func (handler) VisitOneway(ctx context.Context, req *echo.Request) (err error) {
+    // ...
     return nil
 }
 
@@ -96,7 +98,7 @@ import (
 )
 
 func main() {
-    cli, err := echoservice.NewClient("p.s.m")
+    cli, err := echoservice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -123,13 +125,13 @@ import (
 )
 
 func main() {
-    cli, err := echoservice.NewClient("p.s.m")
+    cli, err := echoservice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
     req := echo.NewRequest()
     req.Msg = "hello"
-    err = cli.Echo1(req)
+    err = cli.VisitOneway(req)
     if err != nil {
         panic(err)
     }
@@ -269,7 +271,7 @@ import (
 }
 
 func main() {
-    cli, err := echoseervice.NewClient("p.s.m")
+    cli, err := echoseervice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -298,7 +300,7 @@ import (
 }
 
 func main() {
-    cli, err := echoseervice.NewClient("p.s.m")
+    cli, err := echoseervice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }
@@ -329,7 +331,7 @@ import (
 }
 
 func main() {
-    cli, err := echoseervice.NewClient("p.s.m")
+    cli, err := echoseervice.NewClient("destServiceName")
     if err != nil {
         panic(err)
     }

--- a/docs/guide/extension/service_discovery.md
+++ b/docs/guide/extension/service_discovery.md
@@ -51,7 +51,7 @@ func main() {
     opt := client.WithResolver(YOUR_RESOLVER)
 
     // new client
-    xxx.NewClient("p.s.m", opt)
+    xxx.NewClient("destServiceName", opt)
 }
 ```
 

--- a/docs/guide/extension/service_discovery_cn.md
+++ b/docs/guide/extension/service_discovery_cn.md
@@ -55,7 +55,7 @@ func main() {
     opt := client.WithResolver(YOUR_RESOLVER)
 
     // new client
-    xxx.NewClient("p.s.m", opt)
+    xxx.NewClient("destServiceName", opt)
 }
 ```
 

--- a/pkg/generic/binary_test/generic_test.go
+++ b/pkg/generic/binary_test/generic_test.go
@@ -141,7 +141,7 @@ func TestRawThriftBinary2NormalServer(t *testing.T) {
 
 func initRawThriftBinaryClient() genericclient.Client {
 	g := generic.BinaryThriftGeneric()
-	cli := newGenericClient("p.s.m", g, "127.0.0.1:9009")
+	cli := newGenericClient("destServiceName", g, "127.0.0.1:9009")
 	return cli
 }
 

--- a/pkg/generic/json_test/generic_test.go
+++ b/pkg/generic/json_test/generic_test.go
@@ -147,7 +147,7 @@ func initThriftMockClient(t *testing.T) genericclient.Client {
 	test.Assert(t, err == nil)
 	g, err := generic.JSONThriftGeneric(p)
 	test.Assert(t, err == nil)
-	cli := newGenericClient("p.s.m", g, "127.0.0.1:9119")
+	cli := newGenericClient("destServiceName", g, "127.0.0.1:9119")
 	test.Assert(t, err == nil)
 	return cli
 }
@@ -161,7 +161,7 @@ func initThriftClientByIDL(t *testing.T, addr, idl string) genericclient.Client 
 	test.Assert(t, err == nil)
 	g, err := generic.JSONThriftGeneric(p)
 	test.Assert(t, err == nil)
-	cli := newGenericClient("p.s.m", g, addr)
+	cli := newGenericClient("destServiceName", g, addr)
 	test.Assert(t, err == nil)
 	return cli
 }

--- a/pkg/generic/map_test/generic_test.go
+++ b/pkg/generic/map_test/generic_test.go
@@ -145,7 +145,7 @@ func initThriftMockClient(t *testing.T) genericclient.Client {
 	test.Assert(t, err == nil)
 	g, err := generic.MapThriftGeneric(p)
 	test.Assert(t, err == nil)
-	cli := newGenericClient("p.s.m", g, "127.0.0.1:9019")
+	cli := newGenericClient("destServiceName", g, "127.0.0.1:9019")
 	test.Assert(t, err == nil)
 	return cli
 }
@@ -159,7 +159,7 @@ func initThriftClientByIDL(t *testing.T, addr, idl string) genericclient.Client 
 	test.Assert(t, err == nil)
 	g, err := generic.MapThriftGeneric(p)
 	test.Assert(t, err == nil)
-	cli := newGenericClient("p.s.m", g, addr)
+	cli := newGenericClient("destServiceName", g, addr)
 	test.Assert(t, err == nil)
 	return cli
 }

--- a/server/option.go
+++ b/server/option.go
@@ -64,8 +64,6 @@ func WithSuite(suite Suite) Option {
 }
 
 // WithMuxTransport specifies the transport type to be mux.
-// IMPORTANT: this option is not stable, and will be changed or removed in the future!!!
-// We don't promise compatibility for this option in future versions!!!
 func WithMuxTransport() Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push("WithMuxTransport()")


### PR DESCRIPTION
en: add use guide for Connection Multiplexing
zh: 增加连接多路复用使用说明