### PR TITLE
feat(kerror): add new func WithCauseAndExtraMsg for basicError

### DIFF
--- a/pkg/kerrors/kerrors.go
+++ b/pkg/kerrors/kerrors.go
@@ -65,14 +65,19 @@ func (be *basicError) Error() string {
 	return be.message
 }
 
-// WithCause attach the given cause to current error and creates a detailed error.
+// WithCause creates a detailed error which attach the given cause to current error.
 func (be *basicError) WithCause(cause error) error {
 	return &DetailedError{basic: be, cause: cause}
 }
 
-// WithCauseAndStack attach the given cause and stack to current error.
+// WithCauseAndStack creates a detailed error which attach the given cause to current error and wrap stack.
 func (be *basicError) WithCauseAndStack(cause error, stack string) error {
 	return &DetailedError{basic: be, cause: cause, stack: stack}
+}
+
+// WithCauseAndStack creates a detailed error which attach the given cause to current error and wrap extra msg to supply error msg.
+func (be *basicError) WithCauseAndExtraMsg(cause error, extraMsg string) error {
+	return &DetailedError{basic: be, cause: cause, extraMsg: extraMsg}
 }
 
 // Timeout supports the os.IsTimeout checking.
@@ -132,8 +137,8 @@ func (de *DetailedError) Stack() string {
 }
 
 // WithExtraMsg to add extra msg to supply error msg
-func (de *DetailedError) WithExtraMsg(errMsg string) {
-	de.extraMsg = errMsg
+func (de *DetailedError) WithExtraMsg(extraMsg string) {
+	de.extraMsg = extraMsg
 }
 
 func appendErrMsg(errMsg, extra string) string {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### What this PR does / why we need it (English/Chinese):
en: feat: add new func WithCauseAndExtraMsg for basicError
zh: 为 basicError 添加新的 error 封装 func WithCauseAndExtraMsg

#### Which issue(s) this PR fixes:
none