### PR TITLE
WIP: feat: longpool - delay destroy connection to ease network jitter

### DIFF
--- a/internal/test/assert.go
+++ b/internal/test/assert.go
@@ -50,7 +50,7 @@ func Assertf(t testingTB, cond bool, format string, val ...interface{}) {
 func DeepEqual(t testingTB, a, b interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(a, b) {
-		t.Fatal("assertion failed")
+		t.Fatalf("assertion failed: %v != %v", a, b)
 	}
 }
 

--- a/pkg/remote/connpool/long_pool_bench_test.go
+++ b/pkg/remote/connpool/long_pool_bench_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connpool
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/internal/mocks"
+	dialer "github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/utils"
+)
+
+func newLongPoolWithoutDelayDestroyForTest(peerAddr, global int, timeout time.Duration) *LongPool {
+	lp := newLongPoolForTest(peerAddr, global, timeout)
+	limit := utils.NewMaxCounter(global)
+	lp.newPeer = func(addr net.Addr) *peer {
+		return newPeer("test", addr, peerAddr, timeout, limit, false)
+	}
+	return lp
+}
+
+func newDialerForBench() *dialer.SynthesizedDialer {
+	d := &dialer.SynthesizedDialer{}
+	d.DialFunc = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		time.Sleep(time.Duration(rand.Intn(5)) * time.Millisecond)
+		na := utils.NewNetAddr(network, address)
+		return &mocks.Conn{
+			RemoteAddrFunc: func() net.Addr { return na },
+		}, nil
+	}
+	return d
+}
+
+func BenchmarkLongPoolDelayDestroy(b *testing.B) {
+	p := newLongPoolForTest(1, 1, time.Second)
+	d := newDialerForBench()
+	b.SetParallelism(1000)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			conn, err := p.Get(context.TODO(), "tcp", mockAddr0, dialer.ConnOption{Dialer: d, ConnectTimeout: time.Second})
+			if err != nil {
+				b.Fatal(err)
+			}
+			// send request
+			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+			err = p.Put(conn)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkLongPoolWithoutDelayDestroy(b *testing.B) {
+	p := newLongPoolWithoutDelayDestroyForTest(1, 1, time.Second)
+	d := newDialerForBench()
+	b.SetParallelism(1000)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			conn, err := p.Get(context.TODO(), "tcp", mockAddr0, dialer.ConnOption{Dialer: d, ConnectTimeout: time.Second})
+			if err != nil {
+				b.Fatal(err)
+			}
+			// send request
+			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+			err = p.Put(conn)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
### 问题描述：

**假设有这样一对上下游：**

- 上游对下游服务负载均衡到某个实例 QPS 为 100，且这些请求会均匀发送。
- 连接池 maxidle 设置为 10，只要下游实例 avg latency 小于 100ms，理论上可以做到仅需 10 个持久长连接，且 idleConn 会尽可能维持在 0 左右。

**此时出现场景 A：**

- 下游实例突然抖动，有 10 个请求要 1000ms 才能返回，这 10 个请求会占用 10 条连接，此时至少会创建 10 条新连接以维持原先 QPS。
- 当异常延迟请求返回时，由于是额外增建的请求，所以 idleConn = 10，但依然处于 maxidle 内，所以不关闭。

**此时出现场景 B：**

- 如果下游服务是因为 nr_throttled 等原因被阻塞了一段时间，此时所有请求延迟都会突增，而发送端由于请求速度恒定，所以在出现延迟的这段时间内，一直在创建新连接。当下游延迟问题解除后，瞬间又有大量请求返回，此时 idleConn 会暴增，当超过 maxIdle 后会进行关闭。
- 由于这种异常延迟问题发生时，一般是由于调度繁忙导致的，所以会出现一阵阵的现象。而每次延迟请求返回后会大量关闭连接，下一次异常延迟又大量创建新连接的行为，对下游更是造成了更大的压力(尤其是 poller 每次关闭时间都需要进行处理)，甚至有时出现 dial timeout 的现象。

### 解决方案：

连接池之所以设置 maxidle  的目的是为了避免**长期**持有大量**不需要**的空闲连接，当前判断空闲连接的做法完全依赖于 maxIdle 参数设置，但像是异常延迟的场景下，这一秒"空闲"的连接可能下一秒很快就会被用到，此时最好能够延缓去关闭的连接的时机，等后面确定的确用不到了再关闭。

- sync.Pool 清理对象的时机是两次 GC 后
- SetFinalizer 可以在对象被 gc 后执行 conn.Close

利用上面两个机制，我们可以实现一个临时的连接池，这个连接池不受 maxIdle 限制，真的需要的时候可以复用所有创建过的连接，不需要的时候也可以安全地延后让 runtime 自己关闭连接。


