### PR TITLE
refactor:delete additional atomic operations

### DIFF
--- a/pkg/event/queue.go
+++ b/pkg/event/queue.go
@@ -19,7 +19,6 @@ package event
 import (
 	"sync"
 	"sync/atomic"
-	"unsafe"
 )
 
 const (
@@ -66,8 +65,7 @@ func (q *queue) Push(e *Event) {
 		newV := oldV + 1
 		if atomic.CompareAndSwapUint32(&q.tail, old, new) && atomic.CompareAndSwapUint32(q.tailVersion[old], oldV, newV) {
 			q.mu.Lock()
-			p := (*unsafe.Pointer)(unsafe.Pointer(&q.ring[old]))
-			atomic.StorePointer(p, unsafe.Pointer(e))
+			q.ring[old] = e
 			q.mu.Unlock()
 			break
 		}


### PR DESCRIPTION
#### What type of PR is this?
refactor

#### What this PR does / why we need it (English/Chinese):
en: Delete additional atomic operations and replace it with a normal operation.
zh: 删除额外的原子操作并用普通赋值操作替换。

#### Which issue(s) this PR fixes:
Refactor #349

