### PR TITLE
feat: support options to set the internal params of gRPC (#325)

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/loadbalance/lbcache"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/trans/netpollmux"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
 	"github.com/cloudwego/kitex/pkg/retry"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
@@ -355,5 +356,51 @@ func WithCircuitBreaker(s *circuitbreak.CBSuite) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push("WithCircuitBreaker()")
 		o.CBSuite = s
+	}}
+}
+
+// WithGRPCConnPoolSize sets the value for the client connection pool size.
+func WithGRPCConnPoolSize(s uint32) Option {
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCConnPoolSize(%d)", s))
+		o.GRPCConnPoolSize = s
+	}}
+}
+
+// WithGRPCInitialWindowSize sets the value for initial window size on a grpc stream.
+// The lower bound for window size is 64K and any value smaller than that will be ignored.
+func WithGRPCInitialWindowSize(s uint32) Option {
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCInitialWindowSize(%d)", s))
+		o.GRPCConnectOpts.InitialWindowSize = s
+	}}
+}
+
+// WithGRPCInitialConnWindowSize sets the value for initial window size on a connection of grpc.
+// The lower bound for window size is 64K and any value smaller than that will be ignored.
+func WithGRPCInitialConnWindowSize(s uint32) Option {
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCInitialConnWindowSize(%d)", s))
+		o.GRPCConnectOpts.InitialConnWindowSize = s
+	}}
+}
+
+// WithGRPCMaxHeaderListSize returns a DialOption that specifies the maximum
+// (uncompressed) size of header list that the client is prepared to accept.
+func WithGRPCMaxHeaderListSize(s uint32) Option {
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCMaxHeaderListSize(%d)", s))
+		o.GRPCConnectOpts.MaxHeaderListSize = &s
+	}}
+}
+
+// WithGRPCKeepaliveParams returns a DialOption that specifies keepalive parameters for the client transport.
+func WithGRPCKeepaliveParams(kp grpc.ClientKeepalive) Option {
+	if kp.Time < grpc.KeepaliveMinPingTime {
+		kp.Time = grpc.KeepaliveMinPingTime
+	}
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCKeepaliveParams(%+v)", kp))
+		o.GRPCConnectOpts.KeepaliveParams = kp
 	}}
 }

--- a/client/option.go
+++ b/client/option.go
@@ -360,6 +360,8 @@ func WithCircuitBreaker(s *circuitbreak.CBSuite) Option {
 }
 
 // WithGRPCConnPoolSize sets the value for the client connection pool size.
+// In general, you should not adjust the size of the connection pool, otherwise it may cause performance degradation.
+// You should adjust the size according to the actual situation.
 func WithGRPCConnPoolSize(s uint32) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCConnPoolSize(%d)", s))

