### PR TITLE
feat: server add optional to not wait for system signal

### DIFF
--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -152,3 +152,11 @@ func WithBoundHandler(h remote.BoundHandler) Option {
 		doAddBoundHandler(h, o.RemoteOpt)
 	}}
 }
+
+// WithExitSignal adds ExitSignal for server.
+func WithExitSignal(f func() <-chan error) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("AddExitSignal(%+v)", utils.GetFuncName(f)))
+		o.ExitSignal = f
+	}}
+}


### PR DESCRIPTION
we want to wrap kitex server in our SDK, so KiteX server should be the same life cycle as SDK and not listen to system signal.

* add a option to set ExitSignal
* Cons: will add 1 more goruotine per kitex server, that listen to system signal