### PR TITLE
fix: set default rpctimeout and disable timeout logic if rpctimeout == 0

### DIFF
--- a/pkg/remote/trans/common.go
+++ b/pkg/remote/trans/common.go
@@ -44,8 +44,11 @@ type Extension interface {
 	IsRemoteClosedErr(error) bool
 }
 
-// GetReadTimeout is to make the read timeout logger, it is better for proxy case to receive error resp.
+// GetReadTimeout is to make the read timeout longer, it is better for proxy case to receive error resp.
 func GetReadTimeout(cfg rpcinfo.RPCConfig) time.Duration {
+	if cfg.RPCTimeout() <= 0 {
+		return 0
+	}
 	return cfg.RPCTimeout() + readMoreTimeout
 }
 

--- a/pkg/rpcinfo/rpcconfig.go
+++ b/pkg/rpcinfo/rpcconfig.go
@@ -32,7 +32,7 @@ var (
 
 // default values.
 var (
-	defaultRPCTimeout       = time.Duration(0)
+	defaultRPCTimeout       = time.Second
 	defaultConnectTimeout   = time.Millisecond * 50
 	defaultReadWriteTimeout = time.Second * 5
 	defaultBufferSize       = 4096

--- a/pkg/rpcinfo/rpcconfig_test.go
+++ b/pkg/rpcinfo/rpcconfig_test.go
@@ -27,7 +27,7 @@ import (
 func TestRPCConfig(t *testing.T) {
 	c := rpcinfo.NewRPCConfig()
 	test.Assert(t, c != nil)
-	test.Assert(t, c.RPCTimeout() == 0)
+	test.Assert(t, c.RPCTimeout() != 0)
 	test.Assert(t, c.ConnectTimeout() != 0)
 	test.Assert(t, c.ReadWriteTimeout() != 0)
 	test.Assert(t, c.IOBufferSize() != 0)


### PR DESCRIPTION
1. 默认情况下，RPCTimeout = 1s，开启超时中间件并且对 netpoll 设置 readTimeout: 1s+5ms
2. WithRPCTimeout(0) 可以关闭超时中间件以及 netpoll 的 readTimeout