### PR TITLE
fix(client): release connection when Send failed

### DIFF
--- a/pkg/remote/remotecli/client.go
+++ b/pkg/remote/remotecli/client.go
@@ -86,6 +86,9 @@ func (c *client) init(handler remote.TransHandler, cm *ConnWrapper, conn net.Con
 // Send is blocked.
 func (c *client) Send(ctx context.Context, ri rpcinfo.RPCInfo, req remote.Message) (err error) {
 	err = c.transHdlr.Write(ctx, c.conn, req)
+	if err != nil {
+		c.connManager.ReleaseConn(err, ri)
+	}
 	return err
 }
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: fix a connection leaking bug that happens when clients fail at `Send`
zh: 修复客户端编码失败时连接会泄漏的问题
