### PR TITLE
optimize: lbcache is global, it doesn't need register ProbeFunc for diagnosis

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -155,6 +155,9 @@ func WithHostPorts(hostports ...string) Option {
 				}, nil
 			},
 			NameFunc: func() string { return o.Targets },
+			TargetFunc: func(ctx context.Context, target rpcinfo.EndpointInfo) string {
+				return o.Targets
+			},
 		}
 	}}
 }

--- a/pkg/diagnosis/interface.go
+++ b/pkg/diagnosis/interface.go
@@ -50,7 +50,6 @@ const (
 	DestServiceKey ProbeName = "dest_service"
 	ConnPoolKey    ProbeName = "conn_pool"
 	RetryPolicyKey ProbeName = "retry_policy"
-	LbCacheKey     ProbeName = "lb_cache"
 )
 
 // WrapAsProbeFunc is to wrap probe data as ProbeFunc, the data is some infos that you want to diagnosis, like config info.

--- a/pkg/loadbalance/lbcache/cache.go
+++ b/pkg/loadbalance/lbcache/cache.go
@@ -94,7 +94,6 @@ func cacheKey(resolver, balancer string, opts Options) string {
 // NewBalancerFactory get or create a balancer factory for balancer instance
 // cache key with resolver name, balancer name and options
 func NewBalancerFactory(resolver discovery.Resolver, balancer loadbalance.Loadbalancer, opts Options) *BalancerFactory {
-	diagnosis.RegisterProbeFunc(opts.DiagnosisService, diagnosis.LbCacheKey, Dump)
 	opts.check()
 	uniqueKey := cacheKey(resolver.Name(), balancer.Name(), opts)
 	val, ok := balancerFactories.Load(uniqueKey)


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: optimize: lbcache is global, it doesn't need to register ProbeFunc for every client to do diagnosis
zh: 优化：lbcaches是全局的，无需为每个client注册ProbeFunc用于诊断查询

#### Which issue(s) this PR fixes:
none
