### PR TITLE
chore: add a separate file to declare the use of gRPC source code

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/doc.go
+++ b/pkg/remote/trans/nphttp2/grpc/doc.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The files in grpc package are forked from gRPC[github.com/grpc/grpc-go],
+// and we keep the original Copyright[Copyright 2017 gRPC authors] and License of gRPC for those files.
+// We also need to modify as we need, the modifications are Copyright of 2021 CloudWeGo Authors.
+// Thanks for gRPC authors! Below is the source code information:
+// 		Repo: github.com/grpc/grpc-go
+//		Forked Version: v1.26.0
+package grpc


### PR DESCRIPTION
#### What type of PR is this?
chore

#### What this PR does / why we need it (English/Chinese):
en: chore: add a separate file to declare the use of gRPC source code
zh: chore: 单独增加文件对 grpc 源码使用做声明

#### Which issue(s) this PR fixes:
none