### PR TITLE
perf: support gRPC client connection pool

### DIFF
--- a/pkg/remote/trans/nphttp2/conn_pool.go
+++ b/pkg/remote/trans/nphttp2/conn_pool.go
@@ -18,69 +18,127 @@ package nphttp2
 
 import (
 	"context"
-	"io"
 	"net"
+	"runtime"
 	"sync"
-
-	"github.com/cloudwego/netpoll"
+	"sync/atomic"
+	"time"
 
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
-
+	"github.com/cloudwego/netpoll"
 	"golang.org/x/sync/singleflight"
 )
 
+var _ remote.LongConnPool = &connPool{}
+
+func poolSize() int32 {
+	numP := runtime.GOMAXPROCS(0)
+	return int32(numP * 3 / 2)
+}
+
 // NewConnPool ...
-func NewConnPool() remote.LongConnPool {
-	return &connPool{}
+func NewConnPool() *connPool {
+	return &connPool{
+		size: poolSize(),
+	}
 }
 
 // MuxPool manages a pool of long connections.
 type connPool struct {
+	size  int32
 	sfg   singleflight.Group
-	conns sync.Map // key address, value *clientConn
+	conns sync.Map // key: address, value: *transports
+}
+
+type transports struct {
+	index         int32
+	size          int32
+	cliTransports []grpc.ClientTransport
+}
+
+func (t *transports) get() grpc.ClientTransport {
+	idx := atomic.AddInt32(&t.index, 1)
+	return t.cliTransports[idx%t.size]
+}
+
+func (t *transports) put(trans grpc.ClientTransport) {
+	for i := 0; i < int(t.size); i++ {
+		if t.cliTransports[i] == nil {
+			t.cliTransports[i] = trans
+			return
+		}
+	}
+}
+
+func (t *transports) reset() {
+	curIdx := atomic.LoadInt32(&t.index)
+	t.cliTransports[curIdx%t.size] = nil
+}
+
+func (c *transports) close() {
+	for i := range c.cliTransports {
+		if c.cliTransports[i] != nil {
+			c.cliTransports[i].GracefulClose()
+		}
+	}
 }
 
 var _ remote.LongConnPool = (*connPool)(nil)
 
+func newTransport(dialer remote.Dialer, network, address string, connectTimeout time.Duration) (grpc.ClientTransport, error) {
+	conn, err := dialer.DialTimeout(network, address, connectTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return grpc.NewClientTransport(
+		context.Background(),
+		conn.(netpoll.Connection),
+		nil,
+		nil,
+	)
+}
+
 // Get pick or generate a net.Conn and return
 func (p *connPool) Get(ctx context.Context, network, address string, opt *remote.ConnOption) (net.Conn, error) {
+	var (
+		trans *transports
+		conn  *clientConn
+		err   error
+	)
+
 	v, ok := p.conns.Load(address)
 	if ok {
-		tr := v.(grpc.ClientTransport)
-		conn, err := newClientConn(ctx, tr, address)
-		if err != nil {
-			p.conns.Delete(address)
-			return nil, err
+		trans = v.(*transports)
+		if tr := trans.get(); tr != nil {
+			conn, err = newClientConn(ctx, tr, address)
+			if err != nil {
+				tr.GracefulClose()
+				trans.reset()
+				return nil, err
+			}
+			return conn, nil
 		}
-		return conn, nil
 	}
 	tr, err, _ := p.sfg.Do(address, func() (i interface{}, e error) {
-		conn, err := opt.Dialer.DialTimeout(network, address, opt.ConnectTimeout)
+		tr, err := newTransport(opt.Dialer, network, address, opt.ConnectTimeout)
 		if err != nil {
 			return nil, err
 		}
-		tr, err := grpc.NewClientTransport(context.Background(), conn.(netpoll.Connection), func(r grpc.GoAwayReason) {
-			p.conns.Delete(address)
-		}, func() {
-			// delete from conn pool
-			p.conns.Delete(address)
-		})
-		if err != nil {
-			return nil, err
+		if trans == nil {
+			trans = &transports{
+				size:          p.size,
+				cliTransports: make([]grpc.ClientTransport, p.size),
+			}
 		}
-		p.conns.Store(address, tr)
+		trans.put(tr)
+		p.conns.Store(address, trans)
 		return tr, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	conn, err := newClientConn(ctx, tr.(grpc.ClientTransport), address)
-	if err != nil {
-		p.conns.Delete(address)
-		return nil, err
-	}
-	return conn, nil
+	return newClientConn(ctx, tr.(grpc.ClientTransport), address)
 }
 
 // Put implements the ConnPool interface.
@@ -97,15 +155,15 @@ func (p *connPool) Discard(conn net.Conn) error {
 func (p *connPool) Clean(network, address string) {
 	if v, ok := p.conns.Load(address); ok {
 		p.conns.Delete(address)
-		v.(io.Closer).Close()
+		v.(*transports).close()
 	}
 }
 
 // Close is to release resource of ConnPool, it is executed when client is closed.
 func (p *connPool) Close() error {
-	p.conns.Range(func(addr, clientConn interface{}) bool {
+	p.conns.Range(func(addr, trans interface{}) bool {
 		p.conns.Delete(addr)
-		clientConn.(io.Closer).Close()
+		trans.(*transports).close()
 		return true
 	})
 	return nil


### PR DESCRIPTION
Support client connection pool for gRPC, compared with using a single connection, would improve the throughput.