### PR TITLE
WIP: fix(conn_pool): add watcher to clean stale conn in connection pool

### DIFF
--- a/pkg/remote/connpool/long_pool.go
+++ b/pkg/remote/connpool/long_pool.go
@@ -349,8 +349,7 @@ func (lp *LongPool) invokeWatcher(t *time.Ticker) {
 	if top == nil {
 		return
 	}
-	t.Reset(getTickInterval(top.deadline.Sub(time.Now()), lp.watcher.checkInterval))
-	return
+	t.Reset(getTickInterval(time.Until(top.deadline), lp.watcher.checkInterval))
 }
 
 // cleanStaleConn cleans the stale conn and reset the timer
@@ -370,7 +369,7 @@ func (lp *LongPool) cleanStaleConn(t *time.Ticker) {
 	// set next timer
 	top, _ := lp.watcher.Top().(*connMeta)
 	if top != nil {
-		t.Reset(getTickInterval(top.deadline.Sub(time.Now()), lp.watcher.checkInterval))
+		t.Reset(getTickInterval(time.Until(top.deadline), lp.watcher.checkInterval))
 	} else {
 		t.Stop()
 	}

--- a/pkg/remote/connpool/long_pool_test.go
+++ b/pkg/remote/connpool/long_pool_test.go
@@ -627,9 +627,7 @@ func getActiveConnNum(lp *LongPool) int {
 			if conn == nil {
 				break
 			}
-			if conn.IsActive() {
-				count++
-			}
+			count++
 		}
 		return true
 	})

--- a/pkg/utils/priorityqueue.go
+++ b/pkg/utils/priorityqueue.go
@@ -85,9 +85,6 @@ func (pq *PriorityQueue) Top() PQItem {
 }
 
 func (pq *PriorityQueue) Len() int {
-	pq.m.Lock()
-	defer pq.m.Unlock()
-
 	return pq.queue.Len()
 }
 

--- a/pkg/utils/priorityqueue.go
+++ b/pkg/utils/priorityqueue.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import (

--- a/pkg/utils/priorityqueue.go
+++ b/pkg/utils/priorityqueue.go
@@ -65,7 +65,7 @@ func (pq *PriorityQueue) Top() PQItem {
 	if pq.queue == nil || len(*pq.queue) == 0 {
 		return nil
 	}
-	return (*pq.queue)[0].(PQItem)
+	return (*pq.queue)[0]
 }
 
 func (pq *PriorityQueue) Len() int {

--- a/pkg/utils/priorityqueue.go
+++ b/pkg/utils/priorityqueue.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"container/heap"
+	"sync"
+)
+
+type PQItem interface {
+	Less(i interface{}) bool
+}
+
+type pQueue []PQItem
+
+func (q pQueue) Len() int { return len(q) }
+
+func (q pQueue) Less(i, j int) bool {
+	return q[i].Less(q[j])
+}
+
+func (q pQueue) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+}
+
+func (q *pQueue) Push(i interface{}) {
+	*q = append(*q, i.(PQItem))
+}
+
+func (q *pQueue) Pop() interface{} {
+	n := len(*q)
+	if n == 0 {
+		return nil
+	}
+	item := (*q)[n-1]
+	*q = (*q)[0 : n-1]
+	return item
+}
+
+type PriorityQueue struct {
+	queue *pQueue
+	m     sync.Mutex
+}
+
+func (pq *PriorityQueue) Pop() PQItem {
+	pq.m.Lock()
+	defer pq.m.Unlock()
+
+	if pq.queue.Len() == 0 {
+		return nil
+	}
+
+	return heap.Pop(pq.queue).(PQItem)
+}
+
+func (pq *PriorityQueue) Push(i PQItem) {
+	pq.m.Lock()
+	defer pq.m.Unlock()
+
+	heap.Push(pq.queue, i)
+}
+
+func (pq *PriorityQueue) Top() PQItem {
+	pq.m.Lock()
+	defer pq.m.Unlock()
+
+	if pq.queue == nil || len(*pq.queue) == 0 {
+		return nil
+	}
+	return (*pq.queue)[0].(PQItem)
+}
+
+func (pq *PriorityQueue) Len() int {
+	pq.m.Lock()
+	defer pq.m.Unlock()
+
+	return pq.queue.Len()
+}
+
+func (pq *PriorityQueue) Close() {
+	pq.m.Lock()
+	defer pq.m.Unlock()
+
+	pq.queue = nil
+}
+
+func NewPriorityQueue() *PriorityQueue {
+	pq := &PriorityQueue{queue: new(pQueue)}
+	heap.Init(pq.queue)
+	return pq
+}

--- a/pkg/utils/ring.go
+++ b/pkg/utils/ring.go
@@ -90,6 +90,23 @@ func (r *Ring) Pop() interface{} {
 	return nil
 }
 
+// Top returns the last item
+func (r *Ring) Top() interface{} {
+	if r.length == 1 {
+		return r.rings[0].Top()
+	}
+
+	idx := goid.GetPid() % r.length
+	for i := 0; i < r.length; i, idx = i+1, (idx+1)%r.length {
+		obj := r.rings[idx].Top()
+		if obj != nil {
+			return obj
+		}
+	}
+	return nil
+
+}
+
 // Dump dumps the data in the ring.
 func (r *Ring) Dump() interface{} {
 	m := &ringDump{}

--- a/pkg/utils/ring_single.go
+++ b/pkg/utils/ring_single.go
@@ -65,6 +65,16 @@ func (r *ring) Pop() interface{} {
 	return c
 }
 
+// Top returns the last item
+func (r *ring) Top() interface{} {
+	r.l.Lock()
+	defer r.l.Unlock()
+	if r.isEmpty() {
+		return nil
+	}
+	return r.arr[r.tail]
+}
+
 type ringDump struct {
 	Array []interface{} `json:"array"`
 	Len   int           `json:"len"`


### PR DESCRIPTION
#### What type of PR is this?
fix: add watcher to clean stale conn in connection pool

#### What this PR does / why we need it (English/Chinese):
en: Current implementation of long connection pool is not able to clean stale connection in time.
This PR adds mechanism to clean the stale connections.

zh: 在长连接池中添加 watcher 以及时清理过期的空闲连接