### PR TITLE
build: upgrade to Go 1.17

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,6 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - uses: reviewdog/action-staticcheck@v1
         with:
           github_token: ${{ secrets.github_token }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudwego/kitex
 
-go 1.13
+go 1.17
 
 require (
 	github.com/apache/thrift v0.13.0
@@ -17,4 +17,15 @@ require (
 	google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/text v0.3.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,12 +14,8 @@ github.com/choleraehyq/pid v0.0.12 h1:JLiTCsz2gStQZ3YWet+p9hktRnWzk7VJigpzvGV+I2
 github.com/choleraehyq/pid v0.0.12/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/netpoll v0.0.2/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
-github.com/cloudwego/netpoll v0.0.4 h1:wN+N2JIQMjKOF1x9XaTQDJsEUx/exMBuSGD6YRsLFzg=
-github.com/cloudwego/netpoll v0.0.4/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
 github.com/cloudwego/netpoll v0.0.5-0.20211130070520-dcf8909e227a h1:CODmVnel1RidjWPf6lBi0Oo3yVKneWowlmmvCsaOfjI=
 github.com/cloudwego/netpoll v0.0.5-0.20211130070520-dcf8909e227a/go.mod h1:rZOiNI0FYjuvNybXKKhAPUja03loJi/cdv2F55AE6E8=
-github.com/cloudwego/netpoll-http2 v0.0.4 h1:pN4uqjklPdvuALd3nFH5UFlmxB7vy7t8MkvKaV8HavU=
-github.com/cloudwego/netpoll-http2 v0.0.4/go.mod h1:iFr5SzJCXIYgBg0ubL0fZiCQ6W36s9p0KjXpV04lmoY=
 github.com/cloudwego/netpoll-http2 v0.0.5-0.20211123083853-5756b8c33a14 h1:jbyXMDEIikf5Hssn5ASth64eg2kDJGeEQ2Tt6HyQu+c=
 github.com/cloudwego/netpoll-http2 v0.0.5-0.20211123083853-5756b8c33a14/go.mod h1:iFr5SzJCXIYgBg0ubL0fZiCQ6W36s9p0KjXpV04lmoY=
 github.com/cloudwego/thriftgo v0.1.2 h1:AXpGJiWE3VggfiRHwA6raRJUIcjxliEIfJfGlvRiYUA=

--- a/pkg/generic/httpthrift_codec.go
+++ b/pkg/generic/httpthrift_codec.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sync/atomic"
 
@@ -142,7 +141,7 @@ func FromHTTPRequest(req *http.Request) (*HTTPRequest, error) {
 		// body == nil if from Get request
 		return customReq, nil
 	}
-	if customReq.RawBody, err = ioutil.ReadAll(b); err != nil {
+	if customReq.RawBody, err = io.ReadAll(b); err != nil {
 		return nil, err
 	}
 	if len(customReq.RawBody) == 0 {

--- a/pkg/remote/trans/netpoll/http_client_handler.go
+++ b/pkg/remote/trans/netpoll/http_client_handler.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"path"
@@ -279,7 +279,7 @@ func getBodyBufReader(buf remote.ByteBuffer) (remote.ByteBuffer, error) {
 	if hr.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("http response not OK, StatusCode: %d", hr.StatusCode)
 	}
-	b, err := ioutil.ReadAll(hr.Body)
+	b, err := io.ReadAll(hr.Body)
 	hr.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("read http response body error:%w", err)

--- a/pkg/utils/yaml.go
+++ b/pkg/utils/yaml.go
@@ -17,7 +17,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -45,7 +45,7 @@ func ReadYamlConfigFile(yamlFile string) (*YamlConfig, error) {
 	}
 	defer fd.Close()
 
-	b, err := ioutil.ReadAll(fd)
+	b, err := io.ReadAll(fd)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/internal/pkg/pluginmode/protoc/protoc.go
+++ b/tool/internal/pkg/pluginmode/protoc/protoc.go
@@ -17,7 +17,7 @@ package protoc
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +44,7 @@ func Run() int {
 
 func run(opts protogen.Options) error {
 	// unmarshal request from stdin
-	in, err := ioutil.ReadAll(os.Stdin)
+	in, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/tool/internal/pkg/pluginmode/thriftgo/convertor.go
+++ b/tool/internal/pkg/pluginmode/thriftgo/convertor.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -467,7 +466,7 @@ func (c *converter) persist(res *plugin.Response) error {
 		if err := os.MkdirAll(path, 0o755); err != nil && !os.IsExist(err) {
 			return fmt.Errorf("failed to create path '%s': %w", path, err)
 		}
-		if err := ioutil.WriteFile(full, content, 0o644); err != nil {
+		if err := os.WriteFile(full, content, 0o644); err != nil {
 			return fmt.Errorf("failed to write file '%s': %w", full, err)
 		}
 	}

--- a/tool/internal/pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal/pkg/pluginmode/thriftgo/patcher.go
@@ -16,7 +16,7 @@ package thriftgo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -135,7 +135,7 @@ func (p *patcher) patch(req *plugin.Request) (patches []*plugin.Generated, err e
 		})
 
 		if p.copyIDL {
-			content, err := ioutil.ReadFile(ast.Filename)
+			content, err := os.ReadFile(ast.Filename)
 			if err != nil {
 				return nil, fmt.Errorf("read %q: %w", ast.Filename, err)
 			}

--- a/tool/internal/pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal/pkg/pluginmode/thriftgo/plugin.go
@@ -17,7 +17,7 @@ package thriftgo
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/cloudwego/thriftgo/plugin"
@@ -34,7 +34,7 @@ const TheUseOptionMessage = "kitex_gen is not generated due to the -use option"
 // Run is an entry of the plugin mode of kitex for thriftgo.
 // It reads a plugin request from the standard input and writes out a response.
 func Run() int {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		println("Failed to get input:", err.Error())
 		return 1

--- a/tool/internal/pkg/util/util.go
+++ b/tool/internal/pkg/util/util.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"go/build"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,11 +60,11 @@ func WriteToFile(filename string, data []byte) {
 		if err != nil {
 			log.Warnf("format %v code error: %v\n", filename, err)
 		}
-		err = ioutil.WriteFile(filename, data, 0o644)
+		err = os.WriteFile(filename, data, 0o644)
 	} else if strings.HasSuffix(filename, ".sh") {
-		err = ioutil.WriteFile(filename, data, 0o755)
+		err = os.WriteFile(filename, data, 0o755)
 	} else {
-		err = ioutil.WriteFile(filename, data, 0o644)
+		err = os.WriteFile(filename, data, 0o644)
 	}
 	if err != nil {
 		log.Warn("write to file err:", err.Error())
@@ -131,7 +130,7 @@ func NotPtr(s string) string {
 func SearchGoMod(cwd string) (moduleName, path string, found bool) {
 	for {
 		path = filepath.Join(cwd, "go.mod")
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err == nil {
 			re := regexp.MustCompile(`^\s*module\s+(\S+)\s*`)
 			for _, line := range strings.Split(string(data), "\n") {


### PR DESCRIPTION
This pull request introduces two small changes:

1. Upgrade to Go 1.17.

1. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.