### PR TITLE
Fix/detect circular thrift idl dependency

### DIFF
--- a/pkg/generic/thriftidl_provider_test.go
+++ b/pkg/generic/thriftidl_provider_test.go
@@ -17,7 +17,7 @@
 package generic
 
 import (
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
@@ -61,5 +61,29 @@ func TestThriftContentWithAbsIncludePathProvider(t *testing.T) {
 	p, err := NewThriftContentWithAbsIncludePathProvider(path, includes)
 	test.Assert(t, err == nil)
 	tree := <-p.Provide()
-	fmt.Printf("%#v\n", tree)
+	test.Assert(t, tree != nil)
+}
+
+func TestCircularDependency(t *testing.T) {
+	main := "a.thrift"
+	content := `
+	include "b.thrift"
+	include "c.thrift" 
+
+	service a {}
+	`
+	includes := map[string]string{
+		main: content,
+		"b.thrift": `
+		include "c.thrift"
+		include "d.thrift"
+		`,
+		"c.thrift": `
+		include "d.thrift"
+		`,
+		"d.thrift": `include "a.thrift"`,
+	}
+	p, err := NewThriftContentWithAbsIncludePathProvider(main, includes)
+	test.Assert(t, err != nil && p == nil)
+	test.Assert(t, strings.HasPrefix(err.Error(), "IDL circular dependency:"))
 }


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: detect circular dependency in thrift IDL when using generic call
zh: 在泛化调用的时候检查 IDL 是否有循环依赖

#### Which issue(s) this PR fixes:
