### PR TITLE
Revert "perf: reuse buffer to reduce GC in codec/decode of gRPC"

### DIFF
--- a/pkg/remote/trans/nphttp2/client_handler.go
+++ b/pkg/remote/trans/nphttp2/client_handler.go
@@ -51,11 +51,8 @@ type cliTransHandler struct {
 }
 
 func (h *cliTransHandler) Write(ctx context.Context, conn net.Conn, msg remote.Message) (err error) {
-	buf := newByteBuffer(conn)
-	defer func() {
-		_ = buf.Release(err)
-		bufPool.Put(buf)
-	}()
+	buf := newBuffer(conn)
+	defer buf.Release(err)
 
 	if err = h.codec.Encode(ctx, msg, buf); err != nil {
 		return err
@@ -64,12 +61,8 @@ func (h *cliTransHandler) Write(ctx context.Context, conn net.Conn, msg remote.M
 }
 
 func (h *cliTransHandler) Read(ctx context.Context, conn net.Conn, msg remote.Message) (err error) {
-	buf := newByteBuffer(conn)
-	defer func() {
-		_ = buf.Release(err)
-		bufPool.Put(buf)
-	}()
-
+	buf := newBuffer(conn)
+	defer buf.Release(err)
 	err = h.codec.Decode(ctx, msg, buf)
 	return
 }

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -69,11 +69,8 @@ type svrTransHandler struct {
 }
 
 func (t *svrTransHandler) Write(ctx context.Context, conn net.Conn, msg remote.Message) (err error) {
-	buf := newByteBuffer(conn)
-	defer func() {
-		_ = buf.Release(err)
-		bufPool.Put(buf)
-	}()
+	buf := newBuffer(conn)
+	defer buf.Release(err)
 
 	if err = t.codec.Encode(ctx, msg, buf); err != nil {
 		return err
@@ -82,12 +79,8 @@ func (t *svrTransHandler) Write(ctx context.Context, conn net.Conn, msg remote.M
 }
 
 func (t *svrTransHandler) Read(ctx context.Context, conn net.Conn, msg remote.Message) (err error) {
-	buf := newByteBuffer(conn)
-	defer func() {
-		_ = buf.Release(err)
-		bufPool.Put(buf)
-	}()
-
+	buf := newBuffer(conn)
+	defer buf.Release(err)
 	err = t.codec.Decode(ctx, msg, buf)
 	return
 }


### PR DESCRIPTION
Reverts cloudwego/kitex#201

Streaming 场景下，buffer 是通过 netpoll.NewLinkBuffer() 创建的，不是 connection 的一部分，所以连接关闭时，这个对象不能回收，导致 gc 较多。

会提新的 PR 在 Release 里直接 Close 来回收这个对象，就能解决 gc 问题，所以这个 PR 的池化是没有必要的。