### PR TITLE
fix(tool): fix the issue of the -use option when used with protobuf

### DIFF
--- a/tool/cmd/kitex/main.go
+++ b/tool/cmd/kitex/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -146,7 +147,6 @@ func buildCmd(a *arguments, out io.Writer) *exec.Cmd {
 			cmd.Args = append(cmd.Args, "-p", p)
 		}
 		cmd.Args = append(cmd.Args, a.IDL)
-		log.Info(strings.Join(cmd.Args, " "))
 	} else {
 		a.ThriftOptions = a.ThriftOptions[:0]
 		// "protobuf"
@@ -155,14 +155,18 @@ func buildCmd(a *arguments, out io.Writer) *exec.Cmd {
 			cmd.Args = append(cmd.Args, "-I", inc)
 		}
 		outPath := filepath.Join(".", generator.KitexGenPath)
-		os.MkdirAll(outPath, 0o755)
+		if a.Use == "" {
+			os.MkdirAll(outPath, 0o755)
+		} else {
+			outPath = "."
+		}
 		cmd.Args = append(cmd.Args,
 			"--kitex_out="+outPath,
 			"--kitex_opt="+kas,
 			a.IDL,
 		)
-		log.Info(strings.Join(cmd.Args, " "))
 	}
+	log.Info(strings.ReplaceAll(strings.Join(cmd.Args, " "), kas, fmt.Sprintf("%q", kas)))
 	return cmd
 }
 

--- a/tool/internal/pkg/pluginmode/protoc/plugin.go
+++ b/tool/internal/pkg/pluginmode/protoc/plugin.go
@@ -165,9 +165,7 @@ func (pp *protocPlugin) process(gen *protogen.Plugin) {
 		if pp.Config.Use != "" && f.Proto.GetName() != idl {
 			continue
 		}
-		if pp.Config.Use == "" {
-			pp.GenerateFile(gen, f)
-		}
+		pp.GenerateFile(gen, f)
 	}
 
 	if pp.Config.GenerateMain {
@@ -321,8 +319,11 @@ func (pp *protocPlugin) makeInterfaces(gf *protogen.GeneratedFile, file *protoge
 	}{pp.Config.Version, is}
 }
 
-func (pp *protocPlugin) adjustPath(path string) string {
-	cur, _ := filepath.Abs(filepath.Join(".", generator.KitexGenPath))
+func (pp *protocPlugin) adjustPath(path string) (ret string) {
+	cur, _ := filepath.Abs(".")
+	if pp.Config.Use == "" {
+		cur = filepath.Join(cur, generator.KitexGenPath)
+	}
 	if filepath.IsAbs(path) {
 		path, _ = filepath.Rel(cur, path)
 		return path


### PR DESCRIPTION
Line tool/internal/pkg/pluginmode/protoc/plugin.go:168 skips IDL parsing when the '-use' option is specified. This causes a 'no service defined' error.

However, removing the if condition does not solve the problem: line tool/cmd/kitex/main.go:158 creates the 'kitex_gen' directory in any way and then results an empty folder. But if we do not create 'kitex_gen' protoc will complain the output path is not found. So we should also change the output path and the 'adjustPath' function when the '-use' option is specified.
