### PR TITLE
test: add unit test for pkg/transmeta

### DIFF
--- a/pkg/transmeta/http2.go
+++ b/pkg/transmeta/http2.go
@@ -34,6 +34,11 @@ var ClientHTTP2Handler = &clientHTTP2Handler{}
 
 type clientHTTP2Handler struct{}
 
+var (
+	_ remote.MetaHandler          = ClientHTTP2Handler
+	_ remote.StreamingMetaHandler = ClientHTTP2Handler
+)
+
 func (*clientHTTP2Handler) OnConnectStream(ctx context.Context) (context.Context, error) {
 	ri := rpcinfo.GetRPCInfo(ctx)
 	if !isGRPC(ri) {

--- a/pkg/transmeta/http2_test.go
+++ b/pkg/transmeta/http2_test.go
@@ -18,8 +18,12 @@
 package transmeta
 
 import (
+	"context"
 	"testing"
 
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+	"github.com/cloudwego/kitex/pkg/remote/transmeta"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 
 	"github.com/cloudwego/kitex/transport"
@@ -91,4 +95,73 @@ func TestIsGRPC(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTP2ClientOnConnectStream(t *testing.T) {
+	cfg := rpcinfo.NewRPCConfig()
+	fromInfo := rpcinfo.NewEndpointInfo("fromServiceName", "fromMethod", nil, nil)
+	toInfo := rpcinfo.NewEndpointInfo("toServiceName", "toMethod", nil, nil)
+	ri := rpcinfo.NewRPCInfo(fromInfo, toInfo, rpcinfo.NewInvocation("", ""), cfg, rpcinfo.NewRPCStats())
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+
+	// not grpc
+	ctx, err := ClientHTTP2Handler.OnConnectStream(ctx)
+	test.Assert(t, err == nil)
+	md, exist := metadata.FromOutgoingContext(ctx)
+	test.Assert(t, !exist)
+	test.Assert(t, len(md) == 0)
+
+	// grpc
+	rpcinfo.AsMutableRPCConfig(cfg).SetTransportProtocol(transport.GRPC)
+	ctx, err = ClientHTTP2Handler.OnConnectStream(ctx)
+	test.Assert(t, err == nil)
+
+	md, exist = metadata.FromOutgoingContext(ctx)
+	test.Assert(t, exist)
+	test.Assert(t, md.Get(transmeta.HTTPSourceService)[0] == fromInfo.ServiceName())
+	test.Assert(t, md.Get(transmeta.HTTPSourceMethod)[0] == fromInfo.Method())
+	test.Assert(t, md.Get(transmeta.HTTPDestService)[0] == toInfo.ServiceName())
+	test.Assert(t, md.Get(transmeta.HTTPDestMethod)[0] == toInfo.Method())
+}
+
+func TestHTTP2ServerOnReadStream(t *testing.T) {
+	cfg := rpcinfo.NewRPCConfig()
+	ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), rpcinfo.EmptyEndpointInfo(), rpcinfo.NewInvocation("", ""), cfg, rpcinfo.NewRPCStats())
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+
+	var (
+		toServiceName   = "toServiceName"
+		toMethod        = "toMethod"
+		fromServiceName = "fromServiceName"
+		fromMethod      = "fromMethod"
+	)
+
+	// set incoming metadata
+	md := metadata.MD{}
+	md.Append(transmeta.HTTPDestService, toServiceName)
+	md.Append(transmeta.HTTPDestMethod, toMethod)
+	md.Append(transmeta.HTTPSourceService, fromServiceName)
+	md.Append(transmeta.HTTPSourceMethod, fromMethod)
+
+	// not grpc
+	ctx, err := ServerHTTP2Handler.OnReadStream(ctx)
+	test.Assert(t, err == nil)
+	test.Assert(t, rpcinfo.GetRPCInfo(ctx).From().ServiceName() == "")
+	test.Assert(t, rpcinfo.GetRPCInfo(ctx).From().Method() == "")
+
+	// grpc, no incoming context
+	rpcinfo.AsMutableRPCConfig(cfg).SetTransportProtocol(transport.GRPC)
+	ctx, err = ServerHTTP2Handler.OnReadStream(ctx)
+	test.Assert(t, err == nil)
+	test.Assert(t, rpcinfo.GetRPCInfo(ctx).From().ServiceName() == "")
+	test.Assert(t, rpcinfo.GetRPCInfo(ctx).From().Method() == "")
+
+	// grpc with incoming context
+	ctx = metadata.NewIncomingContext(ctx, md)
+	ctx, err = ServerHTTP2Handler.OnReadStream(ctx)
+	test.Assert(t, err == nil)
+
+	newRPCInfo := rpcinfo.GetRPCInfo(ctx)
+	test.Assert(t, newRPCInfo.From().ServiceName() == fromServiceName)
+	test.Assert(t, newRPCInfo.From().Method() == fromMethod)
 }

--- a/pkg/transmeta/metainfo.go
+++ b/pkg/transmeta/metainfo.go
@@ -26,8 +26,8 @@ import (
 
 // singletons .
 var (
-	MetainfoClientHandler = new(metainfoClientHandler)
-	MetainfoServerHandler = new(metainfoServerHandler)
+	MetainfoClientHandler remote.MetaHandler = new(metainfoClientHandler)
+	MetainfoServerHandler remote.MetaHandler = new(metainfoServerHandler)
 )
 
 type metainfoClientHandler struct{}

--- a/pkg/transmeta/metainfo_test.go
+++ b/pkg/transmeta/metainfo_test.go
@@ -42,14 +42,14 @@ func TestClientReadMetainfo(t *testing.T) {
 	ctx, err = MetainfoClientHandler.ReadMeta(ctx, msg)
 	test.Assert(t, err == nil)
 
-	kvs := metainfo.GetAllBackwardValues(ctx)
+	kvs := metainfo.RecvAllBackwardValues(ctx)
 	test.Assert(t, len(kvs) == 0)
 
 	ctx = metainfo.WithBackwardValues(context.Background())
 	ctx, err = MetainfoClientHandler.ReadMeta(ctx, msg)
 	test.Assert(t, err == nil)
 
-	kvs = metainfo.GetAllBackwardValues(ctx)
+	kvs = metainfo.RecvAllBackwardValues(ctx)
 	test.Assert(t, len(kvs) == 1)
 	test.Assert(t, kvs["hello"] == "world")
 }

--- a/pkg/transmeta/ttheader_test.go
+++ b/pkg/transmeta/ttheader_test.go
@@ -17,11 +17,14 @@
 package transmeta
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/mocks"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/transmeta"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/transport"
@@ -40,4 +43,76 @@ func TestIsTTHeader(t *testing.T) {
 		msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeaderFramed, serviceinfo.Thrift))
 		test.Assert(t, isTTHeader(msg))
 	})
