### PR TITLE
optimize(connpool): adjust minMaxIdleTimeout to 2s

### DIFF
--- a/pkg/connpool/config.go
+++ b/pkg/connpool/config.go
@@ -27,7 +27,7 @@ type IdleConfig struct {
 
 const (
 	defaultMaxIdleTimeout = 30 * time.Second
-	minMaxIdleTimeout     = 3 * time.Second
+	minMaxIdleTimeout     = 2 * time.Second
 )
 
 // CheckPoolConfig to check invalid param.


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: optimize(connpool): adjust minMaxIdleTimeout to 2s
zh: 优化(连接池)：修改默认的连接池最小空闲等待时间为 2s

#### Which issue(s) this PR fixes:
none
