### PR TITLE
optimize(rpcinfo): fill `TransportProtocol`, `PackageName` fields into RPCInfo of server side after decoding 

### DIFF
--- a/internal/mocks/serviceinfo.go
+++ b/internal/mocks/serviceinfo.go
@@ -53,7 +53,9 @@ func newServiceInfo() *serviceinfo.ServiceInfo {
 	svcInfo := &serviceinfo.ServiceInfo{
 		ServiceName: MockServiceName,
 		Methods:     methods,
-		Extra:       make(map[string]interface{}),
+		Extra: map[string]interface{}{
+			"PackageName": "mock",
+		},
 	}
 	return svcInfo
 }

--- a/pkg/remote/codec/default_codec.go
+++ b/pkg/remote/codec/default_codec.go
@@ -317,6 +317,7 @@ func checkPayload(
 		return err
 	}
 	message.SetProtocolInfo(remote.NewProtocolInfo(transProto, codecType))
+	rpcinfo.AsMutableRPCConfig(message.RPCInfo().Config()).SetTransportProtocol(message.ProtocolInfo().TransProto)
 	return nil
 }
 

--- a/pkg/remote/codec/header_codec_test.go
+++ b/pkg/remote/codec/header_codec_test.go
@@ -175,7 +175,7 @@ func BenchmarkTTHeaderCodecParallel(b *testing.B) {
 func initRecvMsg() remote.Message {
 	var req interface{}
 	ink := rpcinfo.NewInvocation("", "mock")
-	ri := rpcinfo.NewRPCInfo(nil, nil, ink, nil, rpcinfo.NewRPCStats())
+	ri := rpcinfo.NewRPCInfo(nil, nil, ink, rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())
 	msg := remote.NewMessage(req, mocks.ServiceInfo(), ri, remote.Call, remote.Server)
 	return msg
 }

--- a/pkg/remote/codec/util.go
+++ b/pkg/remote/codec/util.go
@@ -45,12 +45,14 @@ func SetOrCheckMethodName(methodName string, message remote.Message) error {
 	if message.RPCRole() == remote.Client {
 		return fmt.Errorf("wrong method name, expect=%s, actual=%s", callMethodName, methodName)
 	}
+	svcInfo := message.ServiceInfo()
 	if ink, ok := ink.(rpcinfo.InvocationSetter); ok {
 		ink.SetMethodName(methodName)
+		ink.SetPackageName(svcInfo.GetPackageName())
+		ink.SetServiceName(svcInfo.ServiceName)
 	} else {
 		return errors.New("the interface Invocation doesn't implement InvocationSetter")
 	}
-	svcInfo := message.ServiceInfo()
 	if mt := svcInfo.MethodInfo(methodName); mt == nil {
 		return remote.NewTransErrorWithMsg(remote.UnknownMethod, fmt.Sprintf("unknown method %s", methodName))
 	}

--- a/pkg/remote/codec/util_test.go
+++ b/pkg/remote/codec/util_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"testing"
+
+	"github.com/cloudwego/kitex/internal/mocks"
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+)
+
+func TestSetOrCheckMethodName(t *testing.T) {
+	var req interface{}
+	ri := rpcinfo.NewRPCInfo(nil, rpcinfo.NewEndpointInfo("", "mock", nil, nil),
+		rpcinfo.NewServerInvocation(), rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())
+	msg := remote.NewMessage(req, mocks.ServiceInfo(), ri, remote.Call, remote.Server)
+	err := SetOrCheckMethodName("mock", msg)
+	test.Assert(t, err == nil)
+	ri = msg.RPCInfo()
+	test.Assert(t, ri.Invocation().ServiceName() == mocks.MockServiceName)
+	test.Assert(t, ri.Invocation().PackageName() == "mock")
+	test.Assert(t, ri.Invocation().MethodName() == "mock")
+	test.Assert(t, ri.To().Method() == "mock")
+}


### PR DESCRIPTION
#### What type of PR is this?

Optimize

#### What this PR does / why we need it (English/Chinese):

en: optimize(rpcinfo): fill TransportProtocol, PackageName fields into RPCInfo of server side after decoding

zh: 优化：填充由defaultCodec解码得到的rpcinfo中缺失的 Invocation().PackageName, Invocation().ServiceName and Config().TransportProtocol 字段

#### Which issue(s) this PR fixes:

https://github.com/cloudwego/kitex/issues/384
