### PR TITLE
optimize: improve retry success rate when do failure retry

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -109,7 +109,7 @@ func rpcTimeoutMW(mwCtx context.Context) endpoint.Middleware {
 						e := panicToErr(ctx, panicInfo, ri)
 						done <- e
 					}
-					if !errors.Is(err, kerrors.ErrRPCFinish) {
+					if err == nil || !errors.Is(err, kerrors.ErrRPCFinish) {
 						// Don't regards ErrRPCFinish as normal error, it happens in retry scene,
 						// ErrRPCFinish means previous call returns first but is decoding.
 						close(done)

--- a/pkg/remote/codec/default_codec.go
+++ b/pkg/remote/codec/default_codec.go
@@ -247,6 +247,9 @@ func checkRPCState(ctx context.Context, message remote.Message) error {
 	if message.RPCRole() == remote.Server {
 		return nil
 	}
+	if ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
+		return kerrors.ErrRPCFinish
+	}
 	if respOp, ok := ctx.Value(retry.CtxRespOp).(*int32); ok {
 		if !atomic.CompareAndSwapInt32(respOp, retry.OpNo, retry.OpDoing) {
 			// previous call is being handling or done


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: improve retry success rate when do failure retry and ignore unnecessary decode when timeout happened
zh: 提高异常重试的重试成功率（如果超时的请求先于重试的请求返回，可能会导致重试请求也失败），同时也可以避免超时请求不必要的解码处理

#### Which issue(s) this PR fixes:
none
