### PR TITLE
perf: use strings.Builder to concatenate string

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudwego/kitex/internal/wpool"
@@ -56,10 +58,17 @@ func panicToErr(ctx context.Context, panicInfo interface{}, ri rpcinfo.RPCInfo, 
 }
 
 func makeTimeoutErr(ctx context.Context, start time.Time, timeout time.Duration) error {
+	var str strings.Builder
 	ri := rpcinfo.GetRPCInfo(ctx)
 	to := ri.To()
 
-	errMsg := fmt.Sprintf("timeout=%v, to=%s, method=%s", timeout, to.ServiceName(), to.Method())
+	str.WriteString("timeout=")
+	str.WriteString(strconv.FormatInt(int64(timeout), 10))
+	str.WriteString(", to=")
+	str.WriteString(to.ServiceName())
+	str.WriteString(", method=")
+	str.WriteString(to.Method())
+	errMsg:=str.String()
 	target := to.Address()
 	if target != nil {
 		errMsg = fmt.Sprintf("%s, remote=%s", errMsg, target.String())

--- a/pkg/kerrors/kerrors.go
+++ b/pkg/kerrors/kerrors.go
@@ -92,7 +92,11 @@ type DetailedError struct {
 func (de *DetailedError) Error() string {
 	msg := appendErrMsg(de.basic.Error(), de.extraMsg)
 	if de.cause != nil {
-		return msg + ": " + de.cause.Error()
+		var strBuilder strings.Builder
+		strBuilder.WriteString(msg)
+		strBuilder.WriteString(": ")
+		strBuilder.WriteString(de.cause.Error())
+		return strBuilder.String()
 	}
 	return msg
 }

--- a/pkg/klog/log.go
+++ b/pkg/klog/log.go
@@ -18,7 +18,8 @@ package klog
 
 import (
 	"context"
-	"fmt"
+	"strings"
+	"strconv"
 )
 
 // FormatLogger is a logger interface that output logs with a format.
@@ -93,5 +94,9 @@ func (lv Level) toString() string {
 	if lv >= LevelTrace && lv <= LevelFatal {
 		return strs[lv]
 	}
-	return fmt.Sprintf("[?%d] ", lv)
+	var strBuilder strings.Builder
+	strBuilder.WriteString("[?")
+	strBuilder.WriteString(strconv.Itoa(int(lv)))
+	strBuilder.WriteString("] ")
+	return strBuilder.String()
 }

--- a/pkg/loadbalance/lbcache/cache.go
+++ b/pkg/loadbalance/lbcache/cache.go
@@ -19,7 +19,8 @@ package lbcache
 
 import (
 	"context"
-	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -84,7 +85,16 @@ type BalancerFactory struct {
 }
 
 func cacheKey(resolver, balancer string, opts Options) string {
-	return fmt.Sprintf("%s|%s|{%s %s}", resolver, balancer, opts.RefreshInterval, opts.ExpireInterval)
+	var buffer strings.Builder
+	buffer.WriteString(resolver)
+	buffer.WriteString("|")
+	buffer.WriteString(balancer)
+	buffer.WriteString("|{")
+	buffer.WriteString(strconv.FormatInt(int64(opts.RefreshInterval), 10))
+	buffer.WriteString(" ")
+	buffer.WriteString(strconv.FormatInt(int64(opts.ExpireInterval), 10))
+	buffer.WriteString("}")
+	return buffer.String()
 }
 
 // NewBalancerFactory get or create a balancer factory for balancer instance
@@ -136,7 +146,11 @@ func (b *BalancerFactory) watcher() {
 
 // cache key with resolver name prefix avoid conflict for balancer
 func renameResultCacheKey(res *discovery.Result, resolverName string) {
-	res.CacheKey = resolverName + ":" + res.CacheKey
+	var buffer strings.Builder
+	buffer.WriteString(resolverName)
+	buffer.WriteString(":")
+	buffer.WriteString(res.CacheKey)
+	res.CacheKey = buffer.String()
 }
 
 // Get create a new balancer if not exists

--- a/pkg/remote/trans/nphttp2/client_conn.go
+++ b/pkg/remote/trans/nphttp2/client_conn.go
@@ -18,9 +18,9 @@ package nphttp2
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
@@ -36,11 +36,18 @@ type clientConn struct {
 var _ net.Conn = (*clientConn)(nil)
 
 func newClientConn(ctx context.Context, tr grpc.ClientTransport, addr string) (*clientConn, error) {
+	var str strings.Builder
 	ri := rpcinfo.GetRPCInfo(ctx)
+	str.WriteString("/")
+	str.WriteString(ri.Invocation().PackageName())
+	str.WriteString(".")
+	str.WriteString(ri.Invocation().ServiceName())
+	str.WriteString("/")
+	str.WriteString(ri.Invocation().MethodName())
 	s, err := tr.NewStream(ctx, &grpc.CallHdr{
 		Host: ri.To().ServiceName(),
 		// grpc method format /package.Service/Method
-		Method: fmt.Sprintf("/%s.%s/%s", ri.Invocation().PackageName(), ri.Invocation().ServiceName(), ri.Invocation().MethodName()),
+		Method: str.String(),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/retry/retryer.go
+++ b/pkg/retry/retryer.go
@@ -20,6 +20,8 @@ package retry
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -143,13 +145,26 @@ func (rc *Container) NotifyPolicyChange(method string, p Policy) {
 	if ok && r != nil {
 		retryer, ok := r.(Retryer)
 		if ok {
+			var str strings.Builder
 			if retryer.Type() == p.Type {
 				retryer.UpdatePolicy(p)
-				rc.msg = fmt.Sprintf("update retryer[%s-%s] at %s", method, retryer.Type(), time.Now())
+				str.WriteString("update retryer[")
+				str.WriteString(method)
+				str.WriteString("-")
+				str.WriteString(strconv.Itoa(int(retryer.Type())))
+				str.WriteString("] at ")
+				str.WriteString(time.Now().String())
+				rc.msg = str.String()
 				return
 			}
+			str.WriteString("delete retryer[")
+			str.WriteString(method)
+			str.WriteString("-")
+			str.WriteString(strconv.Itoa(int(retryer.Type())))
+			str.WriteString("] at ")
+			str.WriteString(time.Now().String())
 			rc.retryerMap.Delete(method)
-			rc.msg = fmt.Sprintf("delete retryer[%s-%s] at %s", method, retryer.Type(), time.Now())
+			rc.msg = str.String()
 		}
 	}
 	rc.initRetryer(method, p)

--- a/pkg/retry/util.go
+++ b/pkg/retry/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"strconv"
+	"strings"
 
 	"github.com/bytedance/gopkg/cloud/metainfo"
 	"github.com/cloudwego/kitex/pkg/kerrors"
@@ -89,6 +90,7 @@ func chainStop(ctx context.Context, policy StopPolicy) (bool, string) {
 }
 
 func circuitBreakerStop(ctx context.Context, policy StopPolicy, cbC *cbContainer, request interface{}, cbKey string) (bool, string) {
+	var str strings.Builder
 	if cbC.cbCtl == nil || cbC.cbPanel == nil {
 		return false, ""
 	}
@@ -98,7 +100,11 @@ func circuitBreakerStop(ctx context.Context, policy StopPolicy, cbC *cbContainer
 	if sample < cbMinSample || errRate < policy.CBPolicy.ErrorRate {
 		return false, ""
 	}
-	return true, fmt.Sprintf("retry circuit break, errRate=%0.3f, sample=%d", errRate, sample)
+	str.WriteString("retry circuit break, errRate=")
+	str.WriteString(strconv.FormatFloat(errRate, 'f', 3, 64))
+	str.WriteString(", sample=")
+	str.WriteString(strconv.FormatInt(sample, 10))
+	return true, str.String()
 }
 
 func handleRetryInstance(retrySameNode bool, prevRI, retryRI rpcinfo.RPCInfo) {


### PR DESCRIPTION
strings.Builder  has  better performance  than  fmt.Spintf  in  concatenating  string ,using strings.Builder is a better choice.

I only made this change in some more invoked scenarios. In some scenarios where is error or fail which maybe is less invoked  

 , I didn't make this change.