### PR TITLE
test: add netpollmux unit test

### DIFF
--- a/pkg/remote/trans/netpollmux/client_handler_test.go
+++ b/pkg/remote/trans/netpollmux/client_handler_test.go
@@ -21,11 +21,13 @@ import (
 	"testing"
 	"time"
 
+	np "github.com/cloudwego/kitex/pkg/remote/trans/netpoll"
 	"github.com/cloudwego/netpoll"
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/codec"
+	"github.com/cloudwego/kitex/pkg/remote/trans"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
@@ -107,4 +109,214 @@ func TestCliTransHandler(t *testing.T) {
 
 	err = handler.Read(ctx, conn, msg)
 	test.Assert(t, err == nil, err)
+}
+
+// TestWriteNoMethod test client_handler write return unknown method err
+func TestWriteNoMethod(t *testing.T) {
+	// 1. prepare mock data
+	s := "hello world"
+	opt := &remote.ClientOption{
+		Codec: &MockCodec{
+			EncodeFunc: func(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
+				r := mockHeader(msg.RPCInfo().Invocation().SeqID(), s)
+				n, err := out.WriteBinary(r.Bytes())
+				test.Assert(t, err == nil, err)
+				test.Assert(t, n == r.Len(), n, r.Len())
+				return err
+			},
+			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+				l := in.ReadableLen()
+				test.Assert(t, l == 3*codec.Size32+len(s))
+				in.Skip(3 * codec.Size32)
+				got, err := in.ReadString(len(s))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, got == s, got, s)
+				return err
+			},
+		},
+		ConnPool: NewMuxConnPool(1),
+	}
+
+	handler, err := NewCliTransHandlerFactory().NewTransHandler(opt)
+	test.Assert(t, err == nil)
+
+	ctx := context.Background()
+
+	var isWriteBufFlushed bool
+
+	buf := netpoll.NewLinkBuffer(1024)
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWriteBufFlushed = true
+			return buf
+		},
+	}
+	conn := newMuxCliConn(npconn)
+
+	ri := newMockRPCInfo()
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return ri
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{}
+		},
+	}
+
+	// 2. test
+	err = handler.Write(ctx, conn, msg)
+	// check err not nil
+	test.Assert(t, err != nil, err)
+	test.Assert(t, !isWriteBufFlushed)
+}
+
+// TestWriteOneWayMethod test client_handler write oneway method
+func TestWriteOneWayMethod(t *testing.T) {
+	// 1. prepare mock data
+	s := "hello world"
+	opt := &remote.ClientOption{
+		Codec: &MockCodec{
+			EncodeFunc: func(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
+				r := mockHeader(msg.RPCInfo().Invocation().SeqID(), s)
+				n, err := out.WriteBinary(r.Bytes())
+				test.Assert(t, err == nil, err)
+				test.Assert(t, n == r.Len(), n, r.Len())
+				return err
+			},
+			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+				l := in.ReadableLen()
+				test.Assert(t, l == 3*codec.Size32+len(s))
+				in.Skip(3 * codec.Size32)
+				got, err := in.ReadString(len(s))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, got == s, got, s)
+				return err
+			},
+		},
+		ConnPool: NewMuxConnPool(1),
+	}
+
+	handler, err := NewCliTransHandlerFactory().NewTransHandler(opt)
+	test.Assert(t, err == nil)
+
+	ctx := context.Background()
+	ri := newMockRPCInfo()
+
+	buf := netpoll.NewLinkBuffer(1024)
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			return buf
+		},
+	}
+	conn := newMuxCliConn(npconn)
+
+	oneWayMsg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return ri
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, true),
+				},
+			}
+		},
+	}
+	err = handler.Write(ctx, conn, oneWayMsg)
+	test.Assert(t, err == nil, err)
+}
+
+// TestReadTimeout test client_handler read timeout because of no execute OnRequest
+func TestReadTimeout(t *testing.T) {
+	s := "hello world"
+	opt := &remote.ClientOption{
+		Codec: &MockCodec{
+			EncodeFunc: func(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
+				r := mockHeader(msg.RPCInfo().Invocation().SeqID(), s)
+				n, err := out.WriteBinary(r.Bytes())
+				test.Assert(t, err == nil, err)
+				test.Assert(t, n == r.Len(), n, r.Len())
+				return err
+			},
+			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+				l := in.ReadableLen()
+				test.Assert(t, l == 3*codec.Size32+len(s))
+				in.Skip(3 * codec.Size32)
+				got, err := in.ReadString(len(s))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, got == s, got, s)
+				return err
+			},
+		},
+		ConnPool: NewMuxConnPool(1),
+	}
+
+	handler, err := NewCliTransHandlerFactory().NewTransHandler(opt)
+
+	ctx := context.Background()
+	buf := netpoll.NewLinkBuffer(1024)
+
+	var isRead, isWrite bool
+
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			isRead = true
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWrite = true
+			return buf
+		},
+	}
+	conn := newMuxCliConn(npconn)
+
+	cfg := rpcinfo.NewRPCConfig()
+	rwTimeout := 1 * time.Second
+	rpcinfo.AsMutableRPCConfig(cfg).SetRPCTimeout(rwTimeout)
+
+	method := "method"
+	c := rpcinfo.NewEndpointInfo("", method, nil, nil)
+	to := rpcinfo.NewEndpointInfo("", method, nil, nil)
+	ri := rpcinfo.NewRPCInfo(c, to, rpcinfo.NewInvocation("", method), cfg, rpcinfo.NewRPCStats())
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return ri
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+
+	err = handler.Write(ctx, conn, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+	test.Assert(t, buf.Len() > len(s), buf.Len())
+	test.Assert(t, isWrite)
+
+	err = handler.Read(ctx, conn, msg)
+	test.Assert(t, rwTimeout <= trans.GetReadTimeout(ri.Config()))
+	test.Assert(t, err != nil, err)
+	test.Assert(t, !isRead)
+
+	handler.OnError(ctx, err, conn)
+}
+
+// TestCallbackClose test asyncCallback Close
+func TestCallbackClose(t *testing.T) {
+	buf := netpoll.NewLinkBuffer()
+	bufWriter := np.NewWriterByteBuffer(buf)
+	callback := newAsyncCallback(buf, bufWriter)
+	callback.Close()
 }

