### PR TITLE
fix: combine services

### DIFF
--- a/pkg/generic/thrift/parse_test.go
+++ b/pkg/generic/thrift/parse_test.go
@@ -253,4 +253,20 @@ func TestExtends(t *testing.T) {
 	for _, fn := range []string{"simple", "int2bin", "req2res"} {
 		test.Assert(t, dp.Functions[fn] != nil)
 	}
+
+	dp, err = Parse(demo, FirstServiceOnly)
+	test.Assert(t, err == nil)
+	test.Assert(t, dp.Name == "DemoBaseService")
+	test.Assert(t, len(dp.Functions) == 2)
+	for _, fn := range []string{"simple", "int2bin"} {
+		test.Assert(t, dp.Functions[fn] != nil)
+	}
+
+	dp, err = Parse(demo, CombineServices)
+	test.Assert(t, err == nil)
+	test.Assert(t, dp.Name == "CombinedServices")
+	test.Assert(t, len(dp.Functions) == 3)
+	for _, fn := range []string{"simple", "int2bin", "req2res"} {
+		test.Assert(t, dp.Functions[fn] != nil)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
fix: combine services may have duplicate loading the same service
修复CombineServices可能存在多次加载同一个service问题，例如下面这个case，当加载`DemoService`会加载`DemoBaseService`和`base.BaseService`, 当再次加载`DemoBaseService`就会在后面的逻辑检验中出现重复定义function问题！本质上并没有重复定义func！
```thrift
namespace * demo

include "base.thrift"

struct Request {
    1: string str
    2: required string str2
    3: optional string str3
}

struct Response {
    1: string str
    2: required string str2
    3: optional string str3
}

exception Exception {
    1: string error
    2: required string error2
    3: optional string error3
}

service DemoBaseService extends base.BaseService {
    binary int2bin(1: i32 arg);
}

service DemoService extends DemoBaseService {
    Response req2res(1: Request req);
}
```

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
