### PR TITLE
optimize(rpcinfo): RPCInfo.To().Tag() use instance tag instead of remoteinfo tag firstly

### DIFF
--- a/pkg/rpcinfo/remoteinfo/remoteInfo.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo.go
@@ -111,10 +111,12 @@ func (ri *remoteInfo) Tag(key string) (value string, exist bool) {
 	ri.RLock()
 	defer ri.RUnlock()
 
-	value, exist = ri.tags[key]
-	if !exist && ri.instance != nil {
-		value, exist = ri.instance.Tag(key)
+	if ri.instance != nil {
+		if value, exist = ri.instance.Tag(key); exist {
+			return
+		}
 	}
+	value, exist = ri.tags[key]
 	return
 }
 


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: optimize(rpcinfo): RPCInfo.To().Tag() use instance tag instead of remoteinfo tag firstly
zh: 优化：RPCInfo.To().Tag() 优先使用服务发现的instance tag而不是remoteinfo tag

#### Which issue(s) this PR fixes:
none