--- a/pkg/remote/trans/netpollmux/client_handler_test.go
+++ b/pkg/remote/trans/netpollmux/client_handler_test.go
@@ -258,6 +258,7 @@ func TestReadTimeout(t *testing.T) {
 	}
 
 	handler, err := NewCliTransHandlerFactory().NewTransHandler(opt)
+	test.Assert(t, err == nil, err)
 
 	ctx := context.Background()
 	buf := netpoll.NewLinkBuffer(1024)

--- a/pkg/remote/trans/netpollmux/mux_con_test.go
+++ b/pkg/remote/trans/netpollmux/mux_con_test.go
@@ -1,0 +1,105 @@
+package netpollmux
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/codec"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	"github.com/cloudwego/netpoll"
+)
+
+// TestNewMuxSvrConn test new a muxSvrConn
+func TestNewMuxSvrConn(t *testing.T) {
+	pool := &sync.Pool{}
+	npconn := &MockNetpollConn{}
+	muxSvrCon := newMuxSvrConn(npconn, pool)
+	test.Assert(t, muxSvrCon != nil)
+}
+
+// TestOnRequest test muxSvrConn OnRequest return Err
+func TestOnRequestErr(t *testing.T) {
+	ctx := context.Background()
+
+	var isRead bool
+
+	buf := netpoll.NewLinkBuffer(3)
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			isRead = true
+			return buf
+		},
+	}
+	conn := newMuxCliConn(npconn)
+	err := conn.OnRequest(ctx, conn)
+	test.Assert(t, err != nil, err)
+	test.Assert(t, isRead)
+}
+
+// TestOnRequestErr test muxSvrConn OnRequest success
+func TestOnRequest(t *testing.T) {
+	s := "hello world"
+	ctx := context.Background()
+
+	opt := &remote.ClientOption{
+		Codec: &MockCodec{
+			EncodeFunc: func(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
+				r := mockHeader(msg.RPCInfo().Invocation().SeqID(), s)
+				n, err := out.WriteBinary(r.Bytes())
+				test.Assert(t, err == nil, err)
+				test.Assert(t, n == r.Len(), n, r.Len())
+				return err
+			},
+			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+				l := in.ReadableLen()
+				test.Assert(t, l == 3*codec.Size32+len(s))
+				in.Skip(3 * codec.Size32)
+				got, err := in.ReadString(len(s))
+				test.Assert(t, err == nil, err)
+				test.Assert(t, got == s, got, s)
+				return err
+			},
+		},
+		ConnPool: NewMuxConnPool(1),
+	}
+
+	buf := netpoll.NewLinkBuffer(1024)
+	conn := newMuxCliConn(&MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			return buf
+		},
+	})
+
+	handler, err := NewCliTransHandlerFactory().NewTransHandler(opt)
+	test.Assert(t, err == nil)
+
+	ri := newMockRPCInfo()
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return ri
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+	err = handler.Write(ctx, conn, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+
+	err = conn.OnRequest(ctx, conn)
+	test.Assert(t, err == nil, err)
+}

