### PR TITLE
optimize: reduce the grpc uts timecost from 97s to 35s

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -592,7 +592,11 @@ func TestClientSendAndReceive(t *testing.T) {
 
 func TestClientErrorNotify(t *testing.T) {
 	server, ct := setUp(t, 0, math.MaxUint32, normal)
-	go server.stop()
+	go func() {
+		if server != nil {
+			server.stop()
+		}
+	}()
 	// ct.reader should detect the error and activate ct.Error().
 	<-ct.Error()
 	ct.Close()

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -437,7 +437,7 @@ func (s *server) addr() string {
 func setUpServerOnly(t *testing.T, port int, serverConfig *ServerConfig, ht hType) *server {
 	server := &server{startedErr: make(chan error, 1), ready: make(chan struct{})}
 	go server.start(t, port, serverConfig, ht)
-	server.wait(t, 2*time.Second)
+	server.wait(t, time.Second)
 	return server
 }
 
@@ -540,7 +540,7 @@ func TestInflightStreamClosing(t *testing.T) {
 	client.CloseStream(stream, serr)
 
 	// wait for stream.Read error
-	timeout := time.NewTimer(5 * time.Second)
+	timeout := time.NewTimer(3 * time.Second)
 	select {
 	case <-donec:
 		if !timeout.Stop() {
@@ -611,7 +611,7 @@ func performOneRPC(ct ClientTransport) {
 	}
 	opts := Options{Last: true}
 	if err := ct.Write(s, []byte{}, expectedRequest, &opts); err == nil || err == io.EOF {
-		time.Sleep(5 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 		// The following s.Recv()'s could error out because the
 		// underlying transport is gone.
 		//
@@ -626,7 +626,7 @@ func performOneRPC(ct ClientTransport) {
 func TestClientMix(t *testing.T) {
 	s, ct := setUp(t, 0, math.MaxUint32, normal)
 	go func(s *server) {
-		time.Sleep(5 * time.Second)
+		time.Sleep(300 * time.Millisecond)
 		s.stop()
 	}(s)
 	go func(ct ClientTransport) {
@@ -634,7 +634,7 @@ func TestClientMix(t *testing.T) {
 		ct.Close()
 	}(ct)
 	for i := 0; i < 1000; i++ {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(1 * time.Millisecond)
 		go performOneRPC(ct)
 	}
 }
@@ -995,7 +995,7 @@ func TestServerContextCanceledOnClosedConnection(t *testing.T) {
 		if ss.Context().Err() != context.Canceled {
 			t.Fatalf("ss.Context().Err() got %v, want %v", ss.Context().Err(), context.Canceled)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatalf("Failed to cancel the context of the sever side stream.")
 	}
 	server.stop()
@@ -1884,7 +1884,7 @@ func runPingPongTest(t *testing.T, msgSize int) {
 	incomingHeader := make([]byte, 5)
 	done := make(chan struct{})
 	go func() {
-		timer := time.NewTimer(time.Second * 5)
+		timer := time.NewTimer(time.Second * 1)
 		<-timer.C
 		close(done)
 	}()


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
zh: 减少 grpc 部分的 ut 的时长，从 97s 减少到 35s
en: reduce the grpc uts timecost from 97s to 35s

#### Which issue(s) this PR fixes:

