### PR TITLE
fix:solving the problem of concurrent operation of Hooks

### DIFF
--- a/server/hooks.go
+++ b/server/hooks.go
@@ -16,13 +16,19 @@
 
 package server
 
+import "sync"
+
 // RegisterStartHook add hook which is executed after the server starts.
 func RegisterStartHook(h func()) {
+	muStartHooks.Lock()
+	defer muStartHooks.Unlock()
 	onServerStart.add(h)
 }
 
 // RegisterShutdownHook add hook which is executed after the server shutdown.
 func RegisterShutdownHook(h func()) {
+	muShutdownHooks.Lock()
+	defer muShutdownHooks.Unlock()
 	onShutdown.add(h)
 }
 
@@ -36,6 +42,8 @@ func (h *Hooks) add(g func()) {
 
 // Server hooks
 var (
-	onServerStart Hooks // Hooks executes after the server starts.
-	onShutdown    Hooks // Hooks executes when the server is shutdown gracefully.
+	onServerStart   Hooks      // Hooks executes after the server starts.
+	muStartHooks    sync.Mutex // onServerStart 's mutex
+	onShutdown      Hooks      // Hooks executes when the server is shutdown gracefully.
+	muShutdownHooks sync.Mutex // onShutdown 's mutex
 )

--- a/server/server.go
+++ b/server/server.go
@@ -188,9 +188,11 @@ func (s *server) Run() (err error) {
 	}
 
 	errCh := s.svr.Start()
+	muStartHooks.Lock()
 	for i := range onServerStart {
 		go onServerStart[i]()
 	}
+	muStartHooks.Unlock()
 	s.Lock()
 	s.buildRegistryInfo(s.svr.Address())
 	s.Unlock()
@@ -198,9 +200,11 @@ func (s *server) Run() (err error) {
 	if err = s.waitExit(errCh); err != nil {
 		klog.Errorf("KITEX: received error and exit: error=%s", err.Error())
 	}
+	muShutdownHooks.Lock()
 	for i := range onShutdown {
 		onShutdown[i]()
 	}
+	muShutdownHooks.Unlock()
 	// stop server after user hooks
 	if e := s.Stop(); e != nil && err == nil {
 		err = e


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (English/Chinese):
en: Adding locks to `onServerStart` and `onShutdown`, acquire the corresponding lock when do some read and write operations like `RegisterStartHook` and `range` in `server.Run`.
This is done to avoid concurrency problems with slice.
zh: 为 `onServerStart`和 `onShutdown`添加资源锁，当做一些如`RegisterStartHook`和 `server.Run`中的 `range`之类的读写操作时请求对应的资源锁。
这样做是为了避免slice的并发问题。
#### Which issue(s) this PR fixes:
Fixes #353 

