### PR TITLE
fix(client): should not return NoResolver in NewClient

### DIFF
--- a/client/middlewares_test.go
+++ b/client/middlewares_test.go
@@ -60,8 +60,11 @@ var (
 
 func TestNoResolver(t *testing.T) {
 	svcInfo := mocks.ServiceInfo()
-	_, err := NewClient(svcInfo, WithDestService("destService"))
-	test.Assert(t, errors.Is(err, kerrors.ErrNoResolver), err)
+	cli, err := NewClient(svcInfo, WithDestService("destService"))
+	test.Assert(t, err == nil)
+
+	err = cli.Call(context.Background(), "mock", mocks.NewMockArgs(), mocks.NewMockResult())
+	test.Assert(t, errors.Is(err, kerrors.ErrNoResolver))
 }
 
 func TestResolverMW(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: NewClient should not return kerrors.NoResolver
zh: NewClient 不应该返回 kerrors.NoResolver

#### Which issue(s) this PR fixes:

