### PR TITLE
fix: close conn when flush failed

### DIFF
--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -138,7 +138,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 	var methodInfo serviceinfo.MethodInfo
 	if methodInfo, err = GetMethodInfo(ri, t.svcInfo); err != nil {
 		// it won't be err, because the method has been checked in decode, err check here just do defensive inspection
-		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
+		closeConn = true
+		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
 		// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded
 		t.OnError(ctx, err, conn)
 		return nil

--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -129,7 +129,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 	recvMsg.SetPayloadCodec(t.opt.PayloadCodec)
 	err = t.Read(ctx, conn, recvMsg)
 	if err != nil {
-		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
+		closeConn = true
+		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
 		t.OnError(ctx, err, conn)
 		return nil
 	}

--- a/pkg/remote/trans/netpoll/server_handler_test.go
+++ b/pkg/remote/trans/netpoll/server_handler_test.go
@@ -23,13 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudwego/netpoll"
+
 	"github.com/cloudwego/kitex/internal/mocks"
 	internal_stats "github.com/cloudwego/kitex/internal/stats"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/utils"
-	"github.com/cloudwego/netpoll"
 )
 
 var (
@@ -264,7 +265,6 @@ func TestNoMethodInfo(t *testing.T) {
 	// 1. prepare mock data
 	var isWriteBufFlushed bool
 	var isReaderBufReleased bool
-	var isInvoked bool
 	var isClosed bool
 	conn := &MockNetpollConn{
 		Conn: mocks.Conn{
@@ -312,6 +312,5 @@ func TestNoMethodInfo(t *testing.T) {
 	test.Assert(t, ri != nil)
 	test.Assert(t, isReaderBufReleased)
 	test.Assert(t, isWriteBufFlushed)
-	test.Assert(t, !isInvoked)
 	test.Assert(t, isClosed)
 }

--- a/pkg/remote/trans/netpollmux/server_handler.go
+++ b/pkg/remote/trans/netpollmux/server_handler.go
@@ -219,8 +219,8 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 	bufReader := np.NewReaderByteBuffer(reader)
 	err = t.readWithByteBuffer(ctx, bufReader, recvMsg)
 	if err != nil {
-		closeConn = true
-		t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, true)
+		// no need to close connection in mux case, because it had finished reads.
+		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, true)
 		// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded
 		t.OnError(ctx, err, muxSvrConn)
 		return

--- a/pkg/remote/trans/netpollmux/server_handler.go
+++ b/pkg/remote/trans/netpollmux/server_handler.go
@@ -219,7 +219,8 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 	bufReader := np.NewReaderByteBuffer(reader)
 	err = t.readWithByteBuffer(ctx, bufReader, recvMsg)
 	if err != nil {
-		// no need to close connection in mux case, because it had finished reads.
+		// No need to close the connection when read failed in mux case, because it had finished reads.
+		// But still need to close conn if write failed
 		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, true)
 		// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded
 		t.OnError(ctx, err, muxSvrConn)

--- a/pkg/remote/trans/netpollmux/server_handler.go
+++ b/pkg/remote/trans/netpollmux/server_handler.go
@@ -192,6 +192,7 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 	var err error
 	var recvMsg remote.Message
 	var sendMsg remote.Message
+	var closeConn bool
 	defer func() {
 		panicErr := recover()
 		if panicErr != nil {
@@ -199,10 +200,13 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 				ri := rpcinfo.GetRPCInfo(ctx)
 				rService, rAddr := getRemoteInfo(ri, conn)
 				klog.Errorf("KITEX: panic happened, close conn, remoteAddress=%s remoteService=%s error=%s\nstack=%s", rAddr, rService, panicErr, string(debug.Stack()))
-				conn.Close()
+				closeConn = true
 			} else {
 				klog.Errorf("KITEX: panic happened, error=%s\nstack=%s", panicErr, string(debug.Stack()))
 			}
+		}
+		if closeConn && conn != nil {
+			conn.Close()
 		}
 		t.finishTracer(ctx, rpcInfo, err, panicErr)
 		remote.RecycleMessage(recvMsg)
@@ -215,7 +219,8 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 	bufReader := np.NewReaderByteBuffer(reader)
 	err = t.readWithByteBuffer(ctx, bufReader, recvMsg)
 	if err != nil {
-		t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, false, true)
+		closeConn = true
+		t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, true)
 		// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded
 		t.OnError(ctx, err, muxSvrConn)
 		return
@@ -223,7 +228,7 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 
 	var methodInfo serviceinfo.MethodInfo
 	if methodInfo, err = trans.GetMethodInfo(rpcInfo, t.svcInfo); err != nil {
-		t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, false, true)
+		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, true)
 		t.OnError(ctx, err, muxSvrConn)
 		return
 	}
@@ -238,13 +243,14 @@ func (t *svrTransHandler) task(muxSvrConnCtx context.Context, conn net.Conn, rea
 		// error cannot be wrapped to print here, so it must exec before NewTransError
 		t.OnError(ctx, err, muxSvrConn)
 		err = remote.NewTransError(remote.InternalError, err)
-		t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, false, false)
+		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, muxSvrConn, rpcInfo, err, false)
 		return
 	}
 
 	remote.FillSendMsgFromRecvMsg(recvMsg, sendMsg)
 	if err = t.transPipe.Write(ctx, muxSvrConn, sendMsg); err != nil {
 		t.OnError(ctx, err, muxSvrConn)
+		closeConn = true
 		return
 	}
 }
@@ -311,12 +317,8 @@ func (t *svrTransHandler) SetPipeline(p *remote.TransPipeline) {
 	t.transPipe = p
 }
 
-func (t *svrTransHandler) writeErrorReplyIfNeeded(ctx context.Context, recvMsg remote.Message, conn net.Conn, ri rpcinfo.RPCInfo, err error, closeConn, doOnMessage bool) {
-	defer func() {
-		if closeConn {
-			conn.Close()
-		}
-	}()
+func (t *svrTransHandler) writeErrorReplyIfNeeded(
+	ctx context.Context, recvMsg remote.Message, conn net.Conn, ri rpcinfo.RPCInfo, err error, doOnMessage bool) (shouldCloseConn bool) {
 	if methodInfo, _ := trans.GetMethodInfo(ri, t.svcInfo); methodInfo != nil {
 		if methodInfo.OneWay() {
 			return
@@ -335,7 +337,9 @@ func (t *svrTransHandler) writeErrorReplyIfNeeded(ctx context.Context, recvMsg r
 	err = t.transPipe.Write(ctx, conn, errMsg)
 	if err != nil {
 		klog.CtxErrorf(ctx, "KITEX: write error reply failed, remote=%s, error=%s", conn.RemoteAddr(), err.Error())
+		return true
 	}
+	return
 }
 
 func (t *svrTransHandler) tryRecover(ctx context.Context, conn net.Conn) {


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: close connection when flush data failed to avoid memory leak
zh: 当写入失败时，关闭连接以避免内存泄漏

#### Which issue(s) this PR fixes:

https://github.com/cloudwego/kitex/issues/427
