### PR TITLE
fix(generic): fix base64 binary for json and http

### DIFF
--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -18,6 +18,8 @@
 package generic
 
 import (
+	"fmt"
+
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
@@ -58,7 +60,8 @@ func MapThriftGeneric(p DescriptorProvider) (Generic, error) {
 	}, nil
 }
 
-// HTTPThriftGeneric http mapping Generic
+// HTTPThriftGeneric http mapping Generic.
+// binary encode to/decode from base64 disabled by default.
 func HTTPThriftGeneric(p DescriptorProvider) (Generic, error) {
 	codec, err := newHTTPThriftCodec(p, thriftCodec)
 	if err != nil {
@@ -69,13 +72,33 @@ func HTTPThriftGeneric(p DescriptorProvider) (Generic, error) {
 	}, nil
 }
 
-// JSONThriftGeneric json mapping generic
+// JSONThriftGeneric json mapping generic.
+// binary encode to/decode from base64 enabled by default.
 func JSONThriftGeneric(p DescriptorProvider) (Generic, error) {
 	codec, err := newJsonThriftCodec(p, thriftCodec)
 	if err != nil {
 		return nil, err
 	}
 	return &jsonThriftGeneric{codec: codec}, nil
+}
+
+// SetBase64Binary enable/disable binary encode to/decode from base64 enabled.
+func SetBase64Binary(g Generic, enable bool) error {
+	switch c := g.(type) {
+	case *httpThriftGeneric:
+		if c.codec == nil {
+			return fmt.Errorf("empty codec for %#v", c)
+		}
+		c.codec.base64Binary = enable
+	case *jsonThriftGeneric:
+		if c.codec == nil {
+			return fmt.Errorf("empty codec for %#v", c)
+		}
+		c.codec.base64Binary = enable
+	default:
+		return fmt.Errorf("Base64Binary is unavailable for %#v", g)
+	}
+	return nil
 }
 
 var thriftCodec = thrift.NewThriftCodec()

--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -61,7 +61,10 @@ func MapThriftGeneric(p DescriptorProvider) (Generic, error) {
 }
 
 // HTTPThriftGeneric http mapping Generic.
-// binary encode to/decode from base64 disabled by default.
+// Base64 codec for binary field is disabled by default. You can change this option with SetBinaryWithBase64.
+// eg:
+// 		g, err := generic.HTTPThriftGeneric(p)
+// 		SetBinaryWithBase64(g, true)
 func HTTPThriftGeneric(p DescriptorProvider) (Generic, error) {
 	codec, err := newHTTPThriftCodec(p, thriftCodec)
 	if err != nil {
@@ -73,7 +76,10 @@ func HTTPThriftGeneric(p DescriptorProvider) (Generic, error) {
 }
 
 // JSONThriftGeneric json mapping generic.
-// binary encode to/decode from base64 enabled by default.
+// Base64 codec for binary field is enabled by default. You can change this option with SetBinaryWithBase64.
+// eg:
+// 		g, err := generic.JSONThriftGeneric(p)
+// 		SetBinaryWithBase64(g, false)
 func JSONThriftGeneric(p DescriptorProvider) (Generic, error) {
 	codec, err := newJsonThriftCodec(p, thriftCodec)
 	if err != nil {
@@ -82,19 +88,19 @@ func JSONThriftGeneric(p DescriptorProvider) (Generic, error) {
 	return &jsonThriftGeneric{codec: codec}, nil
 }
 
-// SetBase64Binary enable/disable binary encode to/decode from base64 enabled.
-func SetBase64Binary(g Generic, enable bool) error {
+// SetBinaryWithBase64 enable/disable Base64 codec for binary field.
+func SetBinaryWithBase64(g Generic, enable bool) error {
 	switch c := g.(type) {
 	case *httpThriftGeneric:
 		if c.codec == nil {
 			return fmt.Errorf("empty codec for %#v", c)
 		}
-		c.codec.base64Binary = enable
+		c.codec.binaryWithBase64 = enable
 	case *jsonThriftGeneric:
 		if c.codec == nil {
 			return fmt.Errorf("empty codec for %#v", c)
 		}
-		c.codec.base64Binary = enable
+		c.codec.binaryWithBase64 = enable
 	default:
 		return fmt.Errorf("Base64Binary is unavailable for %#v", g)
 	}

--- a/pkg/generic/http_test/conf/kitex.yml
+++ b/pkg/generic/http_test/conf/kitex.yml
@@ -1,0 +1,18 @@
+Address: ":9109"
+EnableDebugServer: true
+DebugServerPort: "19109"
+Log:
+  Dir: log
+  Loggers:
+    - Name: default
+      Level: info # Notice: change it to debug if needed in local development
+      Outputs:
+        - Console # Notice: change it to debug if needed in local development, don't use this in production!
+    - Name: rpcAccess
+      Level: trace # Notice: Not recommended for modification, otherwise may affect construction of call chain (tracing)
+      Outputs:
+        - Agent
+    - Name: rpcCall
+      Level: trace # Notice: Not recommended for modification, otherwise may affect construction of call chain (tracing)
+      Outputs:
+        - Console

--- a/pkg/generic/http_test/generic_init.go
+++ b/pkg/generic/http_test/generic_init.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package test ...
+package test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/cloudwego/kitex/client"
+	"github.com/cloudwego/kitex/client/genericclient"
+	"github.com/cloudwego/kitex/pkg/generic"
+	"github.com/cloudwego/kitex/server"
+	"github.com/cloudwego/kitex/server/genericserver"
+)
+
+func newGenericClient(destService string, g generic.Generic, targetIPPort string) genericclient.Client {
+	var opts []client.Option
+	opts = append(opts, client.WithHostPorts(targetIPPort))
+	genericCli, _ := genericclient.NewClient(destService, g, opts...)
+	return genericCli
+}
+
+func newGenericServer(g generic.Generic, addr net.Addr, handler generic.Service) server.Server {
+	var opts []server.Option
+	opts = append(opts, server.WithServiceAddr(addr))
+	svr := genericserver.NewServer(handler, g, opts...)
+	go func() {
+		err := svr.Run()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	return svr
+}
+
+// GenericServiceReadRequiredFiledImpl ...
+type GenericServiceBinaryEchoImpl struct{}
+
+const mockMyMsg = "my msg"
+
+// GenericCall ...
+func (g *GenericServiceBinaryEchoImpl) GenericCall(ctx context.Context, method string, request interface{}) (response interface{}, err error) {
+	req := request.(map[string]interface{})
+	gotBase64 := req["got_base64"].(bool)
+	fmt.Printf("Recv: (%T)%s\n", req["msg"], req["msg"])
+	if !gotBase64 && req["msg"].(string) != mockMyMsg {
+		return nil, errors.New("call failed, msg type mismatch")
+	}
+	if gotBase64 && req["msg"].(string) != base64.StdEncoding.EncodeToString([]byte(mockMyMsg)) {
+		return nil, errors.New("call failed, incorrect base64 data")
+	}
+	return req, nil
+}

--- a/pkg/generic/http_test/generic_test.go
+++ b/pkg/generic/http_test/generic_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/cloudwego/kitex/client/genericclient"
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/generic"
+	"github.com/cloudwego/kitex/server"
+)
+
+func initThriftClientByIDL(t *testing.T, addr, idl string, base64Binary bool) genericclient.Client {
+	p, err := generic.NewThriftFileProvider(idl)
+	test.Assert(t, err == nil)
+	g, err := generic.HTTPThriftGeneric(p)
+	test.Assert(t, err == nil)
+	err = generic.SetBase64Binary(g, base64Binary)
+	test.Assert(t, err == nil)
+	cli := newGenericClient("destServiceName", g, addr)
+	test.Assert(t, err == nil)
+	return cli
+}
+
+func initThriftServer(t *testing.T, address string, handler generic.Service) server.Server {
+	addr, _ := net.ResolveTCPAddr("tcp", address)
+	p, err := generic.NewThriftFileProvider("./idl/binary_echo.thrift")
+	test.Assert(t, err == nil)
+	g, err := generic.MapThriftGeneric(p)
+	test.Assert(t, err == nil)
+	svr := newGenericServer(g, addr, handler)
+	test.Assert(t, err == nil)
+	return svr
+}
+
+func TestThriftNormalBinaryEcho(t *testing.T) {
+	time.Sleep(1 * time.Second)
+	svr := initThriftServer(t, ":9126", new(GenericServiceBinaryEchoImpl))
+	time.Sleep(500 * time.Millisecond)
+
+	cli := initThriftClientByIDL(t, "127.0.0.1:9126", "./idl/binary_echo.thrift", false)
+	url := "http://example.com/BinaryEcho"
+
+	// []byte value for binary field
+	body := map[string]interface{}{
+		"msg":        []byte(mockMyMsg),
+		"got_base64": true,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	req, err := http.NewRequest(http.MethodGet, url, bytes.NewBuffer(data))
+	if err != nil {
+		panic(err)
+	}
+	customReq, err := generic.FromHTTPRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := cli.GenericCall(context.Background(), "", customReq, callopt.WithRPCTimeout(100*time.Second))
+	test.Assert(t, err == nil, err)
+	gr, ok := resp.(*generic.HTTPResponse)
+	test.Assert(t, ok)
+	test.Assert(t, gr.Body["msg"] == base64.StdEncoding.EncodeToString([]byte(mockMyMsg)))
+
+	// string value for binary field which should fail
+	body = map[string]interface{}{
+		"msg":        string(mockMyMsg),
+		"got_base64": false,
+	}
+	data, err = json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	req, err = http.NewRequest(http.MethodGet, url, bytes.NewBuffer(data))
+	if err != nil {
+		panic(err)
+	}
+	customReq, err = generic.FromHTTPRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = cli.GenericCall(context.Background(), "", customReq, callopt.WithRPCTimeout(100*time.Second))
+	test.Assert(t, err == nil, err)
+	gr, ok = resp.(*generic.HTTPResponse)
+	test.Assert(t, ok)
+	test.Assert(t, gr.Body["msg"] == mockMyMsg)
+
+	svr.Stop()
+}
+
+func TestThriftBase64BinaryEcho(t *testing.T) {
+	time.Sleep(1 * time.Second)
+	svr := initThriftServer(t, ":9126", new(GenericServiceBinaryEchoImpl))
+	time.Sleep(500 * time.Millisecond)
+
+	cli := initThriftClientByIDL(t, "127.0.0.1:9126", "./idl/binary_echo.thrift", true)
+	url := "http://example.com/BinaryEcho"
+
+	// []byte value for binary field
+	body := map[string]interface{}{
+		"msg":        []byte(mockMyMsg),
+		"got_base64": false,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	req, err := http.NewRequest(http.MethodGet, url, bytes.NewBuffer(data))
+	if err != nil {
+		panic(err)
+	}
+	customReq, err := generic.FromHTTPRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := cli.GenericCall(context.Background(), "", customReq, callopt.WithRPCTimeout(100*time.Second))
+	test.Assert(t, err == nil, err)
+	gr, ok := resp.(*generic.HTTPResponse)
+	test.Assert(t, ok)
+	test.Assert(t, gr.Body["msg"] == base64.StdEncoding.EncodeToString(body["msg"].([]byte)))
+
+	// string value for binary field which should fail
+	body = map[string]interface{}{
+		"msg": string(mockMyMsg),
+	}
+	data, err = json.Marshal(body)
+	if err != nil {
+		panic(err)
+	}
+	req, err = http.NewRequest(http.MethodGet, url, bytes.NewBuffer(data))
+	if err != nil {
+		panic(err)
+	}
+	customReq, err = generic.FromHTTPRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cli.GenericCall(context.Background(), "", customReq, callopt.WithRPCTimeout(100*time.Second))
+	test.Assert(t, strings.Contains(err.Error(), "illegal base64 data"))
+
+	svr.Stop()
+}

--- a/pkg/generic/http_test/generic_test.go
+++ b/pkg/generic/http_test/generic_test.go
@@ -34,12 +34,17 @@ import (
 	"github.com/cloudwego/kitex/server"
 )
 
+func TestRun(t *testing.T) {
+	t.Run("TestThriftNormalBinaryEcho", testThriftNormalBinaryEcho)
+	t.Run("TestThriftBase64BinaryEcho", testThriftBase64BinaryEcho)
+}
+
 func initThriftClientByIDL(t *testing.T, addr, idl string, base64Binary bool) genericclient.Client {
 	p, err := generic.NewThriftFileProvider(idl)
 	test.Assert(t, err == nil)
 	g, err := generic.HTTPThriftGeneric(p)
 	test.Assert(t, err == nil)
-	err = generic.SetBase64Binary(g, base64Binary)
+	err = generic.SetBinaryWithBase64(g, base64Binary)
 	test.Assert(t, err == nil)
 	cli := newGenericClient("destServiceName", g, addr)
 	test.Assert(t, err == nil)
@@ -57,8 +62,7 @@ func initThriftServer(t *testing.T, address string, handler generic.Service) ser
 	return svr
 }
 
-func TestThriftNormalBinaryEcho(t *testing.T) {
-	time.Sleep(1 * time.Second)
+func testThriftNormalBinaryEcho(t *testing.T) {
 	svr := initThriftServer(t, ":9126", new(GenericServiceBinaryEchoImpl))
 	time.Sleep(500 * time.Millisecond)
 
@@ -114,8 +118,7 @@ func TestThriftNormalBinaryEcho(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftBase64BinaryEcho(t *testing.T) {
-	time.Sleep(1 * time.Second)
+func testThriftBase64BinaryEcho(t *testing.T) {
 	svr := initThriftServer(t, ":9126", new(GenericServiceBinaryEchoImpl))
 	time.Sleep(500 * time.Millisecond)
 

--- a/pkg/generic/http_test/idl/binary_echo.thrift
+++ b/pkg/generic/http_test/idl/binary_echo.thrift
@@ -1,0 +1,10 @@
+namespace go kitex.test.server
+
+struct BinaryWrapper {
+    1: binary msg (api.body = "msg")
+    2: bool got_base64 (api.body = "got_base64")
+}
+
+service ExampleService {
+    BinaryWrapper BinaryEcho(1: BinaryWrapper req) (api.get = '/BinaryEcho', api.baseurl = 'example.com')
+}

--- a/pkg/generic/httpthrift_codec.go
+++ b/pkg/generic/httpthrift_codec.go
@@ -46,15 +46,15 @@ type HTTPRequest = descriptor.HTTPRequest
 type HTTPResponse = descriptor.HTTPResponse
 
 type httpThriftCodec struct {
-	svcDsc       atomic.Value // *idl
-	provider     DescriptorProvider
-	codec        remote.PayloadCodec
-	base64Binary bool
+	svcDsc           atomic.Value // *idl
+	provider         DescriptorProvider
+	codec            remote.PayloadCodec
+	binaryWithBase64 bool
 }
 
 func newHTTPThriftCodec(p DescriptorProvider, codec remote.PayloadCodec) (*httpThriftCodec, error) {
 	svc := <-p.Provide()
-	c := &httpThriftCodec{codec: codec, provider: p, base64Binary: false}
+	c := &httpThriftCodec{codec: codec, provider: p, binaryWithBase64: false}
 	c.svcDsc.Store(svc)
 	go c.update()
 	return c, nil
@@ -93,7 +93,7 @@ func (c *httpThriftCodec) Marshal(ctx context.Context, msg remote.Message, out r
 	}
 
 	inner := thrift.NewWriteHTTPRequest(svcDsc)
-	inner.SetBase64Binary(c.base64Binary)
+	inner.SetBinaryWithBase64(c.binaryWithBase64)
 	msg.Data().(WithCodec).SetCodec(inner)
 	return c.codec.Marshal(ctx, msg, out)
 }
@@ -107,7 +107,7 @@ func (c *httpThriftCodec) Unmarshal(ctx context.Context, msg remote.Message, in 
 		return fmt.Errorf("get parser ServiceDescriptor failed")
 	}
 	inner := thrift.NewReadHTTPResponse(svcDsc)
-	inner.SetBase64Binary(c.base64Binary)
+	inner.SetBase64Binary(c.binaryWithBase64)
 	msg.Data().(WithCodec).SetCodec(inner)
 	return c.codec.Unmarshal(ctx, msg, in)
 }

--- a/pkg/generic/httpthrift_codec.go
+++ b/pkg/generic/httpthrift_codec.go
@@ -46,14 +46,15 @@ type HTTPRequest = descriptor.HTTPRequest
 type HTTPResponse = descriptor.HTTPResponse
 
 type httpThriftCodec struct {
-	svcDsc   atomic.Value // *idl
-	provider DescriptorProvider
-	codec    remote.PayloadCodec
+	svcDsc       atomic.Value // *idl
+	provider     DescriptorProvider
+	codec        remote.PayloadCodec
+	base64Binary bool
 }
 
 func newHTTPThriftCodec(p DescriptorProvider, codec remote.PayloadCodec) (*httpThriftCodec, error) {
 	svc := <-p.Provide()
-	c := &httpThriftCodec{codec: codec, provider: p}
+	c := &httpThriftCodec{codec: codec, provider: p, base64Binary: false}
 	c.svcDsc.Store(svc)
 	go c.update()
 	return c, nil
@@ -92,6 +93,7 @@ func (c *httpThriftCodec) Marshal(ctx context.Context, msg remote.Message, out r
 	}
 
 	inner := thrift.NewWriteHTTPRequest(svcDsc)
+	inner.SetBase64Binary(c.base64Binary)
 	msg.Data().(WithCodec).SetCodec(inner)
 	return c.codec.Marshal(ctx, msg, out)
 }
@@ -105,6 +107,7 @@ func (c *httpThriftCodec) Unmarshal(ctx context.Context, msg remote.Message, in 
 		return fmt.Errorf("get parser ServiceDescriptor failed")
 	}
 	inner := thrift.NewReadHTTPResponse(svcDsc)
+	inner.SetBase64Binary(c.base64Binary)
 	msg.Data().(WithCodec).SetCodec(inner)
 	return c.codec.Unmarshal(ctx, msg, in)
 }

--- a/pkg/generic/json_test/generic_init.go
+++ b/pkg/generic/json_test/generic_init.go
@@ -19,6 +19,8 @@ package test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -121,6 +123,30 @@ func (g *GenericServiceReadRequiredFiledImpl) GenericCall(ctx context.Context, m
 	msg := request.(string)
 	fmt.Printf("Recv: %s\n", msg)
 	return `{"Msg":"world"}`, nil
+}
+
+// GenericServiceReadRequiredFiledImpl ...
+type GenericServiceBinaryEchoImpl struct{}
+
+const mockMyMsg = "my msg"
+
+type BinaryEcho struct {
+	Msg       string `json:"msg"`
+	GotBase64 bool   `json:"got_base64"`
+}
+
+// GenericCall ...
+func (g *GenericServiceBinaryEchoImpl) GenericCall(ctx context.Context, method string, request interface{}) (response interface{}, err error) {
+	req := &BinaryEcho{}
+	json.Unmarshal([]byte(request.(string)), req)
+	fmt.Printf("Recv: %s\n", req.Msg)
+	if !req.GotBase64 && req.Msg != mockMyMsg {
+		return nil, errors.New("call failed, msg type mismatch")
+	}
+	if req.GotBase64 && req.Msg != base64.StdEncoding.EncodeToString([]byte(mockMyMsg)) {
+		return nil, errors.New("call failed, incorrect base64 data")
+	}
+	return request, nil
 }
 
 var (

--- a/pkg/generic/json_test/generic_test.go
+++ b/pkg/generic/json_test/generic_test.go
@@ -38,7 +38,22 @@ import (
 	"github.com/cloudwego/kitex/server"
 )
 
-func TestThrift(t *testing.T) {
+func TestRun(t *testing.T) {
+	t.Run("TestThrift", testThrift)
+	t.Run("TestThriftPingMethod", testThriftPingMethod)
+	t.Run("TestThriftError", testThriftError)
+	t.Run("TestThriftOnewayMethod", testThriftOnewayMethod)
+	t.Run("TestThriftVoidMethod", testThriftVoidMethod)
+	t.Run("TestThriftReadRequiredField", testThriftReadRequiredField)
+	t.Run("TestThriftWriteRequiredField", testThriftWriteRequiredField)
+	t.Run("TestThrift2NormalServer", testThrift2NormalServer)
+	t.Run("TestJSONThriftGenericClientClose", testJSONThriftGenericClientClose)
+	t.Run("TestThriftRawBinaryEcho", testThriftRawBinaryEcho)
+	t.Run("TestThriftBase64BinaryEcho", testThriftBase64BinaryEcho)
+	t.Run("TestJSONThriftGenericClientFinalizer", testJSONThriftGenericClientFinalizer)
+}
+
+func testThrift(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServer(t, ":9121", new(GenericServiceImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -53,7 +68,7 @@ func TestThrift(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftPingMethod(t *testing.T) {
+func testThriftPingMethod(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServer(t, ":9122", new(GenericServicePingImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -68,7 +83,7 @@ func TestThriftPingMethod(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftError(t *testing.T) {
+func testThriftError(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	svr := initThriftServer(t, ":9123", new(GenericServiceErrorImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -81,7 +96,7 @@ func TestThriftError(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftOnewayMethod(t *testing.T) {
+func testThriftOnewayMethod(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServer(t, ":9124", new(GenericServiceOnewayImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -94,7 +109,7 @@ func TestThriftOnewayMethod(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftVoidMethod(t *testing.T) {
+func testThriftVoidMethod(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServer(t, ":9125", new(GenericServiceVoidImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -107,7 +122,7 @@ func TestThriftVoidMethod(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftReadRequiredField(t *testing.T) {
+func testThriftReadRequiredField(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServer(t, ":9126", new(GenericServiceReadRequiredFiledImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -120,7 +135,7 @@ func TestThriftReadRequiredField(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftWriteRequiredField(t *testing.T) {
+func testThriftWriteRequiredField(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServer(t, ":9127", new(GenericServiceReadRequiredFiledImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -133,7 +148,7 @@ func TestThriftWriteRequiredField(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThrift2NormalServer(t *testing.T) {
+func testThrift2NormalServer(t *testing.T) {
 	time.Sleep(4 * time.Second)
 	svr := initMockServer(t, new(mockImpl))
 	time.Sleep(500 * time.Millisecond)
@@ -145,7 +160,7 @@ func TestThrift2NormalServer(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftRawBinaryEcho(t *testing.T) {
+func testThriftRawBinaryEcho(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServerByIDL(t, ":9126", new(GenericServiceBinaryEchoImpl), "./idl/binary_echo.thrift", &(&struct{ x bool }{false}).x)
 	time.Sleep(500 * time.Millisecond)
@@ -162,7 +177,7 @@ func TestThriftRawBinaryEcho(t *testing.T) {
 	svr.Stop()
 }
 
-func TestThriftBase64BinaryEcho(t *testing.T) {
+func testThriftBase64BinaryEcho(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	svr := initThriftServerByIDL(t, ":9126", new(GenericServiceBinaryEchoImpl), "./idl/binary_echo.thrift", nil)
 	time.Sleep(500 * time.Millisecond)
@@ -200,7 +215,7 @@ func initThriftClientByIDL(t *testing.T, addr, idl string, base64binary *bool) g
 	g, err := generic.JSONThriftGeneric(p)
 	test.Assert(t, err == nil)
 	if base64binary != nil {
-		generic.SetBase64Binary(g, *base64binary)
+		generic.SetBinaryWithBase64(g, *base64binary)
 	}
 	cli := newGenericClient("destServiceName", g, addr)
 	test.Assert(t, err == nil)
@@ -218,7 +233,7 @@ func initThriftServerByIDL(t *testing.T, address string, handler generic.Service
 	g, err := generic.JSONThriftGeneric(p)
 	test.Assert(t, err == nil)
 	if base64Binary != nil {
-		generic.SetBase64Binary(g, *base64Binary)
+		generic.SetBinaryWithBase64(g, *base64Binary)
 	}
 	svr := newGenericServer(g, addr, handler)
 	test.Assert(t, err == nil)
@@ -231,7 +246,7 @@ func initMockServer(t *testing.T, handler kt.Mock) server.Server {
 	return svr
 }
 
-func TestJSONThriftGenericClientClose(t *testing.T) {
+func testJSONThriftGenericClientClose(t *testing.T) {
 	debug.SetGCPercent(-1)
 	defer debug.SetGCPercent(100)
 
@@ -263,7 +278,7 @@ func TestJSONThriftGenericClientClose(t *testing.T) {
 	test.Assert(t, aferGCHeepAlloc < preHeepAlloc && afterGCHeapObjects < preHeapObjects)
 }
 
-func TestJSONThriftGenericClientFinalizer(t *testing.T) {
+func testJSONThriftGenericClientFinalizer(t *testing.T) {
 	debug.SetGCPercent(-1)
 	defer debug.SetGCPercent(100)
 

--- a/pkg/generic/json_test/idl/binary_echo.thrift
+++ b/pkg/generic/json_test/idl/binary_echo.thrift
@@ -1,0 +1,10 @@
+namespace go kitex.test.server
+
+struct BinaryWrapper {
+    1: binary msg
+    2: bool got_base64
+}
+
+service ExampleService {
+    BinaryWrapper BinaryEcho(1: BinaryWrapper req)
+}

--- a/pkg/generic/jsonthrift_codec.go
+++ b/pkg/generic/jsonthrift_codec.go
@@ -37,15 +37,15 @@ var (
 type JSONRequest = string
 
 type jsonThriftCodec struct {
-	svcDsc       atomic.Value // *idl
-	provider     DescriptorProvider
-	codec        remote.PayloadCodec
-	base64Binary bool
+	svcDsc           atomic.Value // *idl
+	provider         DescriptorProvider
+	codec            remote.PayloadCodec
+	binaryWithBase64 bool
 }
 
 func newJsonThriftCodec(p DescriptorProvider, codec remote.PayloadCodec) (*jsonThriftCodec, error) {
 	svc := <-p.Provide()
-	c := &jsonThriftCodec{codec: codec, provider: p, base64Binary: true}
+	c := &jsonThriftCodec{codec: codec, provider: p, binaryWithBase64: true}
 	c.svcDsc.Store(svc)
 	go c.update()
 	return c, nil
@@ -77,7 +77,7 @@ func (c *jsonThriftCodec) Marshal(ctx context.Context, msg remote.Message, out r
 	if err != nil {
 		return err
 	}
-	wm.SetBase64Binary(c.base64Binary)
+	wm.SetBase64Binary(c.binaryWithBase64)
 	msg.Data().(WithCodec).SetCodec(wm)
 	return c.codec.Marshal(ctx, msg, out)
 }
@@ -91,7 +91,7 @@ func (c *jsonThriftCodec) Unmarshal(ctx context.Context, msg remote.Message, in 
 		return perrors.NewProtocolErrorWithMsg("get parser ServiceDescriptor failed")
 	}
 	rm := thrift.NewReadJSON(svcDsc, msg.RPCRole() == remote.Client)
-	rm.SetBase64Binary(c.base64Binary)
+	rm.SetBinaryWithBase64(c.binaryWithBase64)
 	msg.Data().(WithCodec).SetCodec(rm)
 	return c.codec.Unmarshal(ctx, msg, in)
 }

--- a/pkg/generic/jsonthrift_codec.go
+++ b/pkg/generic/jsonthrift_codec.go
@@ -37,14 +37,15 @@ var (
 type JSONRequest = string
 
 type jsonThriftCodec struct {
-	svcDsc   atomic.Value // *idl
-	provider DescriptorProvider
-	codec    remote.PayloadCodec
+	svcDsc       atomic.Value // *idl
+	provider     DescriptorProvider
+	codec        remote.PayloadCodec
+	base64Binary bool
 }
 
 func newJsonThriftCodec(p DescriptorProvider, codec remote.PayloadCodec) (*jsonThriftCodec, error) {
 	svc := <-p.Provide()
-	c := &jsonThriftCodec{codec: codec, provider: p}
+	c := &jsonThriftCodec{codec: codec, provider: p, base64Binary: true}
 	c.svcDsc.Store(svc)
 	go c.update()
 	return c, nil
@@ -76,6 +77,7 @@ func (c *jsonThriftCodec) Marshal(ctx context.Context, msg remote.Message, out r
 	if err != nil {
 		return err
 	}
+	wm.SetBase64Binary(c.base64Binary)
 	msg.Data().(WithCodec).SetCodec(wm)
 	return c.codec.Marshal(ctx, msg, out)
 }
@@ -89,6 +91,7 @@ func (c *jsonThriftCodec) Unmarshal(ctx context.Context, msg remote.Message, in 
 		return perrors.NewProtocolErrorWithMsg("get parser ServiceDescriptor failed")
 	}
 	rm := thrift.NewReadJSON(svcDsc, msg.RPCRole() == remote.Client)
+	rm.SetBase64Binary(c.base64Binary)
 	msg.Data().(WithCodec).SetCodec(rm)
 	return c.codec.Unmarshal(ctx, msg, in)
 }

--- a/pkg/generic/thrift/http.go
+++ b/pkg/generic/thrift/http.go
@@ -26,8 +26,8 @@ import (
 
 // WriteHTTPRequest implement of MessageWriter
 type WriteHTTPRequest struct {
-	svc          *descriptor.ServiceDescriptor
-	base64Binary bool
+	svc              *descriptor.ServiceDescriptor
+	binaryWithBase64 bool
 }
 
 var _ MessageWriter = (*WriteHTTPRequest)(nil)
@@ -40,8 +40,8 @@ func NewWriteHTTPRequest(svc *descriptor.ServiceDescriptor) *WriteHTTPRequest {
 
 // SetBase64Binary enable/disable Base64 decoding for binary.
 // Note that this method is not concurrent-safe.
-func (w *WriteHTTPRequest) SetBase64Binary(enable bool) {
-	w.base64Binary = enable
+func (w *WriteHTTPRequest) SetBinaryWithBase64(enable bool) {
+	w.binaryWithBase64 = enable
 }
 
 // Write ...
@@ -54,7 +54,7 @@ func (w *WriteHTTPRequest) Write(ctx context.Context, out thrift.TProtocol, msg 
 	if !fn.HasRequestBase {
 		requestBase = nil
 	}
-	return wrapStructWriter(ctx, req, out, fn.Request, &writerOption{requestBase: requestBase, base64Binary: w.base64Binary})
+	return wrapStructWriter(ctx, req, out, fn.Request, &writerOption{requestBase: requestBase, binaryWithBase64: w.binaryWithBase64})
 }
 
 // ReadHTTPResponse implement of MessageReaderWithMethod
@@ -84,5 +84,5 @@ func (r *ReadHTTPResponse) Read(ctx context.Context, method string, in thrift.TP
 		return nil, err
 	}
 	fDsc := fnDsc.Response
-	return skipStructReader(ctx, in, fDsc, &readerOption{forJSON: true, http: true, base64Binary: r.base64Binary})
+	return skipStructReader(ctx, in, fDsc, &readerOption{forJSON: true, http: true, binaryWithBase64: r.base64Binary})
 }

--- a/pkg/generic/thrift/json.go
+++ b/pkg/generic/thrift/json.go
@@ -68,7 +68,7 @@ func (m *WriteJSON) Write(ctx context.Context, out thrift.TProtocol, msg interfa
 
 	// msg is void
 	if _, ok := msg.(descriptor.Void); ok {
-		return wrapStructWriter(ctx, msg, out, m.ty, &writerOption{requestBase: requestBase, base64Binary: m.base64Binary})
+		return wrapStructWriter(ctx, msg, out, m.ty, &writerOption{requestBase: requestBase, binaryWithBase64: m.base64Binary})
 	}
 
 	// msg is string
@@ -87,31 +87,31 @@ func (m *WriteJSON) Write(ctx context.Context, out thrift.TProtocol, msg interfa
 			Index: 0,
 		}
 	}
-	return wrapJSONWriter(ctx, &body, out, m.ty, &writerOption{requestBase: requestBase, base64Binary: m.base64Binary})
+	return wrapJSONWriter(ctx, &body, out, m.ty, &writerOption{requestBase: requestBase, binaryWithBase64: m.base64Binary})
 }
 
 // NewReadJSON build ReadJSON according to ServiceDescriptor
 func NewReadJSON(svc *descriptor.ServiceDescriptor, isClient bool) *ReadJSON {
 	return &ReadJSON{
-		svc:          svc,
-		isClient:     isClient,
-		base64Binary: true,
+		svc:              svc,
+		isClient:         isClient,
+		binaryWithBase64: true,
 	}
 }
 
 // ReadJSON implement of MessageReaderWithMethod
 type ReadJSON struct {
-	svc          *descriptor.ServiceDescriptor
-	isClient     bool
-	base64Binary bool
+	svc              *descriptor.ServiceDescriptor
+	isClient         bool
+	binaryWithBase64 bool
 }
 
 var _ MessageReader = (*ReadJSON)(nil)
 
-// SetBase64Binary enable/disable Base64 encoding for binary.
+// SetBinaryWithBase64 enable/disable Base64 encoding for binary.
 // Note that this method is not concurrent-safe.
-func (m *ReadJSON) SetBase64Binary(enable bool) {
-	m.base64Binary = enable
+func (m *ReadJSON) SetBinaryWithBase64(enable bool) {
+	m.binaryWithBase64 = enable
 }
 
 // Read read data from in thrift.TProtocol and convert to json string
@@ -124,7 +124,7 @@ func (m *ReadJSON) Read(ctx context.Context, method string, in thrift.TProtocol)
 	if !m.isClient {
 		fDsc = fnDsc.Request
 	}
-	resp, err := skipStructReader(ctx, in, fDsc, &readerOption{forJSON: true, throwException: true, base64Binary: m.base64Binary})
+	resp, err := skipStructReader(ctx, in, fDsc, &readerOption{forJSON: true, throwException: true, binaryWithBase64: m.binaryWithBase64})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generic/thrift/json.go
+++ b/pkg/generic/thrift/json.go
@@ -40,6 +40,7 @@ func NewWriteJSON(svc *descriptor.ServiceDescriptor, method string, isClient boo
 	ws := &WriteJSON{
 		ty:             ty,
 		hasRequestBase: fnDsc.HasRequestBase && isClient,
+		base64Binary:   true,
 	}
 	return ws, nil
 }
@@ -48,9 +49,16 @@ func NewWriteJSON(svc *descriptor.ServiceDescriptor, method string, isClient boo
 type WriteJSON struct {
 	ty             *descriptor.TypeDescriptor
 	hasRequestBase bool
+	base64Binary   bool
 }
 
 var _ MessageWriter = (*WriteJSON)(nil)
+
+// SetBase64Binary enable/disable Base64 decoding for binary.
+// Note that this method is not concurrent-safe.
+func (m *WriteJSON) SetBase64Binary(enable bool) {
+	m.base64Binary = enable
+}
 
 // Write write json string to out thrift.TProtocol
 func (m *WriteJSON) Write(ctx context.Context, out thrift.TProtocol, msg interface{}, requestBase *Base) error {
@@ -60,7 +68,7 @@ func (m *WriteJSON) Write(ctx context.Context, out thrift.TProtocol, msg interfa
 
 	// msg is void
 	if _, ok := msg.(descriptor.Void); ok {
-		return wrapStructWriter(ctx, msg, out, m.ty, &writerOption{requestBase: requestBase})
+		return wrapStructWriter(ctx, msg, out, m.ty, &writerOption{requestBase: requestBase, base64Binary: m.base64Binary})
 	}
 
 	// msg is string
@@ -79,24 +87,32 @@ func (m *WriteJSON) Write(ctx context.Context, out thrift.TProtocol, msg interfa
 			Index: 0,
 		}
 	}
-	return wrapJSONWriter(ctx, &body, out, m.ty, &writerOption{requestBase: requestBase})
+	return wrapJSONWriter(ctx, &body, out, m.ty, &writerOption{requestBase: requestBase, base64Binary: m.base64Binary})
 }
 
 // NewReadJSON build ReadJSON according to ServiceDescriptor
 func NewReadJSON(svc *descriptor.ServiceDescriptor, isClient bool) *ReadJSON {
 	return &ReadJSON{
-		svc:      svc,
-		isClient: isClient,
+		svc:          svc,
+		isClient:     isClient,
+		base64Binary: true,
 	}
 }
 
 // ReadJSON implement of MessageReaderWithMethod
 type ReadJSON struct {
-	svc      *descriptor.ServiceDescriptor
-	isClient bool
+	svc          *descriptor.ServiceDescriptor
+	isClient     bool
+	base64Binary bool
 }
 
 var _ MessageReader = (*ReadJSON)(nil)
+
+// SetBase64Binary enable/disable Base64 encoding for binary.
+// Note that this method is not concurrent-safe.
+func (m *ReadJSON) SetBase64Binary(enable bool) {
+	m.base64Binary = enable
+}
 
 // Read read data from in thrift.TProtocol and convert to json string
 func (m *ReadJSON) Read(ctx context.Context, method string, in thrift.TProtocol) (interface{}, error) {
@@ -108,7 +124,7 @@ func (m *ReadJSON) Read(ctx context.Context, method string, in thrift.TProtocol)
 	if !m.isClient {
 		fDsc = fnDsc.Request
 	}
-	resp, err := skipStructReader(ctx, in, fDsc, &readerOption{forJSON: true, throwException: true})
+	resp, err := skipStructReader(ctx, in, fDsc, &readerOption{forJSON: true, throwException: true, base64Binary: m.base64Binary})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generic/thrift/read.go
+++ b/pkg/generic/thrift/read.go
@@ -32,8 +32,8 @@ type readerOption struct {
 	// return exception as error
 	throwException bool
 	// read http response
-	http         bool
-	base64Binary bool
+	http             bool
+	binaryWithBase64 bool
 }
 
 type reader func(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescriptor, opt *readerOption) (interface{}, error)
@@ -54,7 +54,7 @@ func nextReader(tt descriptor.Type, t *descriptor.TypeDescriptor, opt *readerOpt
 	case descriptor.I64:
 		return readInt64, nil
 	case descriptor.STRING:
-		if t.Name == "binary" && opt.base64Binary {
+		if t.Name == "binary" && opt.binaryWithBase64 {
 			return readBase64Binary, nil
 		}
 		return readString, nil

--- a/pkg/generic/thrift/read.go
+++ b/pkg/generic/thrift/read.go
@@ -32,12 +32,13 @@ type readerOption struct {
 	// return exception as error
 	throwException bool
 	// read http response
-	http bool
+	http         bool
+	base64Binary bool
 }
 
 type reader func(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescriptor, opt *readerOption) (interface{}, error)
 
-func nextReader(tt descriptor.Type, t *descriptor.TypeDescriptor) (reader, error) {
+func nextReader(tt descriptor.Type, t *descriptor.TypeDescriptor, opt *readerOption) (reader, error) {
 	if err := assertType(tt, t.Type); err != nil {
 		return nil, err
 	}
@@ -53,6 +54,9 @@ func nextReader(tt descriptor.Type, t *descriptor.TypeDescriptor) (reader, error
 	case descriptor.I64:
 		return readInt64, nil
 	case descriptor.STRING:
+		if t.Name == "binary" && opt.base64Binary {
+			return readBase64Binary, nil
+		}
 		return readString, nil
 	case descriptor.DOUBLE:
 		return readDouble, nil
@@ -95,7 +99,7 @@ func skipStructReader(ctx context.Context, in thrift.TProtocol, t *descriptor.Ty
 			}
 		} else {
 			_fieldType := descriptor.FromThriftTType(fieldType)
-			reader, err := nextReader(_fieldType, field.Type)
+			reader, err := nextReader(_fieldType, field.Type, opt)
 			if err != nil {
 				return nil, fmt.Errorf("nextReader of %s/%s/%d error %w", structName, fieldName, fieldID, err)
 			}
@@ -153,16 +157,15 @@ func readInt64(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescr
 }
 
 func readString(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescriptor, opt *readerOption) (interface{}, error) {
-	switch t.Name {
-	case "binary":
-		bytes, err := in.ReadBinary()
-		if err != nil {
-			return "", err
-		}
-		return base64.StdEncoding.EncodeToString(bytes), nil
-	default:
-		return in.ReadString()
+	return in.ReadString()
+}
+
+func readBase64Binary(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescriptor, opt *readerOption) (interface{}, error) {
+	bytes, err := in.ReadBinary()
+	if err != nil {
+		return "", err
 	}
+	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
 func readList(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescriptor, opt *readerOption) (interface{}, error) {
@@ -171,7 +174,7 @@ func readList(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDescri
 		return nil, err
 	}
 	_elemType := descriptor.FromThriftTType(elemType)
-	reader, err := nextReader(_elemType, t.Elem)
+	reader, err := nextReader(_elemType, t.Elem, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -203,12 +206,12 @@ func readInterfaceMap(ctx context.Context, in thrift.TProtocol, t *descriptor.Ty
 		return m, nil
 	}
 	_keyType := descriptor.FromThriftTType(keyType)
-	keyReader, err := nextReader(_keyType, t.Key)
+	keyReader, err := nextReader(_keyType, t.Key, opt)
 	if err != nil {
 		return nil, err
 	}
 	_elemType := descriptor.FromThriftTType(elemType)
-	elemReader, err := nextReader(_elemType, t.Elem)
+	elemReader, err := nextReader(_elemType, t.Elem, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -236,12 +239,12 @@ func readStringMap(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeD
 		return m, nil
 	}
 	_keyType := descriptor.FromThriftTType(keyType)
-	keyReader, err := nextReader(_keyType, t.Key)
+	keyReader, err := nextReader(_keyType, t.Key, opt)
 	if err != nil {
 		return nil, err
 	}
 	_elemType := descriptor.FromThriftTType(elemType)
-	elemReader, err := nextReader(_elemType, t.Elem)
+	elemReader, err := nextReader(_elemType, t.Elem, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +295,7 @@ func readStruct(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDesc
 			}
 		} else {
 			_fieldType := descriptor.FromThriftTType(fieldType)
-			reader, err := nextReader(_fieldType, field.Type)
+			reader, err := nextReader(_fieldType, field.Type, opt)
 			if err != nil {
 				return nil, fmt.Errorf("nextReader of %s/%s/%d error %w", t.Name, field.Name, fieldID, err)
 			}
@@ -345,7 +348,7 @@ func readHTTPResponse(ctx context.Context, in thrift.TProtocol, t *descriptor.Ty
 		} else {
 			// check required
 			_fieldType := descriptor.FromThriftTType(fieldType)
-			reader, err := nextReader(_fieldType, field.Type)
+			reader, err := nextReader(_fieldType, field.Type, opt)
 			if err != nil {
 				return nil, fmt.Errorf("nextReader of %s/%s/%d error %w", t.Name, field.Name, fieldID, err)
 			}

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -30,11 +30,14 @@ import (
 
 type writerOption struct {
 	requestBase *Base // request base from metahandler
+	// decoding Base64 to binary
+	base64Binary bool
 }
 
 type writer func(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error
 
-func typeOf(sample interface{}, tt descriptor.Type) (descriptor.Type, writer, error) {
+func typeOf(sample interface{}, t *descriptor.TypeDescriptor, opt *writerOption) (descriptor.Type, writer, error) {
+	tt := t.Type
 	switch sample.(type) {
 	case bool:
 		return descriptor.BOOL, writeBool, nil
@@ -58,6 +61,10 @@ func typeOf(sample interface{}, tt descriptor.Type) (descriptor.Type, writer, er
 			return tt, writeJSONNumber, nil
 		}
 	case string:
+		// maybe a base64 string encoded from binary
+		if t.Name == "binary" && opt.base64Binary {
+			return descriptor.STRING, writeBase64Binary, nil
+		}
 		// maybe a json number string
 		return descriptor.STRING, writeString, nil
 	case []byte:
@@ -85,7 +92,8 @@ func typeOf(sample interface{}, tt descriptor.Type) (descriptor.Type, writer, er
 	return 0, nil, fmt.Errorf("unsupported type:%T, expected type:%s", sample, tt)
 }
 
-func typeJSONOf(data *gjson.Result, tt descriptor.Type) (v interface{}, w writer, err error) {
+func typeJSONOf(data *gjson.Result, t *descriptor.TypeDescriptor, opt *writerOption) (v interface{}, w writer, err error) {
+	tt := t.Type
 	defer func() {
 		if r := recover(); r != nil {
 			err = perrors.NewProtocolErrorWithType(perrors.InvalidData, fmt.Sprintf("json convert error:%#+v", r))
@@ -118,7 +126,11 @@ func typeJSONOf(data *gjson.Result, tt descriptor.Type) (v interface{}, w writer
 		return
 	case descriptor.STRING:
 		v = data.String()
-		w = writeString
+		if t.Name == "binary" && opt.base64Binary {
+			w = writeBase64Binary
+		} else {
+			w = writeString
+		}
 		return
 	// case descriptor.BINARY:
 	//	return writeBinary, nil
@@ -142,8 +154,8 @@ func typeJSONOf(data *gjson.Result, tt descriptor.Type) (v interface{}, w writer
 	return 0, nil, fmt.Errorf("data:%#v, expected type:%s, err:%#v", data, tt, err)
 }
 
-func nextWriter(sample interface{}, t *descriptor.TypeDescriptor) (writer, error) {
-	tt, fn, err := typeOf(sample, t.Type)
+func nextWriter(sample interface{}, t *descriptor.TypeDescriptor, opt *writerOption) (writer, error) {
+	tt, fn, err := typeOf(sample, t, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +165,8 @@ func nextWriter(sample interface{}, t *descriptor.TypeDescriptor) (writer, error
 	return fn, assertType(t.Type, tt)
 }
 
-func nextJSONWriter(data *gjson.Result, t *descriptor.TypeDescriptor) (interface{}, writer, error) {
-	v, fn, err := typeJSONOf(data, t.Type)
+func nextJSONWriter(data *gjson.Result, t *descriptor.TypeDescriptor, opt *writerOption) (interface{}, writer, error) {
+	v, fn, err := typeJSONOf(data, t, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -174,7 +186,7 @@ func wrapStructWriter(ctx context.Context, val interface{}, out thrift.TProtocol
 		if err := out.WriteFieldBegin(field.Name, field.Type.Type.ToThriftTType(), int16(field.ID)); err != nil {
 			return err
 		}
-		writer, err := nextWriter(val, field.Type)
+		writer, err := nextWriter(val, field.Type, opt)
 		if err != nil {
 			return fmt.Errorf("nextWriter of field[%s] error %w", name, err)
 		}
@@ -204,7 +216,7 @@ func wrapJSONWriter(ctx context.Context, val *gjson.Result, out thrift.TProtocol
 		if err := out.WriteFieldBegin(field.Name, field.Type.Type.ToThriftTType(), int16(field.ID)); err != nil {
 			return err
 		}
-		v, writer, err := nextJSONWriter(val, field.Type)
+		v, writer, err := nextJSONWriter(val, field.Type, opt)
 		if err != nil {
 			return fmt.Errorf("nextWriter of field[%s] error %w", name, err)
 		}
@@ -304,16 +316,15 @@ func writeFloat64(ctx context.Context, val interface{}, out thrift.TProtocol, t 
 }
 
 func writeString(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error {
-	switch t.Name {
-	case "binary":
-		bytes, err := base64.StdEncoding.DecodeString(val.(string))
-		if err != nil {
-			return err
-		}
-		return out.WriteBinary(bytes)
-	default:
-		return out.WriteString(val.(string))
+	return out.WriteString(val.(string))
+}
+
+func writeBase64Binary(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error {
+	bytes, err := base64.StdEncoding.DecodeString(val.(string))
+	if err != nil {
+		return err
 	}
+	return out.WriteBinary(bytes)
 }
 
 func writeBinary(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error {
@@ -329,7 +340,7 @@ func writeList(ctx context.Context, val interface{}, out thrift.TProtocol, t *de
 	if length == 0 {
 		return out.WriteListEnd()
 	}
-	writer, err := nextWriter(l[0], t.Elem)
+	writer, err := nextWriter(l[0], t.Elem, opt)
 	if err != nil {
 		return err
 	}
@@ -351,7 +362,7 @@ func writeJSONList(ctx context.Context, val interface{}, out thrift.TProtocol, t
 		return out.WriteListEnd()
 	}
 	for _, elem := range l {
-		v, writer, err := nextJSONWriter(&elem, t.Elem)
+		v, writer, err := nextJSONWriter(&elem, t.Elem, opt)
 		if err != nil {
 			return err
 		}
@@ -379,11 +390,11 @@ func writeInterfaceMap(ctx context.Context, val interface{}, out thrift.TProtoco
 		return out.WriteMapEnd()
 	}
 	keySample, elemSample := takeSampleFromMap(m)
-	keyWriter, err := nextWriter(keySample, t.Key)
+	keyWriter, err := nextWriter(keySample, t.Key, opt)
 	if err != nil {
 		return err
 	}
-	elemWriter, err := nextWriter(elemSample, t.Elem)
+	elemWriter, err := nextWriter(elemSample, t.Elem, opt)
 	if err != nil {
 		return err
 	}
@@ -418,12 +429,12 @@ func writeStringMap(ctx context.Context, val interface{}, out thrift.TProtocol, 
 			return err
 		}
 		if keyWriter == nil {
-			if keyWriter, err = nextWriter(_key, t.Key); err != nil {
+			if keyWriter, err = nextWriter(_key, t.Key, opt); err != nil {
 				return err
 			}
 		}
 		if elemWriter == nil {
-			if elemWriter, err = nextWriter(elem, t.Elem); err != nil {
+			if elemWriter, err = nextWriter(elem, t.Elem, opt); err != nil {
 				return err
 			}
 		}
@@ -459,11 +470,11 @@ func writeStringJSONMap(ctx context.Context, val interface{}, out thrift.TProtoc
 			return err
 		}
 		if keyWriter == nil {
-			if keyWriter, err = nextWriter(_key, t.Key); err != nil {
+			if keyWriter, err = nextWriter(_key, t.Key, opt); err != nil {
 				return err
 			}
 		}
-		if v, elemWriter, err = nextJSONWriter(&elem, t.Elem); err != nil {
+		if v, elemWriter, err = nextJSONWriter(&elem, t.Elem, opt); err != nil {
 			return err
 		}
 		if err := keyWriter(ctx, _key, out, t.Key, opt); err != nil {
@@ -547,7 +558,7 @@ func writeStruct(ctx context.Context, val interface{}, out thrift.TProtocol, t *
 				return err
 			}
 		}
-		writer, err := nextWriter(elem, field.Type)
+		writer, err := nextWriter(elem, field.Type, opt)
 		if err != nil {
 			return fmt.Errorf("nextWriter of field[%s] error %w", name, err)
 		}
@@ -599,7 +610,7 @@ func writeHTTPRequest(ctx context.Context, val interface{}, out thrift.TProtocol
 				return err
 			}
 		}
-		writer, err := nextWriter(v, field.Type)
+		writer, err := nextWriter(v, field.Type, opt)
 		if err != nil {
 			return fmt.Errorf("nextWriter of field[%s] error %w", name, err)
 		}
@@ -641,7 +652,7 @@ func writeJSON(ctx context.Context, val interface{}, out thrift.TProtocol, t *de
 			continue
 		}
 
-		v, writer, err := nextJSONWriter(&elem, field.Type)
+		v, writer, err := nextJSONWriter(&elem, field.Type, opt)
 		if err != nil {
 			return fmt.Errorf("nextWriter of field[%s] error %w", name, err)
 		}

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -31,7 +31,7 @@ import (
 type writerOption struct {
 	requestBase *Base // request base from metahandler
 	// decoding Base64 to binary
-	base64Binary bool
+	binaryWithBase64 bool
 }
 
 type writer func(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error
@@ -62,7 +62,7 @@ func typeOf(sample interface{}, t *descriptor.TypeDescriptor, opt *writerOption)
 		}
 	case string:
 		// maybe a base64 string encoded from binary
-		if t.Name == "binary" && opt.base64Binary {
+		if t.Name == "binary" && opt.binaryWithBase64 {
 			return descriptor.STRING, writeBase64Binary, nil
 		}
 		// maybe a json number string
@@ -126,7 +126,7 @@ func typeJSONOf(data *gjson.Result, t *descriptor.TypeDescriptor, opt *writerOpt
 		return
 	case descriptor.STRING:
 		v = data.String()
-		if t.Name == "binary" && opt.base64Binary {
+		if t.Name == "binary" && opt.binaryWithBase64 {
 			w = writeBase64Binary
 		} else {
 			w = writeString

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -435,8 +435,41 @@ func Test_writeString(t *testing.T) {
 			},
 			false,
 		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := writeString(context.Background(), tt.args.val, tt.args.out, tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
+				t.Errorf("writeString() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_writeBase64String(t *testing.T) {
+	type args struct {
+		val interface{}
+		out thrift.TProtocol
+		t   *descriptor.TypeDescriptor
+		opt *writerOption
+	}
+	mockTTransport := &mocks.MockThriftTTransport{
+		WriteStringFunc: func(val string) error {
+			test.Assert(t, val == stringInput)
+			return nil
+		},
+		WriteBinaryFunc: func(val []byte) error {
+			test.DeepEqual(t, val, binaryInput)
+			return nil
+		},
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
 		{
-			"writeBinary", // write to binary field with base64 string
+			"writeBase64Binary", // write to binary field with base64 string
 			args{
 				val: base64.StdEncoding.EncodeToString(binaryInput),
 				out: mockTTransport,
@@ -451,7 +484,7 @@ func Test_writeString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := writeString(context.Background(), tt.args.val, tt.args.out, tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
+			if err := writeBase64Binary(context.Background(), tt.args.val, tt.args.out, tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
 				t.Errorf("writeString() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
fix incompatible base64-binary conversion for json and http generic
zh:
修复 json http 泛化中 base64 和 binary 的不兼容改动