### PR TITLE
hotfix: disable timeout for streaming

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -81,10 +81,13 @@ func rpcTimeoutMW(mwCtx context.Context) endpoint.Middleware {
 	logger := mwCtx.Value(endpoint.CtxLoggerKey).(klog.FormatLogger)
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request, response interface{}) error {
-			var err error
 			ri := rpcinfo.GetRPCInfo(ctx)
-			tm := ri.Config().RPCTimeout()
+			if enabledStreaming := ri.Config().EnabledStreaming(); enabledStreaming {
+				return next(ctx, request, response)
+			}
 
+			var err error
+			tm := ri.Config().RPCTimeout()
 			start := time.Now()
 			ctx, cancel := context.WithTimeout(ctx, tm+moreTimeout)
 			defer cancel()

--- a/client/stream.go
+++ b/client/stream.go
@@ -45,6 +45,9 @@ func (kc *kClient) Stream(ctx context.Context, method string, request, response 
 	var ri rpcinfo.RPCInfo
 	ctx, ri = kc.initRPCInfo(ctx, method)
 
+	rpcinfo.AsMutableRPCConfig(ri.Config()).SetEnableStreaming(true)
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
+
 	ctx = kc.opt.TracerCtl.DoStart(ctx, ri, kc.opt.Logger)
 	return kc.sEps(ctx, request, response)
 }

--- a/pkg/rpcinfo/interface.go
+++ b/pkg/rpcinfo/interface.go
@@ -73,6 +73,7 @@ type RPCConfig interface {
 	Timeouts
 	IOBufferSize() int
 	TransportProtocol() transport.Protocol
+	EnabledStreaming() bool
 }
 
 // Invocation contains specific information about the call.

--- a/pkg/rpcinfo/mutable.go
+++ b/pkg/rpcinfo/mutable.go
@@ -46,6 +46,8 @@ type MutableRPCConfig interface {
 	LockConfig(bits int)
 	Clone() MutableRPCConfig
 	ImmutableView() RPCConfig
+
+	SetEnableStreaming(enabled bool) error
 }
 
 // MutableRPCStats is used to change the information in the RPCStats.

--- a/pkg/rpcinfo/rpcconfig.go
+++ b/pkg/rpcinfo/rpcconfig.go
@@ -36,6 +36,7 @@ var (
 	defaultConnectTimeout   = time.Millisecond * 50
 	defaultReadWriteTimeout = time.Second * 5
 	defaultBufferSize       = 4096
+	defaultEnabledStreaming = false
 )
 
 // Mask bits.
@@ -54,6 +55,7 @@ type rpcConfig struct {
 	readWriteTimeout  time.Duration
 	ioBufferSize      int
 	transportProtocol transport.Protocol
+	enabledStreaming  bool
 }
 
 func init() {
@@ -156,6 +158,15 @@ func (r *rpcConfig) SetTransportProtocol(tp transport.Protocol) error {
 	return nil
 }
 
+func (r* rpcConfig) SetEnableStreaming(enabled bool) error {
+	r.enabledStreaming = enabled
+	return nil
+}
+
+func (r *rpcConfig) EnabledStreaming() bool {
+	return r.enabledStreaming
+}
+
 // Clone returns a copy of the current rpcConfig.
 func (r *rpcConfig) Clone() MutableRPCConfig {
 	r2 := rpcConfigPool.Get().(*rpcConfig)
@@ -185,5 +196,6 @@ func NewRPCConfig() RPCConfig {
 	r.connectTimeout = defaultConnectTimeout
 	r.readWriteTimeout = defaultReadWriteTimeout
 	r.ioBufferSize = defaultBufferSize
+	r.enabledStreaming = defaultEnabledStreaming
 	return r
 }


### PR DESCRIPTION
hotfix: disable timeout for streaming by adding `enabledStreaming` in `rpcinfo.config` and check the config when constructing Stream