--- a/pkg/remote/trans/netpollmux/mux_conn_test.go
+++ b/pkg/remote/trans/netpollmux/mux_conn_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package netpollmux
 
 import (

--- a/pkg/remote/trans/netpollmux/mux_conn_test.go
+++ b/pkg/remote/trans/netpollmux/mux_conn_test.go
@@ -18,7 +18,6 @@ package netpollmux
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,14 +28,6 @@ import (
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/netpoll"
 )
-
-// TestNewMuxSvrConn test new a muxSvrConn
-func TestNewMuxSvrConn(t *testing.T) {
-	pool := &sync.Pool{}
-	npconn := &MockNetpollConn{}
-	muxSvrCon := newMuxSvrConn(npconn, pool)
-	test.Assert(t, muxSvrCon != nil)
-}
 
 // TestOnRequest test muxSvrConn OnRequest return Err
 func TestOnRequestErr(t *testing.T) {

--- a/pkg/remote/trans/netpollmux/mux_transport_test.go
+++ b/pkg/remote/trans/netpollmux/mux_transport_test.go
@@ -39,6 +39,34 @@ func TestParseHeader(t *testing.T) {
 	test.Assert(t, l == rl, l, rl)
 }
 
+// TestParseHeaderErr test parseHeader return err
+func TestParseHeaderErr(t *testing.T) {
+	s := "hello world"
+
+	reader := netpoll.NewLinkBuffer()
+	buf, _ := reader.Malloc(1 * codec.Size32)
+	// length
+	binary.BigEndian.PutUint32(buf[:codec.Size32], uint32(0))
+
+	reader.WriteString(s)
+	reader.Flush()
+
+	_, _, err := parseHeader(reader)
+	test.Assert(t, err != nil, err)
+
+	reader = netpoll.NewLinkBuffer()
+	buf, _ = reader.Malloc(1 * codec.Size32)
+	// length
+	binary.BigEndian.PutUint32(buf[:codec.Size32], uint32(1))
+	// TTHeader
+	binary.BigEndian.PutUint32(buf[:codec.Size32], uint32(1))
+
+	reader.WriteString(s)
+	reader.Flush()
+	_, _, err = parseHeader(reader)
+	test.Assert(t, err != nil, err)
+}
+
 // 0-4Byte length, 4-8Byte version check, 8-12Byte seqID
 func mockHeader(seqID int32, body string) *netpoll.LinkBuffer {
 	reader := netpoll.NewLinkBuffer()

--- a/pkg/remote/trans/netpollmux/server_handler_test.go
+++ b/pkg/remote/trans/netpollmux/server_handler_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package netpollmux
 
 import (

--- a/pkg/remote/trans/netpollmux/server_handler_test.go
+++ b/pkg/remote/trans/netpollmux/server_handler_test.go
@@ -1,0 +1,548 @@
+package netpollmux
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/internal/mocks"
+	internal_stats "github.com/cloudwego/kitex/internal/stats"
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/codec"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	"github.com/cloudwego/kitex/pkg/utils"
+	"github.com/cloudwego/netpoll"
+)
+
+var (
+	svrTransHdlr remote.ServerTransHandler
+	opt          *remote.ServerOption
+	rwTimeout    = time.Second
+	addrStr      = "test addr"
+	addr         = utils.NewNetAddr("tcp", addrStr)
+	method       = "mock"
+	rpcInfo      rpcinfo.RPCInfo
+)
+
+func init() {
+	fromInfo := rpcinfo.EmptyEndpointInfo()
+	rpcCfg := rpcinfo.NewRPCConfig()
+	mCfg := rpcinfo.AsMutableRPCConfig(rpcCfg)
+	mCfg.SetReadWriteTimeout(rwTimeout)
+	ink := rpcinfo.NewInvocation("", method)
+	rpcStat := rpcinfo.NewRPCStats()
+
+	body := "hello world"
+
+	rpcInfo = rpcinfo.NewRPCInfo(fromInfo, nil, ink, rpcCfg, rpcStat)
+	rpcinfo.AsMutableEndpointInfo(rpcInfo.From()).SetAddress(addr)
+
+	opt = &remote.ServerOption{
+		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+			return rpcInfo, ctx
+		},
+		Codec: &MockCodec{
+			EncodeFunc: func(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
+				r := mockHeader(msg.RPCInfo().Invocation().SeqID(), body)
+				_, err := out.WriteBinary(r.Bytes())
+				return err
+			},
+			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+				in.Skip(3 * codec.Size32)
+				_, err := in.ReadString(len(body))
+				return err
+			},
+		},
+		SvcInfo:          mocks.ServiceInfo(),
+		TracerCtl:        &internal_stats.Controller{},
+		ReadWriteTimeout: rwTimeout,
+	}
+
+	svrTransHdlr, _ = NewSvrTransHandlerFactory().NewTransHandler(opt)
+}
+
+// TestNewTransHandler test new a ServerTransHandler
+func TestNewTransHandler(t *testing.T) {
+	handler, err := NewSvrTransHandlerFactory().NewTransHandler(&remote.ServerOption{})
+	test.Assert(t, err == nil, err)
+	test.Assert(t, handler != nil)
+}
+
+// TestOnActive test ServerTransHandler OnActive
+func TestOnActive(t *testing.T) {
+	// 1. prepare mock data
+	var readTimeout time.Duration
+	conn := &MockNetpollConn{
+		SetReadTimeoutFunc: func(timeout time.Duration) (e error) {
+			readTimeout = timeout
+			return nil
+		},
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+		},
+	}
+
+	// 2. test
+	ctx := context.Background()
+	ctx, err := svrTransHdlr.OnActive(ctx, conn)
+	test.Assert(t, err == nil, err)
+	muxSvrCon, _ := ctx.Value(ctxKeyMuxSvrConn{}).(*muxSvrConn)
+	test.Assert(t, muxSvrCon != nil)
+	test.Assert(t, readTimeout == rwTimeout, readTimeout, rwTimeout)
+}
+
+// TestMuxSvrWrite test ServerTransHandler Write
+func TestMuxSvrWrite(t *testing.T) {
+	// 1. prepare mock data
+	npconn := &MockNetpollConn{
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+		},
+	}
+	pool := &sync.Pool{}
+	muxSvrCon := newMuxSvrConn(npconn, pool)
+	test.Assert(t, muxSvrCon != nil)
+
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return rpcInfo
+		},
+	}
+
+	// 2. test
+	ri := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, ri != nil, ri)
+
+	err := svrTransHdlr.Write(ctx, muxSvrCon, msg)
+	test.Assert(t, err == nil, err)
+}
+
+// TestMuxSvrOnRead test ServerTransHandler OnRead
+func TestMuxSvrOnRead(t *testing.T) {
+	var isWriteBufFlushed bool
+	var isReaderBufReleased bool
+	var isInvoked bool
+
+	buf := netpoll.NewLinkBuffer(1024)
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			isReaderBufReleased = true
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWriteBufFlushed = true
+			return buf
+		},
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return rpcInfo
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+
+	pool := &sync.Pool{}
+	muxSvrCon := newMuxSvrConn(npconn, pool)
+
+	var err error
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, ri != nil, ri)
+
+	err = svrTransHdlr.Write(ctx, muxSvrCon, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+	test.Assert(t, npconn.Reader().Len() > 0, npconn.Reader().Len())
+
+	ctx, err = svrTransHdlr.OnActive(ctx, muxSvrCon)
+	test.Assert(t, err == nil, err)
+	muxSvrConFromCtx, _ := ctx.Value(ctxKeyMuxSvrConn{}).(*muxSvrConn)
+	test.Assert(t, muxSvrConFromCtx != nil)
+
+	pl := remote.NewTransPipeline(svrTransHdlr)
+	svrTransHdlr.SetPipeline(pl)
+
+	if setter, ok := svrTransHdlr.(remote.InvokeHandleFuncSetter); ok {
+		setter.SetInvokeHandleFunc(func(ctx context.Context, req, resp interface{}) (err error) {
+			isInvoked = true
+			return nil
+		})
+	}
+
+	err = svrTransHdlr.OnRead(ctx, npconn)
+	test.Assert(t, err == nil, err)
+	time.Sleep(500 * time.Millisecond)
+
+	test.Assert(t, isReaderBufReleased)
+	test.Assert(t, isWriteBufFlushed)
+	test.Assert(t, isInvoked)
+}
+
+// TestPanicAfterMuxSvrOnRead test have panic after read
+func TestPanicAfterMuxSvrOnRead(t *testing.T) {
+	// 1. prepare mock data
+	var isWriteBufFlushed bool
+	var isReaderBufReleased bool
+
+	buf := netpoll.NewLinkBuffer(1024)
+	conn := &MockNetpollConn{
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+			CloseFunc: func() (e error) {
+				return nil
+			},
+		},
+		ReaderFunc: func() (r netpoll.Reader) {
+			isReaderBufReleased = true
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWriteBufFlushed = true
+			return buf
+		},
+		IsActiveFunc: func() (r bool) {
+			return true
+		},
+	}
+
+	// pipeline nil panic
+	svrTransHdlr.SetPipeline(nil)
+
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return rpcInfo
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+
+	pool := &sync.Pool{}
+	muxSvrCon := newMuxSvrConn(conn, pool)
+
+	// 2. test
+	var err error
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, ri != nil, ri)
+
+	err = svrTransHdlr.Write(ctx, muxSvrCon, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+	test.Assert(t, conn.Reader().Len() > 0, conn.Reader().Len())
+
+	ctx, err = svrTransHdlr.OnActive(ctx, conn)
+	test.Assert(t, err == nil, err)
+
+	err = svrTransHdlr.OnRead(ctx, conn)
+	time.Sleep(1 * time.Second)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, isReaderBufReleased)
+	test.Assert(t, isWriteBufFlushed)
+}
+
+// TestRecoverAfterOnReadPanic test tryRecover after read panic
+func TestRecoverAfterOnReadPanic(t *testing.T) {
+	var isWriteBufFlushed bool
+	var isReaderBufReleased bool
+	var isClosed bool
+	buf := netpoll.NewLinkBuffer(1024)
+
+	conn := &MockNetpollConn{
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+			CloseFunc: func() (e error) {
+				isClosed = true
+				return nil
+			},
+		},
+		ReaderFunc: func() (r netpoll.Reader) {
+			isReaderBufReleased = true
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWriteBufFlushed = true
+			return buf
+		},
+		IsActiveFunc: func() (r bool) {
+			return true
+		},
+	}
+
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return rpcInfo
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+
+	pool := &sync.Pool{}
+	muxSvrCon := newMuxSvrConn(conn, pool)
+
+	var err error
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, ri != nil, ri)
+
+	err = svrTransHdlr.Write(ctx, muxSvrCon, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+	test.Assert(t, conn.Reader().Len() > 0, conn.Reader().Len())
+
+	ctx, err = svrTransHdlr.OnActive(ctx, conn)
+	test.Assert(t, err == nil, err)
+
+	// test recover after panic
+	err = svrTransHdlr.OnRead(ctx, nil)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, isReaderBufReleased)
+	test.Assert(t, isWriteBufFlushed)
+	test.Assert(t, !isClosed)
+
+	// test recover after panic
+	err = svrTransHdlr.OnRead(ctx, &MockNetpollConn{})
+	test.Assert(t, err == nil, err)
+	test.Assert(t, isReaderBufReleased)
+	test.Assert(t, isWriteBufFlushed)
+	test.Assert(t, !isClosed)
+}
+
+// TestOnError test Invoke has err
+func TestInvokeError(t *testing.T) {
+	var isWriteBufFlushed bool
+	var isReaderBufReleased bool
+	var isInvoked bool
+
+	buf := netpoll.NewLinkBuffer(1024)
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			isReaderBufReleased = true
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWriteBufFlushed = true
+			return buf
+		},
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+			CloseFunc: func() (e error) {
+				return nil
+			},
+		},
+	}
+
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return rpcInfo
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+
+	pool := &sync.Pool{}
+	muxSvrCon := newMuxSvrConn(npconn, pool)
+
+	var err error
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, ri != nil, ri)
+
+	err = svrTransHdlr.Write(ctx, muxSvrCon, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+	test.Assert(t, npconn.Reader().Len() > 0, npconn.Reader().Len())
+
+	ctx, err = svrTransHdlr.OnActive(ctx, muxSvrCon)
+	test.Assert(t, err == nil, err)
+	muxSvrCon, _ = ctx.Value(ctxKeyMuxSvrConn{}).(*muxSvrConn)
+	test.Assert(t, muxSvrCon != nil)
+
+	pl := remote.NewTransPipeline(svrTransHdlr)
+	svrTransHdlr.SetPipeline(pl)
+
+	if setter, ok := svrTransHdlr.(remote.InvokeHandleFuncSetter); ok {
+		setter.SetInvokeHandleFunc(func(ctx context.Context, req, resp interface{}) (err error) {
+			isInvoked = true
+			return errors.New("mock invoke err test")
+		})
+	}
+
+	err = svrTransHdlr.OnRead(ctx, npconn)
+	time.Sleep(1 * time.Second)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, isReaderBufReleased)
+	test.Assert(t, isWriteBufFlushed)
+	test.Assert(t, isInvoked)
+}
+
+// TestOnError test OnError method
+func TestOnError(t *testing.T) {
+	// 1. prepare mock data
+	buf := netpoll.NewLinkBuffer(1)
+	conn := &MockNetpollConn{
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+			CloseFunc: func() (e error) {
+				return nil
+			},
+		},
+		ReaderFunc: func() (r netpoll.Reader) {
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			return buf
+		},
+	}
+
+	// 2. test
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+	svrTransHdlr.OnError(ctx, errors.New("a"), conn)
+	svrTransHdlr.OnError(ctx, netpoll.ErrConnClosed, conn)
+}
+
+// TestInvokeNoMethod test invoke no method
+func TestInvokeNoMethod(t *testing.T) {
+	var isWriteBufFlushed bool
+	var isReaderBufReleased bool
+	var isInvoked bool
+
+	buf := netpoll.NewLinkBuffer(1024)
+	npconn := &MockNetpollConn{
+		ReaderFunc: func() (r netpoll.Reader) {
+			isReaderBufReleased = true
+			return buf
+		},
+		WriterFunc: func() (r netpoll.Writer) {
+			isWriteBufFlushed = true
+			return buf
+		},
+		Conn: mocks.Conn{
+			RemoteAddrFunc: func() (r net.Addr) {
+				return addr
+			},
+			CloseFunc: func() (e error) {
+				return nil
+			},
+		},
+	}
+
+	msg := &MockMessage{
+		RPCInfoFunc: func() rpcinfo.RPCInfo {
+			return rpcInfo
+		},
+		ServiceInfoFunc: func() *serviceinfo.ServiceInfo {
+			return &serviceinfo.ServiceInfo{
+				Methods: map[string]serviceinfo.MethodInfo{
+					"method": serviceinfo.NewMethodInfo(nil, nil, nil, false),
+				},
+			}
+		},
+	}
+
+	pool := &sync.Pool{}
+	muxSvrCon := newMuxSvrConn(npconn, pool)
+
+	var err error
+	ctx := context.Background()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, ri != nil, ri)
+
+	err = svrTransHdlr.Write(ctx, muxSvrCon, msg)
+	test.Assert(t, err == nil, err)
+
+	time.Sleep(5 * time.Millisecond)
+	buf.Flush()
+	test.Assert(t, npconn.Reader().Len() > 0, npconn.Reader().Len())
+
+	ctx, err = svrTransHdlr.OnActive(ctx, muxSvrCon)
+	test.Assert(t, err == nil, err)
+	muxSvrCon, _ = ctx.Value(ctxKeyMuxSvrConn{}).(*muxSvrConn)
+	test.Assert(t, muxSvrCon != nil)
+
+	pl := remote.NewTransPipeline(svrTransHdlr)
+	svrTransHdlr.SetPipeline(pl)
+
+	delete(opt.SvcInfo.Methods, method)
+
+	if setter, ok := svrTransHdlr.(remote.InvokeHandleFuncSetter); ok {
+		setter.SetInvokeHandleFunc(func(ctx context.Context, req, resp interface{}) (err error) {
+			isInvoked = true
+			return nil
+		})
+	}
+
+	err = svrTransHdlr.OnRead(ctx, npconn)
+	time.Sleep(1 * time.Second)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, isReaderBufReleased)
+	test.Assert(t, isWriteBufFlushed)
+	test.Assert(t, !isInvoked)
+}

