### PR TITLE
feat: support close generic client to avoid memory leak

### DIFF
--- a/pkg/generic/closer.go
+++ b/pkg/generic/closer.go
@@ -16,11 +16,8 @@
 
 package generic
 
-import "github.com/cloudwego/kitex/pkg/generic/descriptor"
-
-// DescriptorProvider provide service descriptor
-type DescriptorProvider interface {
-	Closer
-	// Provide return a channel for provide service descriptors
-	Provide() <-chan *descriptor.ServiceDescriptor
+// Closer is usually used to recycle resource.
+type Closer interface {
+	// Close the unused resource.
+	Close() error
 }

--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -25,6 +25,7 @@ import (
 
 // Generic ...
 type Generic interface {
+	Closer
 	// PayloadCodec return codec implement
 	PayloadCodec() remote.PayloadCodec
 	// PayloadCodecType return the type of codec
@@ -98,6 +99,10 @@ func (g *binaryThriftGeneric) GetMethod(req interface{}, method string) (*Method
 	return &Method{method, false}, nil
 }
 
+func (g *binaryThriftGeneric) Close() error {
+	return nil
+}
+
 type mapThriftGeneric struct {
 	codec *mapThriftCodec
 }
@@ -116,6 +121,10 @@ func (g *mapThriftGeneric) PayloadCodec() remote.PayloadCodec {
 
 func (g *mapThriftGeneric) GetMethod(req interface{}, method string) (*Method, error) {
 	return g.codec.getMethod(req, method)
+}
+
+func (g *mapThriftGeneric) Close() error {
+	return g.codec.Close()
 }
 
 type jsonThriftGeneric struct {
@@ -138,6 +147,10 @@ func (g *jsonThriftGeneric) GetMethod(req interface{}, method string) (*Method, 
 	return g.codec.getMethod(req, method)
 }
 
+func (g *jsonThriftGeneric) Close() error {
+	return g.codec.Close()
+}
+
 type httpThriftGeneric struct {
 	codec *httpThriftCodec
 }
@@ -156,4 +169,8 @@ func (g *httpThriftGeneric) PayloadCodec() remote.PayloadCodec {
 
 func (g *httpThriftGeneric) GetMethod(req interface{}, method string) (*Method, error) {
 	return g.codec.getMethod(req)
+}
+
+func (g *httpThriftGeneric) Close() error {
+	return g.codec.Close()
 }

--- a/pkg/generic/httpthrift_codec.go
+++ b/pkg/generic/httpthrift_codec.go
@@ -34,6 +34,11 @@ import (
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
 
+var (
+	_ remote.PayloadCodec = &httpThriftCodec{}
+	_ Closer              = &httpThriftCodec{}
+)
+
 // HTTPRequest alias of descriptor HTTPRequest
 type HTTPRequest = descriptor.HTTPRequest
 
@@ -106,6 +111,10 @@ func (c *httpThriftCodec) Unmarshal(ctx context.Context, msg remote.Message, in 
 
 func (c *httpThriftCodec) Name() string {
 	return "HttpThrift"
+}
+
+func (c *httpThriftCodec) Close() error {
+	return c.provider.Close()
 }
 
 var json = jsoniter.Config{

--- a/pkg/generic/jsonthrift_codec.go
+++ b/pkg/generic/jsonthrift_codec.go
@@ -28,6 +28,11 @@ import (
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
 
+var (
+	_ remote.PayloadCodec = &jsonThriftCodec{}
+	_ Closer              = &jsonThriftCodec{}
+)
+
 // JSONRequest alias of string
 type JSONRequest = string
 
@@ -98,4 +103,8 @@ func (c *jsonThriftCodec) getMethod(req interface{}, method string) (*Method, er
 
 func (c *jsonThriftCodec) Name() string {
 	return "JSONThrift"
+}
+
+func (c *jsonThriftCodec) Close() error {
+	return c.provider.Close()
 }

--- a/pkg/generic/map_test/generic_test.go
+++ b/pkg/generic/map_test/generic_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"net"
 	"reflect"
+	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -179,4 +181,72 @@ func initMockServer(t *testing.T, handler kt.Mock) server.Server {
 	addr, _ := net.ResolveTCPAddr("tcp", ":9019")
 	svr := newMockServer(handler, addr)
 	return svr
+}
+
+func TestMapThriftGenericClientClose(t *testing.T) {
+	debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(100)
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", mb(ms.HeapAlloc), ms.HeapObjects)
+
+	clis := make([]genericclient.Client, 1000)
+	for i := 0; i < 1000; i++ {
+		p, err := generic.NewThriftFileProvider("./idl/mock.thrift")
+		test.Assert(t, err == nil)
+		g, err := generic.MapThriftGeneric(p)
+		test.Assert(t, err == nil)
+		clis[i] = newGenericClient("destServiceName", g, "127.0.0.1:9020")
+	}
+
+	runtime.ReadMemStats(&ms)
+	preHeepAlloc, preHeapObjects := mb(ms.HeapAlloc), ms.HeapObjects
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", preHeepAlloc, preHeapObjects)
+
+	for _, cli := range clis {
+		_ = cli.Close()
+	}
+	runtime.GC()
+	runtime.ReadMemStats(&ms)
+	aferGCHeepAlloc, afterGCHeapObjects := mb(ms.HeapAlloc), ms.HeapObjects
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", aferGCHeepAlloc, afterGCHeapObjects)
+	test.Assert(t, aferGCHeepAlloc < preHeepAlloc && afterGCHeapObjects < preHeapObjects)
+}
+
+func TestMapThriftGenericClientFinalizer(t *testing.T) {
+	debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(100)
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", mb(ms.HeapAlloc), ms.HeapObjects)
+
+	clis := make([]genericclient.Client, 1000)
+	for i := 0; i < 1000; i++ {
+		p, err := generic.NewThriftFileProvider("./idl/mock.thrift")
+		test.Assert(t, err == nil)
+		g, err := generic.MapThriftGeneric(p)
+		test.Assert(t, err == nil)
+		clis[i] = newGenericClient("destServiceName", g, "127.0.0.1:9021")
+	}
+
+	runtime.ReadMemStats(&ms)
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", mb(ms.HeapAlloc), ms.HeapObjects)
+
+	runtime.GC()
+	runtime.ReadMemStats(&ms)
+	firstGCHeepAlloc, firstGCHeapObjects := mb(ms.HeapAlloc), ms.HeapObjects
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", firstGCHeepAlloc, firstGCHeapObjects)
+
+	runtime.GC()
+	runtime.ReadMemStats(&ms)
+	secondGCHeepAlloc, secondGCHeapObjects := mb(ms.HeapAlloc), ms.HeapObjects
+	t.Logf("Allocation: %f Mb, Number of allocation: %d\n", secondGCHeepAlloc, secondGCHeapObjects)
+	test.Assert(t, secondGCHeepAlloc < firstGCHeepAlloc && secondGCHeapObjects < firstGCHeapObjects)
+}
+
+func mb(byteSize uint64) float32 {
+	return float32(byteSize) / float32(1024*1024)
 }

--- a/pkg/generic/mapthrift_codec.go
+++ b/pkg/generic/mapthrift_codec.go
@@ -29,6 +29,11 @@ import (
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
 
+var (
+	_ remote.PayloadCodec = &mapThriftCodec{}
+	_ Closer              = &mapThriftCodec{}
+)
+
 type mapThriftCodec struct {
 	svcDsc   atomic.Value // *idl
 	provider DescriptorProvider
@@ -37,7 +42,10 @@ type mapThriftCodec struct {
 
 func newMapThriftCodec(p DescriptorProvider, codec remote.PayloadCodec) (*mapThriftCodec, error) {
 	svc := <-p.Provide()
-	c := &mapThriftCodec{codec: codec, provider: p}
+	c := &mapThriftCodec{
+		codec:    codec,
+		provider: p,
+	}
 	c.svcDsc.Store(svc)
 	go c.update()
 	return c, nil
@@ -96,4 +104,8 @@ func (c *mapThriftCodec) getMethod(req interface{}, method string) (*Method, err
 
 func (c *mapThriftCodec) Name() string {
 	return "MapThrift"
+}
+
+func (c *mapThriftCodec) Close() error {
+	return c.provider.Close()
 }

--- a/pkg/generic/thriftidl_provider.go
+++ b/pkg/generic/thriftidl_provider.go
@@ -71,7 +71,8 @@ func (p *thriftFileProvider) Close() error {
 
 // ThriftContentProvider provide descriptor from contents
 type ThriftContentProvider struct {
-	svcs chan *descriptor.ServiceDescriptor
+	closeOnce sync.Once
+	svcs      chan *descriptor.ServiceDescriptor
 }
 
 var _ DescriptorProvider = (*ThriftContentProvider)(nil)
@@ -123,7 +124,9 @@ func (p *ThriftContentProvider) Provide() <-chan *descriptor.ServiceDescriptor {
 
 // Close the sending chan.
 func (p *ThriftContentProvider) Close() error {
-	close(p.svcs)
+	p.closeOnce.Do(func() {
+		close(p.svcs)
+	})
 	return nil
 }
 
@@ -176,7 +179,8 @@ func parseContent(path, content string, includes map[string]string, isAbsInclude
 
 // ThriftContentWithAbsIncludePathProvider ...
 type ThriftContentWithAbsIncludePathProvider struct {
-	svcs chan *descriptor.ServiceDescriptor
+	closeOnce sync.Once
+	svcs      chan *descriptor.ServiceDescriptor
 }
 
 var _ DescriptorProvider = (*ThriftContentWithAbsIncludePathProvider)(nil)
@@ -235,6 +239,8 @@ func (p *ThriftContentWithAbsIncludePathProvider) Provide() <-chan *descriptor.S
 
 // Close the sending chan.
 func (p *ThriftContentWithAbsIncludePathProvider) Close() error {
-	close(p.svcs)
+	p.closeOnce.Do(func() {
+		close(p.svcs)
+	})
 	return nil
 }


### PR DESCRIPTION
generic client 有个异步更新逻辑，里面是个死循环，会造成内存泄露