### PR TITLE
fix: enable server error handle middleware

### DIFF
--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -264,7 +264,7 @@ func getRemoteInfo(ri rpcinfo.RPCInfo, conn net.Conn) (string, net.Addr) {
 	if ri == nil {
 		return "", rAddr
 	}
-	if rAddr.Network() == "unix" {
+	if rAddr != nil && rAddr.Network() == "unix" {
 		if ri.From().Address() != nil {
 			rAddr = ri.From().Address()
 		}

--- a/server/invoke_test.go
+++ b/server/invoke_test.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -28,9 +30,11 @@ import (
 )
 
 func TestInvokerCall(t *testing.T) {
-	var opts []Option
-	opts = append(opts, WithMetaHandler(noopMetahandler{}))
-	invoker := NewInvoker(opts...)
+	var gotErr atomic.Value
+	invoker := NewInvoker(WithMetaHandler(noopMetahandler{}), WithErrorHandler(func(err error) error {
+		gotErr.Store(err)
+		return err
+	}))
 
 	err := invoker.RegisterService(mocks.ServiceInfo(), mocks.MyServiceHandler())
 	if err != nil {
@@ -40,13 +44,14 @@ func TestInvokerCall(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	args := mocks.NewMockArgs()
 	codec := utils.NewThriftMessageCodec()
-	b, _ := codec.Encode("mock", thrift.CALL, 0, args.(thrift.TStruct))
 
+	// call success
+	b, _ := codec.Encode("mock", thrift.CALL, 0, args.(thrift.TStruct))
 	msg := invoke.NewMessage(nil, nil)
 	msg.SetRequestBytes(b)
-
 	err = invoker.Call(msg)
 	if err != nil {
 		t.Fatal(err)
@@ -56,4 +61,15 @@ func TestInvokerCall(t *testing.T) {
 		t.Fatal(err)
 	}
 	test.Assert(t, len(b) > 0)
+	test.Assert(t, gotErr.Load() == nil)
+
+	// call fails
+	b, _ = codec.Encode("mockError", thrift.CALL, 0, args.(thrift.TStruct))
+	msg = invoke.NewMessage(nil, nil)
+	msg.SetRequestBytes(b)
+	err = invoker.Call(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.Assert(t, strings.Contains(gotErr.Load().(error).Error(), "mockError"))
 }


### PR DESCRIPTION
与 client 的 WithErrorHandler 实现一样，server error handle 只会在 server impl handler 函数返回了 error 时调用，不包含其他中间件(例如 ACL)处理的 error。