### PR TITLE
fix(client): fix oneway seqid and lower loss rate

### DIFF
--- a/pkg/remote/codec/util.go
+++ b/pkg/remote/codec/util.go
@@ -63,7 +63,7 @@ func SetOrCheckMethodName(methodName string, message remote.Message) error {
 // SetOrCheckSeqID is used to check the sequence ID.
 func SetOrCheckSeqID(seqID int32, message remote.Message) error {
 	switch message.MessageType() {
-	case remote.Call:
+	case remote.Call, remote.Oneway:
 		if ink, ok := message.RPCInfo().Invocation().(rpcinfo.InvocationSetter); ok {
 			ink.SetSeqID(seqID)
 		} else {

--- a/pkg/remote/remotecli/client.go
+++ b/pkg/remote/remotecli/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/remote"
@@ -98,6 +99,10 @@ func (c *client) Recv(ctx context.Context, ri rpcinfo.RPCInfo, resp remote.Messa
 	if resp != nil {
 		err = c.transHdlr.Read(ctx, c.conn, resp)
 		c.transHdlr.OnMessage(ctx, nil, resp)
+	} else {
+		// Wait for the request to be flushed out before closing the connection.
+		// 500us is an acceptable duration to keep a minimal loss rate at best effort.
+		time.Sleep(time.Millisecond / 2)
 	}
 
 	c.connManager.ReleaseConn(err, ri)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: fix a bug that sequence ID of oneway requests are not encoded and lower the loss rate of oneway requests
zh: 修复 oneway 请求的 sequence ID 没有被编码的问题以及降低 oneway 调用的丢包率

