### PR TITLE
fix: rpc finished error may happen small probability in failure retry scenario && add sample check for retry circuit breaking

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -363,7 +363,7 @@ func WithBackupRequest(p *retry.BackupPolicy) Option {
 // WithCircuitBreaker adds a circuitbreaker suite for the client.
 func WithCircuitBreaker(s *circuitbreak.CBSuite) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
-		di.Push(fmt.Sprintf("WithCircuitBreaker()"))
+		di.Push("WithCircuitBreaker()")
 		o.CBSuite = s
 	}}
 }

--- a/pkg/retry/policy.go
+++ b/pkg/retry/policy.go
@@ -73,7 +73,10 @@ type StopPolicy struct {
 	CBPolicy         CBPolicy `json:"cb_policy"`
 }
 
-const defaultCBErrRate = 0.1
+const (
+	defaultCBErrRate = 0.1
+	cbMinSample      = 10
+)
 
 // CBPolicy is the circuit breaker policy
 type CBPolicy struct {

--- a/pkg/retry/util.go
+++ b/pkg/retry/util.go
@@ -95,7 +95,7 @@ func circuitBreakerStop(ctx context.Context, policy StopPolicy, cbC *cbContainer
 	metricer := cbC.cbPanel.GetMetricer(cbKey)
 	errRate := metricer.ErrorRate()
 	sample := metricer.Samples()
-	if errRate < policy.CBPolicy.ErrorRate {
+	if sample < cbMinSample || errRate < policy.CBPolicy.ErrorRate {
 		return false, ""
 	}
 	return true, fmt.Sprintf("retry circuit break, errRate=%0.3f, sample=%d", errRate, sample)


### PR DESCRIPTION
zh: 修复在失败重试场景会小概率触发“rpc finished error”问题 && 重试熔断增加sample判断避免低qps时重试无法生效问题