--- a/client/option.go
+++ b/client/option.go
@@ -369,6 +369,7 @@ func WithGRPCConnPoolSize(s uint32) Option {
 
 // WithGRPCInitialWindowSize sets the value for initial window size on a grpc stream.
 // The lower bound for window size is 64K and any value smaller than that will be ignored.
+// It corresponds to the WithInitialWindowSize DialOption of gRPC.
 func WithGRPCInitialWindowSize(s uint32) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCInitialWindowSize(%d)", s))
@@ -378,6 +379,7 @@ func WithGRPCInitialWindowSize(s uint32) Option {
 
 // WithGRPCInitialConnWindowSize sets the value for initial window size on a connection of grpc.
 // The lower bound for window size is 64K and any value smaller than that will be ignored.
+// It corresponds to the WithInitialConnWindowSize DialOption of gRPC.
 func WithGRPCInitialConnWindowSize(s uint32) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCInitialConnWindowSize(%d)", s))
@@ -387,6 +389,7 @@ func WithGRPCInitialConnWindowSize(s uint32) Option {
 
 // WithGRPCMaxHeaderListSize returns a DialOption that specifies the maximum
 // (uncompressed) size of header list that the client is prepared to accept.
+// It corresponds to the WithMaxHeaderListSize DialOption of gRPC.
 func WithGRPCMaxHeaderListSize(s uint32) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCMaxHeaderListSize(%d)", s))
@@ -395,6 +398,7 @@ func WithGRPCMaxHeaderListSize(s uint32) Option {
 }
 
 // WithGRPCKeepaliveParams returns a DialOption that specifies keepalive parameters for the client transport.
+// It corresponds to the WithKeepaliveParams DialOption of gRPC.
 func WithGRPCKeepaliveParams(kp grpc.ClientKeepalive) Option {
 	if kp.Time < grpc.KeepaliveMinPingTime {
 		kp.Time = grpc.KeepaliveMinPingTime

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
 	"github.com/cloudwego/kitex/pkg/remote/trans/detection"
 	"github.com/cloudwego/kitex/pkg/remote/trans/netpoll"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
@@ -130,6 +131,7 @@ func newServerOption() *remote.ServerOption {
 		ExitWaitTime:          defaultExitWaitTime,
 		MaxConnectionIdleTime: defaultConnectionIdleTime,
 		AcceptFailedDelayTime: defaultAcceptFailedDelayTime,
+		GRPCCfg:               new(grpc.ServerConfig),
 	}
 }
 

--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	internal_stats "github.com/cloudwego/kitex/internal/stats"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
@@ -65,6 +66,8 @@ type ServerOption struct {
 	InitRPCInfoFunc func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context)
 
 	TracerCtl *internal_stats.Controller
+
+	GRPCCfg *grpc.ServerConfig
 
 	Option
 }

--- a/pkg/remote/trans/netpoll/server_handler_test.go
+++ b/pkg/remote/trans/netpoll/server_handler_test.go
@@ -23,14 +23,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudwego/netpoll"
-
 	"github.com/cloudwego/kitex/internal/mocks"
 	internal_stats "github.com/cloudwego/kitex/internal/stats"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/utils"
+	"github.com/cloudwego/netpoll"
 )
 
 var (

--- a/pkg/remote/trans/nphttp2/grpc/defaults.go
+++ b/pkg/remote/trans/nphttp2/grpc/defaults.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// The default value of flow control window size in HTTP2 spec.
-	defaultWindowSize = uint32(1 << 30) // 1GB
+	defaultWindowSize = uint32(65535) // 64KB
 	// The initial window size for flow control.
 	initialWindowSize = defaultWindowSize // for an RPC
 	// Infinity means unset duration
@@ -54,4 +54,10 @@ const (
 	defaultServerMaxHeaderListSize = uint32(16 << 20)
 
 	defaultUserAgent = "kitex/" + kitex.Version
+)
+
+const (
+	// KeepaliveMinPingTime is the minimum ping interval.
+	// This must be 10s by default, but tests may wish to set it lower for convenience.
+	KeepaliveMinPingTime = 10 * time.Second
 )

--- a/pkg/remote/trans/nphttp2/grpc/defaults.go
+++ b/pkg/remote/trans/nphttp2/grpc/defaults.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	// The default value of flow control window size in HTTP2 spec.
+	// Warning: please don't modify the value of defaultWindowSize, otherwise may cause compatibility problems.
 	defaultWindowSize = uint32(65535) // 64KB
 	// The initial window size for flow control.
 	initialWindowSize = defaultWindowSize // for an RPC

--- a/pkg/remote/trans/nphttp2/grpc/http_util.go
+++ b/pkg/remote/trans/nphttp2/grpc/http_util.go
@@ -31,17 +31,14 @@ import (
 	"time"
 	"unicode/utf8"
 
-	spb "google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/cloudwego/kitex/pkg/klog"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
-
 	"github.com/cloudwego/netpoll"
-
 	"github.com/cloudwego/netpoll-http2"
 	"github.com/cloudwego/netpoll-http2/hpack"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -504,16 +504,39 @@ const (
 	draining
 )
 
+// ServerConfig consists of all the configurations to establish a server transport.
+type ServerConfig struct {
+	MaxStreams                 uint32
+	KeepaliveParams            ServerKeepalive
+	KeepaliveEnforcementPolicy EnforcementPolicy
+	InitialWindowSize          uint32
+	InitialConnWindowSize      uint32
+	MaxHeaderListSize          *uint32
+}
+
+// ConnectOptions covers all relevant options for communicating with the server.
+type ConnectOptions struct {
+	// KeepaliveParams stores the keepalive parameters.
+	KeepaliveParams ClientKeepalive
+	// InitialWindowSize sets the initial window size for a stream.
+	InitialWindowSize uint32
+	// InitialConnWindowSize sets the initial window size for a connection.
+	InitialConnWindowSize uint32
+	// MaxHeaderListSize sets the max (uncompressed) size of header list that is prepared to be received.
+	MaxHeaderListSize *uint32
+}
+
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
-func NewServerTransport(ctx context.Context, conn netpoll.Connection) (ServerTransport, error) {
-	return newHTTP2Server(ctx, conn)
+func NewServerTransport(ctx context.Context, conn netpoll.Connection, cfg *ServerConfig) (ServerTransport, error) {
+	return newHTTP2Server(ctx, conn, cfg)
 }
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
-func NewClientTransport(ctx context.Context, conn netpoll.Connection, remoteService string, onGoAway func(GoAwayReason), onClose func()) (ClientTransport, error) {
-	return newHTTP2Client(ctx, conn, remoteService, onGoAway, onClose)
+func NewClientTransport(ctx context.Context, conn netpoll.Connection, opts ConnectOptions,
+	remoteService string, onGoAway func(GoAwayReason), onClose func()) (ClientTransport, error) {
+	return newHTTP2Client(ctx, conn, opts, remoteService, onGoAway, onClose)
 }
 
 // Options provides additional hints and information for message

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -87,7 +87,7 @@ func (t *svrTransHandler) Read(ctx context.Context, conn net.Conn, msg remote.Me
 
 // 只 return write err
 func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
-	tr, err := grpcTransport.NewServerTransport(ctx, conn.(netpoll.Connection))
+	tr, err := grpcTransport.NewServerTransport(ctx, conn.(netpoll.Connection), t.opt.GRPCCfg)
 	if err != nil {
 		return err
 	}

--- a/server/option.go
+++ b/server/option.go
@@ -209,6 +209,7 @@ func WithRegistryInfo(info *registry.Info) Option {
 
 // WithGRPCInitialWindowSize returns a Option that sets window size for stream.
 // The lower bound for window size is 64K and any value smaller than that will be ignored.
+// It corresponds to the InitialWindowSize ServerOption of gRPC.
 func WithGRPCInitialWindowSize(s uint32) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithRegistryInfo(%+v)", s))
@@ -219,6 +220,7 @@ func WithGRPCInitialWindowSize(s uint32) Option {
 
 // WithGRPCInitialConnWindowSize returns a Option that sets window size for a connection.
 // The lower bound for window size is 64K and any value smaller than that will be ignored.
+// It corresponds to the InitialConnWindowSize ServerOption of gRPC.
 func WithGRPCInitialConnWindowSize(s uint32) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCInitialConnWindowSize(%+v)", s))
@@ -228,6 +230,7 @@ func WithGRPCInitialConnWindowSize(s uint32) Option {
 }
 
 // WithGRPCKeepaliveParams returns a Option that sets keepalive and max-age parameters for the server.
+// It corresponds to the KeepaliveParams ServerOption of gRPC.
 func WithGRPCKeepaliveParams(kp grpc.ServerKeepalive) Option {
 	if kp.Time > 0 && kp.Time < time.Second {
 		kp.Time = time.Second
@@ -241,6 +244,7 @@ func WithGRPCKeepaliveParams(kp grpc.ServerKeepalive) Option {
 }
 
 // WithGRPCKeepaliveEnforcementPolicy returns a Option that sets keepalive enforcement policy for the server.
+// It corresponds to the KeepaliveEnforcementPolicy ServerOption of gRPC.
 func WithGRPCKeepaliveEnforcementPolicy(kep grpc.EnforcementPolicy) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCKeepaliveEnforcementPolicy(%+v)", kep))
@@ -251,6 +255,7 @@ func WithGRPCKeepaliveEnforcementPolicy(kep grpc.EnforcementPolicy) Option {
 
 // WithGRPCMaxConcurrentStreams returns a Option that will apply a limit on the number
 // of concurrent streams to each ServerTransport.
+// It corresponds to the MaxConcurrentStreams ServerOption of gRPC.
 func WithGRPCMaxConcurrentStreams(n uint32) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCMaxConcurrentStreams(%+v)", n))
@@ -261,6 +266,7 @@ func WithGRPCMaxConcurrentStreams(n uint32) Option {
 
 // WithGRPCMaxHeaderListSize returns a ServerOption that sets the max (uncompressed) size
 // of header list that the server is prepared to accept.
+// It corresponds to the MaxHeaderListSize ServerOption of gRPC.
 func WithGRPCMaxHeaderListSize(s uint32) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCMaxHeaderListSize(%+v)", s))

--- a/server/option.go
+++ b/server/option.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/registry"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/trans/netpollmux"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
 	"github.com/cloudwego/kitex/pkg/utils"
@@ -203,5 +204,67 @@ func WithRegistryInfo(info *registry.Info) Option {
 		di.Push(fmt.Sprintf("WithRegistryInfo(%+v)", info))
 
 		o.RegistryInfo = info
+	}}
+}
+
+// WithGRPCInitialWindowSize returns a Option that sets window size for stream.
+// The lower bound for window size is 64K and any value smaller than that will be ignored.
+func WithGRPCInitialWindowSize(s uint32) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithRegistryInfo(%+v)", s))
+
+		o.RemoteOpt.GRPCCfg.InitialWindowSize = s
+	}}
+}
+
+// WithGRPCInitialConnWindowSize returns a Option that sets window size for a connection.
+// The lower bound for window size is 64K and any value smaller than that will be ignored.
+func WithGRPCInitialConnWindowSize(s uint32) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCInitialConnWindowSize(%+v)", s))
+
+		o.RemoteOpt.GRPCCfg.InitialConnWindowSize = s
+	}}
+}
+
+// WithGRPCKeepaliveParams returns a Option that sets keepalive and max-age parameters for the server.
+func WithGRPCKeepaliveParams(kp grpc.ServerKeepalive) Option {
+	if kp.Time > 0 && kp.Time < time.Second {
+		kp.Time = time.Second
+	}
+
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCKeepaliveParams(%+v)", kp))
+
+		o.RemoteOpt.GRPCCfg.KeepaliveParams = kp
+	}}
+}
+
+// WithGRPCKeepaliveEnforcementPolicy returns a Option that sets keepalive enforcement policy for the server.
+func WithGRPCKeepaliveEnforcementPolicy(kep grpc.EnforcementPolicy) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCKeepaliveEnforcementPolicy(%+v)", kep))
+
+		o.RemoteOpt.GRPCCfg.KeepaliveEnforcementPolicy = kep
+	}}
+}
+
+// WithGRPCMaxConcurrentStreams returns a Option that will apply a limit on the number
+// of concurrent streams to each ServerTransport.
+func WithGRPCMaxConcurrentStreams(n uint32) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCMaxConcurrentStreams(%+v)", n))
+
+		o.RemoteOpt.GRPCCfg.MaxStreams = n
+	}}
+}
+
+// WithGRPCMaxHeaderListSize returns a ServerOption that sets the max (uncompressed) size
+// of header list that the server is prepared to accept.
+func WithGRPCMaxHeaderListSize(s uint32) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithGRPCMaxHeaderListSize(%+v)", s))
+
+		o.RemoteOpt.GRPCCfg.MaxHeaderListSize = &s
 	}}
 }


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):
en: Support to modify the gRPC settings through options, and adjust the default window size to 64KB for compatible with older versions
zh: gRPC 相关配置支持通过 options 来设置，并且为了兼容旧版本默认窗口大小调整为 64K
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
