### PR TITLE
fix: race problems of callTimes in retry and some fields of rpcStats.

### DIFF
--- a/pkg/rpcinfo/rpcstats_test.go
+++ b/pkg/rpcinfo/rpcstats_test.go
@@ -18,8 +18,10 @@ package rpcinfo_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/cloudwego/kitex/internal"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
@@ -35,5 +37,29 @@ func TestRPCStats(t *testing.T) {
 	test.Assert(t, st.RecvSize() == 0)
 	test.Assert(t, st.Error() == nil)
 	ok, err := st.Panicked()
+	test.Assert(t, !ok && err == nil)
+
+	st.(internal.Reusable).Recycle()
+	mst := rpcinfo.AsMutableRPCStats(st)
+	mst.SetLevel(stats.LevelBase)
+	st.Record(context.TODO(), stats.RPCStart, stats.StatusInfo, "start rpc")
+	test.Assert(t, st.GetEvent(stats.RPCStart) != nil)
+	mst.SetSendSize(1024)
+	test.Assert(t, st.SendSize() == 1024)
+	mst.SetRecvSize(1024)
+	test.Assert(t, st.RecvSize() == 1024)
+	mst.SetError(errors.New("err"))
+	test.Assert(t, st.Error() != nil)
+	mst.SetPanicked(errors.New("err"))
+	ok, err = st.Panicked()
+	test.Assert(t, ok && err != nil)
+
+	st.(internal.Reusable).Recycle()
+	test.Assert(t, st.Level() == stats.LevelDisabled)
+	test.Assert(t, st.GetEvent(stats.RPCStart) == nil)
+	test.Assert(t, st.SendSize() == 0)
+	test.Assert(t, st.RecvSize() == 0)
+	test.Assert(t, st.Error() == nil)
+	ok, err = st.Panicked()
 	test.Assert(t, !ok && err == nil)
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
#### What this PR does / why we need it (English/Chinese):

en:
1. Fix race problems of `callTimes` in retry.
2. Fix race problems of some fields of `rpcStats `.

zh:
1. 修复重试`callTimes`的race问题；
2. 修复`rpcStats`的一些字段的race问题。

#### Which issue(s) this PR fixes:
https://github.com/cloudwego/kitex/issues/444

