### PR TITLE
feat: muxpool supports graceful closing of connections when called Clean

### DIFF
--- a/pkg/remote/trans/netpollmux/mux_conn.go
+++ b/pkg/remote/trans/netpollmux/mux_conn.go
@@ -39,6 +39,7 @@ func newMuxCliConn(connection netpoll.Connection) *muxCliConn {
 		muxConn:  newMuxConn(connection),
 		seqIDMap: newShardMap(mux.ShardSize),
 	}
+	connection.AddCloseCallback(c.CloseCallback)
 	connection.SetOnRequest(c.OnRequest)
 	return c
 }
@@ -80,7 +81,11 @@ func (c *muxCliConn) Close() error {
 }
 
 func (c *muxCliConn) close() error {
-	c.Connection.Close()
+	return c.Connection.Close()
+}
+
+// graceful exit
+func (c *muxCliConn) CloseCallback(connection netpoll.Connection) error {
 	c.seqIDMap.rangeMap(func(seqID int32, msg EventHandler) {
 		msg.Recv(nil, ErrConnClosed)
 	})

--- a/pkg/remote/trans/netpollmux/mux_pool.go
+++ b/pkg/remote/trans/netpollmux/mux_pool.go
@@ -96,9 +96,13 @@ func (mp *MuxPool) Discard(conn net.Conn) error {
 
 // Clean implements the LongConnPool interface.
 func (mp *MuxPool) Clean(network, address string) {
-	if v, ok := mp.connMap.Load(address); ok {
+	if _, ok := mp.connMap.Load(address); ok {
 		mp.connMap.Delete(address)
-		v.(*conns).close()
+		// `Clean` is called by `lbcache.clean` which means the peer (server) is exiting,
+		// so we don't have to close these connections.
+		// Just wait for the peer to close, then gracefully close the connection via `CloseCallback`
+		//
+		// v.(*conns).close()
 	}
 }
 

--- a/pkg/remote/trans/netpollmux/mux_pool_test.go
+++ b/pkg/remote/trans/netpollmux/mux_pool_test.go
@@ -152,8 +152,9 @@ func TestMuxConnPoolDiscardClean(t *testing.T) {
 		p.Discard(conns[i])
 		test.Assert(t, closed == 0, closed)
 	}
+	// graceful clean
 	p.Clean(network, address)
-	test.Assert(t, closed == size, closed, size)
+	test.Assert(t, closed == 0, closed)
 }
 
 func TestMuxConnPoolClose(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it (English/Chinese):

en: muxpool supports graceful closing of connections when called Clean
zh: 连接多路复用场景，client 端支持连接优雅关闭

#### Which issue(s) this PR fixes:
