### PR TITLE
fix: rename BackwardProxy to ReverseProxy

### DIFF
--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -68,7 +68,7 @@ type Options struct {
 	RemoteOpt  *remote.ServerOption
 	ErrHandle  func(error) error
 	ExitSignal func() <-chan error
-	Proxy      proxy.BackwardProxy
+	Proxy      proxy.ReverseProxy
 
 	// Registry is used for service registry.
 	Registry registry.Registry

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -44,10 +44,13 @@ type ForwardProxy interface {
 	ResolveProxyInstance(ctx context.Context) error
 }
 
-// BackwardProxy replaces the listen address with another one.
-type BackwardProxy interface {
+// ReverseProxy replaces the listen address with another one.
+type ReverseProxy interface {
 	Replace(net.Addr) (net.Addr, error)
 }
+
+// Deprecated: BackwardProxy is deprecated, use ReverseProxy instead.
+type BackwardProxy = ReverseProxy
 
 // ContextHandler is to handle context info, it just be used for passing params when client/server initialization.
 // Eg: Customized endpoint.MiddlewareBuilder need get init information to judge

--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -79,7 +79,7 @@ func WithMetaHandler(h remote.MetaHandler) Option {
 }
 
 // WithProxy stes the backward Proxy for server.
-func WithProxy(p proxy.BackwardProxy) Option {
+func WithProxy(p proxy.ReverseProxy) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		o.Once.OnceOrPanic()
 		di.Push(fmt.Sprintf("WithProxy(%T)", p))


### PR DESCRIPTION
Server-side proxy is called reverse proxy, not backward proxy.