### PR TITLE
fix: remove reflection of option arguments to prevent data-race

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -363,7 +363,7 @@ func WithBackupRequest(p *retry.BackupPolicy) Option {
 // WithCircuitBreaker adds a circuitbreaker suite for the client.
 func WithCircuitBreaker(s *circuitbreak.CBSuite) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
-		di.Push(fmt.Sprintf("WithCircuitBreaker(%+v)", s))
+		di.Push(fmt.Sprintf("WithCircuitBreaker()"))
 		o.CBSuite = s
 	}}
 }


### PR DESCRIPTION
`UpdateControl` 本身常在异步 goroutine 里使用，因此在 NewClient 的线程里通过 `fmt.Sprintf %+v` 读取 `CBSuite` 的字段会有潜在的 data-race 问题。而 `CBSuite` 的字段详情对于调试信息本身意义不大，因此去掉。