+}
+
+func TestTTHeaderClientWriteMetainfo(t *testing.T) {
+	ctx := context.Background()
+
+	fromInfo := rpcinfo.NewEndpointInfo("fromServiceName", "fromMethod", nil, nil)
+	toInfo := rpcinfo.NewEndpointInfo("toServiceName", "toMethod", nil, nil)
+	ri := rpcinfo.NewRPCInfo(fromInfo, toInfo, rpcinfo.NewInvocation("", ""), nil, rpcinfo.NewRPCStats())
+	msg := remote.NewMessage(nil, mocks.ServiceInfo(), ri, remote.Call, remote.Client)
+
+	// pure paylod, no effect
+	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.PurePayload, serviceinfo.Thrift))
+	ctx, err := ClientTTHeaderHandler.WriteMeta(ctx, msg)
+	kvs := msg.TransInfo().TransIntInfo()
+	test.Assert(t, err == nil)
+	test.Assert(t, len(kvs) == 0)
+
+	// ttheader
+	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeader, serviceinfo.Thrift))
+	_, err = ClientTTHeaderHandler.WriteMeta(ctx, msg)
+	test.Assert(t, err == nil)
+	kvs = msg.TransInfo().TransIntInfo()
+	test.Assert(t, len(kvs) > 0)
+	test.Assert(t, kvs[transmeta.FromService] == fromInfo.ServiceName())
+	test.Assert(t, kvs[transmeta.FromMethod] == fromInfo.Method())
+	test.Assert(t, kvs[transmeta.ToService] == toInfo.ServiceName())
+	test.Assert(t, kvs[transmeta.ToMethod] == toInfo.Method())
+	test.Assert(t, kvs[transmeta.MsgType] == strconv.Itoa(int(remote.Call)))
+	test.Assert(t, kvs[transmeta.TransportType] == unframedTransportType)
+}
+
+func TestTTHeaderServerReadMetainfo(t *testing.T) {
+	ctx := context.Background()
+	ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), nil, rpcinfo.NewInvocation("", ""), nil, rpcinfo.NewRPCStats())
+	msg := remote.NewMessage(nil, mocks.ServiceInfo(), ri, remote.Call, remote.Client)
+
+	hd := map[uint16]string{
+		transmeta.FromService: "fromService",
+		transmeta.FromMethod:  "fromMethod",
+	}
+	msg.TransInfo().PutTransIntInfo(hd)
+
+	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.PurePayload, serviceinfo.Thrift))
+	_, err := ServerTTHeaderHandler.ReadMeta(ctx, msg)
+	test.Assert(t, err == nil)
+	fromEndPoint := msg.RPCInfo().From()
+	test.Assert(t, fromEndPoint.ServiceName() == "")
+	test.Assert(t, fromEndPoint.Method() == "")
+
+	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeader, serviceinfo.Thrift))
+	_, err = ServerTTHeaderHandler.ReadMeta(ctx, msg)
+	test.Assert(t, err == nil)
+	test.Assert(t, msg.RPCInfo().From().ServiceName() == hd[transmeta.FromService])
+	test.Assert(t, msg.RPCInfo().From().Method() == hd[transmeta.FromMethod])
+}
+
+func TestTTHeaderServerWriteMetainfo(t *testing.T) {
+	ctx := context.Background()
+	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", ""), nil, rpcinfo.NewRPCStats())
+	msg := remote.NewMessage(nil, mocks.ServiceInfo(), ri, remote.Call, remote.Client)
+
+	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.PurePayload, serviceinfo.Thrift))
+	_, err := ServerTTHeaderHandler.WriteMeta(ctx, msg)
+	test.Assert(t, err == nil)
+	kvs := msg.TransInfo().TransIntInfo()
+	test.Assert(t, len(kvs) == 0)
+
+	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeader, serviceinfo.Thrift))
+	_, err = ServerTTHeaderHandler.WriteMeta(ctx, msg)
+	test.Assert(t, err == nil)
+	kvs = msg.TransInfo().TransIntInfo()
+	test.Assert(t, kvs[transmeta.MsgType] == strconv.Itoa(int(remote.Call)))
 }


### PR DESCRIPTION
#### What type of PR is this?

test


#### What this PR does / why we need it (English/Chinese):

Supplementary of unit tests for http2 and ttheader implementations of MetaHandler/StreamingMetaHandler in `pkg/transmeta`.


#### Which issue(s) this PR fixes:

https://github.com/cloudwego/kitex/issues/372

Now the coverage for `pkg/transmeta` has already reached 90.1%.