### PR TITLE
optimize: add error definition ErrInstanceNotFound which is used in service discovery module

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -22,7 +22,6 @@ package discovery
 
 import (
 	"context"
-	"errors"
 	"net"
 
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
@@ -31,9 +30,6 @@ import (
 
 // DefaultWeight is the default weight for an instance.
 const DefaultWeight = 10
-
-// ErrInstanceNotFound means instance not found
-var ErrInstanceNotFound = errors.New("instance not found")
 
 // Result contains the result of service discovery process.
 // Cacheable tells whether the instance list can/should be cached.

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -22,6 +22,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
@@ -30,6 +31,9 @@ import (
 
 // DefaultWeight is the default weight for an instance.
 const DefaultWeight = 10
+
+// ErrInstanceNotFound means instance not found
+var ErrInstanceNotFound = errors.New("instance not found")
 
 // Result contains the result of service discovery process.
 // Cacheable tells whether the instance list can/should be cached.

--- a/pkg/kerrors/kerrors.go
+++ b/pkg/kerrors/kerrors.go
@@ -54,7 +54,7 @@ var (
 	ErrNoIvkRequest         = ErrInternalException.WithCause(errors.New("invoker request not set"))
 	ErrServiceCircuitBreak  = ErrCircuitBreak.WithCause(errors.New("service circuitbreak"))
 	ErrInstanceCircuitBreak = ErrCircuitBreak.WithCause(errors.New("instance circuitbreak"))
-	ErrInstanceNotFound     = ErrServiceDiscovery.WithCause(errors.New("instance not found"))
+	ErrNoInstance           = ErrServiceDiscovery.WithCause(errors.New("no instance available"))
 )
 
 type basicError struct {

--- a/pkg/kerrors/kerrors.go
+++ b/pkg/kerrors/kerrors.go
@@ -54,6 +54,7 @@ var (
 	ErrNoIvkRequest         = ErrInternalException.WithCause(errors.New("invoker request not set"))
 	ErrServiceCircuitBreak  = ErrCircuitBreak.WithCause(errors.New("service circuitbreak"))
 	ErrInstanceCircuitBreak = ErrCircuitBreak.WithCause(errors.New("instance circuitbreak"))
+	ErrInstanceNotFound     = ErrServiceDiscovery.WithCause(errors.New("instance not found"))
 )
 
 type basicError struct {


### PR DESCRIPTION
Define instance not found error.
For kinds of registries in kitex-contrib.