### PR TITLE
feat: support pass proxy ctx to mwBuilder && register Dump in lbcache to diagnosis

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -85,8 +85,12 @@ func NewClient(svcInfo *serviceinfo.ServiceInfo, opts ...Option) (Client, error)
 
 func (kc *kClient) init() error {
 	initTransportProtocol(kc.svcInfo, kc.opt.Configs)
-
 	ctx := fillContext(kc.opt)
+	if nCtx, err := kc.proxyInit(ctx); err != nil {
+		return err
+	} else {
+		ctx = nCtx
+	}
 	if err := kc.checkOptions(); err != nil {
 		return err
 	}
@@ -126,38 +130,29 @@ func (kc *kClient) initRetryer() error {
 	return kc.opt.RetryContainer.Init(kc.opt.RetryPolicy, kc.opt.Logger)
 }
 
-func initTransportProtocol(svcInfo *serviceinfo.ServiceInfo, cfg rpcinfo.RPCConfig) {
-	if svcInfo.PayloadCodec == serviceinfo.Protobuf && cfg.TransportProtocol() != transport.GRPC {
-		// pb use ttheader framed by default
-		rpcinfo.AsMutableRPCConfig(cfg).SetTransportProtocol(transport.TTHeaderFramed)
-	}
-}
-
-func fillContext(opt *client.Options) context.Context {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, endpoint.CtxEventBusKey, opt.Bus)
-	ctx = context.WithValue(ctx, endpoint.CtxEventQueueKey, opt.Events)
-	ctx = context.WithValue(ctx, endpoint.CtxLoggerKey, opt.Logger)
-	ctx = context.WithValue(ctx, rpctimeout.TimeoutAdjustKey, &opt.ExtraTimeout)
-	return ctx
-}
-
-func (kc *kClient) checkOptions() (err error) {
-	if kc.opt.Svr.ServiceName == "" {
-		return errors.New("service name is required")
-	}
+func (kc *kClient) proxyInit(ctx context.Context) (context.Context, error) {
 	if kc.opt.Proxy != nil {
 		cfg := proxy.Config{
-			ServiceName:  kc.opt.Svr.ServiceName,
+			ServerInfo:   kc.opt.Svr,
 			Resolver:     kc.opt.Resolver,
 			Balancer:     kc.opt.Balancer,
 			Pool:         kc.opt.RemoteOpt.ConnPool,
 			FixedTargets: kc.opt.Targets,
 		}
-		if err = kc.opt.Proxy.Configure(&cfg); err != nil {
-			return err
+		if err := kc.opt.Proxy.Configure(&cfg); err != nil {
+			return ctx, err
+		}
+		if chr, ok := kc.opt.Proxy.(proxy.ContextHandler); ok {
+			ctx = chr.HandleContext(ctx)
 		}
 		updateOptWithProxyCfg(cfg, kc.opt)
+	}
+	return ctx, nil
+}
+
+func (kc *kClient) checkOptions() (err error) {
+	if kc.opt.Svr.ServiceName == "" {
+		return errors.New("service name is required")
 	}
 	if kc.opt.Logger == nil {
 		return errors.New("logger need to be initialized")
@@ -443,9 +438,25 @@ func newCliTransHandler(opt *remote.ClientOption) (remote.ClientTransHandler, er
 	return transPl, nil
 }
 
+func fillContext(opt *client.Options) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, endpoint.CtxEventBusKey, opt.Bus)
+	ctx = context.WithValue(ctx, endpoint.CtxEventQueueKey, opt.Events)
+	ctx = context.WithValue(ctx, endpoint.CtxLoggerKey, opt.Logger)
+	ctx = context.WithValue(ctx, rpctimeout.TimeoutAdjustKey, &opt.ExtraTimeout)
+	return ctx
+}
+
 func updateOptWithProxyCfg(cfg proxy.Config, opt *client.Options) {
 	opt.Resolver = cfg.Resolver
 	opt.Balancer = cfg.Balancer
 	opt.RemoteOpt.ConnPool = cfg.Pool
 	opt.Targets = cfg.FixedTargets
+}
+
+func initTransportProtocol(svcInfo *serviceinfo.ServiceInfo, cfg rpcinfo.RPCConfig) {
+	if svcInfo.PayloadCodec == serviceinfo.Protobuf && cfg.TransportProtocol() != transport.GRPC {
+		// pb use ttheader framed by default
+		rpcinfo.AsMutableRPCConfig(cfg).SetTransportProtocol(transport.TTHeaderFramed)
+	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 
 	"github.com/bytedance/gopkg/cloud/metainfo"
-
 	"github.com/cloudwego/kitex/client/callopt"
 	"github.com/cloudwego/kitex/internal/client"
 	"github.com/cloudwego/kitex/pkg/acl"

--- a/client/middlewares.go
+++ b/client/middlewares.go
@@ -96,7 +96,7 @@ func newResolveMWBuilder(opt *client.Options) endpoint.MiddlewareBuilder {
 			balancer = loadbalance.NewWeightedBalancer()
 		}
 
-		var cacheOpts lbcache.Options
+		var cacheOpts = lbcache.Options{DiagnosisService: opt.DebugService}
 		if opt.BalancerCacheOpt != nil {
 			cacheOpts = *opt.BalancerCacheOpt
 		}

--- a/pkg/diagnosis/interface.go
+++ b/pkg/diagnosis/interface.go
@@ -31,6 +31,13 @@ type Service interface {
 	RegisterProbeFunc(ProbeName, ProbeFunc)
 }
 
+// RegisterProbeFunc is a wrap function to execute Service.RegisterProbeFunc.
+func RegisterProbeFunc(svc Service, name ProbeName, pf ProbeFunc) {
+	if svc != nil {
+		svc.RegisterProbeFunc(name, pf)
+	}
+}
+
 // Keys below are probe info that has been registered by default.
 // If you want to register other info, please use RegisterProbeFunc(ProbeName, ProbeFunc) to do that.
 const (
@@ -43,6 +50,7 @@ const (
 	DestServiceKey ProbeName = "dest_service"
 	ConnPoolKey    ProbeName = "conn_pool"
 	RetryPolicyKey ProbeName = "retry_policy"
+	LbCacheKey     ProbeName = "lb_cache"
 )
 
 // WrapAsProbeFunc is to wrap probe data as ProbeFunc, the data is some infos that you want to diagnosis, like config info.

--- a/pkg/loadbalance/lbcache/cache.go
+++ b/pkg/loadbalance/lbcache/cache.go
@@ -230,17 +230,17 @@ func Dump() interface{} {
 		Address string
 		Weight  int
 	}
-	var cacheDump = make(map[string]interface{})
+	cacheDump := make(map[string]interface{})
 	balancerFactories.Range(func(key, val interface{}) bool {
 		cacheKey := key.(string)
 		if bf, ok := val.(*BalancerFactory); ok {
-			var routeMap = make(map[string]interface{})
+			routeMap := make(map[string]interface{})
 			cacheDump[cacheKey] = routeMap
 			bf.cache.Range(func(k, v interface{}) bool {
 				routeKey := k.(string)
 				if bl, ok := v.(*Balancer); ok {
 					if dr, ok := bl.res.Load().(discovery.Result); ok {
-						var insts = make([]instInfo, 0, len(dr.Instances))
+						insts := make([]instInfo, 0, len(dr.Instances))
 						for i := range dr.Instances {
 							inst := dr.Instances[i]
 							addr := fmt.Sprintf("%s://%s", inst.Address().Network(), inst.Address().String())

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -23,11 +23,12 @@ import (
 	"github.com/cloudwego/kitex/pkg/discovery"
 	"github.com/cloudwego/kitex/pkg/loadbalance"
 	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
 
 // Config contains basic components used in service discovery process.
 type Config struct {
-	ServiceName  string
+	ServerInfo   *rpcinfo.EndpointBasicInfo
 	Resolver     discovery.Resolver
 	Balancer     loadbalance.Loadbalancer
 	Pool         remote.ConnPool
@@ -46,4 +47,11 @@ type ForwardProxy interface {
 // BackwardProxy replaces the listen address with another one.
 type BackwardProxy interface {
 	Replace(net.Addr) (net.Addr, error)
+}
+
+// ContextHandler is to handle context info, it just be used for passing params when client/server initialization.
+// Eg: Customized endpoint.MiddlewareBuilder need get init information to judge
+// if it is necessary to add the middleware into the call chain.
+type ContextHandler interface {
+	HandleContext(context.Context) context.Context
 }

--- a/server/server.go
+++ b/server/server.go
@@ -136,9 +136,7 @@ func (s *server) RegisterService(svcInfo *serviceinfo.ServiceInfo, handler inter
 	}
 	s.svcInfo = svcInfo
 	s.handler = handler
-	if ds := s.opt.DebugService; ds != nil {
-		ds.RegisterProbeFunc(diagnosis.ServiceInfoKey, diagnosis.WrapAsProbeFunc(s.svcInfo))
-	}
+	diagnosis.RegisterProbeFunc(s.opt.DebugService, diagnosis.ServiceInfoKey, diagnosis.WrapAsProbeFunc(s.svcInfo))
 	return nil
 }
 


### PR DESCRIPTION
1. proxy add ContextHandler interface to support passing initialization context to mwBuilder
2. register Dump in lbcache to diagnosis
3. fix mistake dump info when instances change 

zh:
1. proxy 增加 ContextHandler 接口用于传递初始化ctx给 mwbuilder
2. 注册 lbcache 的 Dump 给 diagnosis，用于问题诊断
3. 修复实例变更时dump信息不正确问题