--- a/pkg/remote/trans/netpollmux/server_handler_test.go
+++ b/pkg/remote/trans/netpollmux/server_handler_test.go
@@ -217,7 +217,7 @@ func TestMuxSvrOnRead(t *testing.T) {
 
 	err = svrTransHdlr.OnRead(ctx, npconn)
 	test.Assert(t, err == nil, err)
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(5 * time.Second)
 
 	test.Assert(t, isReaderBufReleased)
 	test.Assert(t, isWriteBufFlushed)
@@ -291,7 +291,7 @@ func TestPanicAfterMuxSvrOnRead(t *testing.T) {
 	test.Assert(t, err == nil, err)
 
 	err = svrTransHdlr.OnRead(ctx, conn)
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 	test.Assert(t, err == nil, err)
 	test.Assert(t, isReaderBufReleased)
 	test.Assert(t, isWriteBufFlushed)
@@ -447,7 +447,7 @@ func TestInvokeError(t *testing.T) {
 	}
 
 	err = svrTransHdlr.OnRead(ctx, npconn)
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 	test.Assert(t, err == nil, err)
 	test.Assert(t, isReaderBufReleased)
 	test.Assert(t, isWriteBufFlushed)
@@ -556,7 +556,7 @@ func TestInvokeNoMethod(t *testing.T) {
 	}
 
 	err = svrTransHdlr.OnRead(ctx, npconn)
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 	test.Assert(t, err == nil, err)
 	test.Assert(t, isReaderBufReleased)
 	test.Assert(t, isWriteBufFlushed)


### PR DESCRIPTION
Change-Id: I76d10781a20b443d97d6ba561e7de5547020bcbd

#### What type of PR is this?
test

#### What this PR does / why we need it (English/Chinese):
en: add unit test for kitex/pkg/remote/trans/netpollmux
zh：增加kitex/pkg/remote/trans/netpollmux包的单测

#### Which issue(s) this PR fixes:
[372](https://github.com/cloudwego/kitex/issues/372)
