### PR TITLE
feat: passthrough context when generating a picker to extend traffic route ability

### DIFF
--- a/client/middlewares.go
+++ b/client/middlewares.go
@@ -100,7 +100,7 @@ func newResolveMWBuilder(lbf *lbcache.BalancerFactory) endpoint.MiddlewareBuilde
 					return kerrors.ErrServiceDiscovery.WithCause(err)
 				}
 
-				picker := lb.GetPicker()
+				picker := lb.GetPicker(ctx)
 				if r, ok := picker.(internal.Reusable); ok {
 					defer r.Recycle()
 				}

--- a/pkg/loadbalance/consist.go
+++ b/pkg/loadbalance/consist.go
@@ -312,7 +312,7 @@ func (cb *consistBalancer) AddToDaemon() {
 }
 
 // GetPicker implements the Loadbalancer interface.
-func (cb *consistBalancer) GetPicker(e discovery.Result) Picker {
+func (cb *consistBalancer) GetPicker(ctx context.Context, e discovery.Result) Picker {
 	var ci *consistInfo
 	if e.Cacheable {
 		cii, ok := cb.cachedConsistInfo.Load(e.CacheKey)

--- a/pkg/loadbalance/consist_test.go
+++ b/pkg/loadbalance/consist_test.go
@@ -69,7 +69,7 @@ func TestConsistPicker_Next_Nil(t *testing.T) {
 	}
 
 	cb := NewConsistBalancer(opt)
-	picker := cb.GetPicker(e)
+	picker := cb.GetPicker(context.TODO(), e)
 	test.Assert(t, picker.Next(context.TODO(), nil) == nil)
 
 	e = discovery.Result{
@@ -79,7 +79,7 @@ func TestConsistPicker_Next_Nil(t *testing.T) {
 	}
 
 	cb = NewConsistBalancer(newTestConsistentHashOption())
-	picker = cb.GetPicker(e)
+	picker = cb.GetPicker(context.TODO(), e)
 	test.Assert(t, picker.Next(context.TODO(), nil) == nil)
 	test.Assert(t, cb.Name() == "consist")
 }
@@ -99,7 +99,7 @@ func TestConsistPicker_Replica(t *testing.T) {
 	}
 
 	cb := NewConsistBalancer(opt)
-	picker := cb.GetPicker(e)
+	picker := cb.GetPicker(context.TODO(), e)
 	first := picker.Next(context.TODO(), nil)
 	second := picker.Next(context.TODO(), nil)
 	test.Assert(t, first != second)
@@ -118,7 +118,7 @@ func TestConsistPicker_Next_NoCache(t *testing.T) {
 	}
 
 	cb := NewConsistBalancer(opt)
-	picker := cb.GetPicker(e)
+	picker := cb.GetPicker(context.TODO(), e)
 	test.Assert(t, picker.Next(context.TODO(), nil) == ins)
 	test.Assert(t, picker.Next(context.TODO(), nil) == nil)
 }
@@ -139,16 +139,16 @@ func TestConsistPicker_Next_NoCache_Consist(t *testing.T) {
 	}
 
 	cb := NewConsistBalancer(opt)
-	picker := cb.GetPicker(e)
+	picker := cb.GetPicker(context.TODO(), e)
 	ins := picker.Next(context.TODO(), nil)
 	for i := 0; i < 100; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		test.Assert(t, picker.Next(context.TODO(), nil) == ins)
 	}
 
 	cb = NewConsistBalancer(opt)
 	for i := 0; i < 100; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		test.Assert(t, picker.Next(context.TODO(), nil) == ins)
 	}
 }
@@ -166,7 +166,7 @@ func TestConsistPicker_Next_Cache(t *testing.T) {
 	}
 
 	cb := NewConsistBalancer(opt)
-	picker := cb.GetPicker(e)
+	picker := cb.GetPicker(context.TODO(), e)
 	test.Assert(t, picker.Next(context.TODO(), nil) == ins)
 }
 
@@ -190,16 +190,16 @@ func TestConsistPicker_Next_Cache_Consist(t *testing.T) {
 	}
 
 	cb := NewConsistBalancer(opt)
-	picker := cb.GetPicker(e)
+	picker := cb.GetPicker(context.TODO(), e)
 	ins := picker.Next(context.TODO(), nil)
 	for i := 0; i < 100; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		test.Assert(t, picker.Next(context.TODO(), nil) == ins)
 	}
 
 	cb = NewConsistBalancer(opt)
 	for i := 0; i < 100; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		test.Assert(t, picker.Next(context.TODO(), nil) == ins)
 	}
 }
@@ -226,7 +226,7 @@ func TestConsistBalance(t *testing.T) {
 
 	cb := NewConsistBalancer(opt)
 	for i := 0; i < 100000; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		ins := picker.Next(context.TODO(), nil)
 		m[ins]++
 		if p, ok := picker.(internal.Reusable); ok {
@@ -257,7 +257,7 @@ func TestWeightedConsistBalance(t *testing.T) {
 
 	cb := NewConsistBalancer(opt)
 	for i := 0; i < 100000; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		ins := picker.Next(context.TODO(), nil)
 		m[ins]++
 	}
@@ -276,7 +276,7 @@ func TestConsistPicker_Reblance(t *testing.T) {
 	cb := NewConsistBalancer(opt)
 	record := make(map[string]discovery.Instance)
 	for i := 0; i < 10; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		key := strconv.Itoa(i)
 		ctx = context.WithValue(ctx, keyCtxKey, key)
 		record[key] = picker.Next(ctx, nil)
@@ -287,7 +287,7 @@ func TestConsistPicker_Reblance(t *testing.T) {
 	}
 	cb.(Rebalancer).Rebalance(c)
 	for i := 0; i < 10; i++ {
-		picker := cb.GetPicker(e)
+		picker := cb.GetPicker(context.TODO(), e)
 		key := strconv.Itoa(i)
 		ctx = context.WithValue(ctx, keyCtxKey, key)
 		test.DeepEqual(t, record[key], picker.Next(ctx, nil))
@@ -307,13 +307,13 @@ func BenchmarkNewConsistPicker_NoCache(bb *testing.B) {
 				CacheKey:  "",
 				Instances: inss,
 			}
-			picker := balancer.GetPicker(e)
+			picker := balancer.GetPicker(ctx, e)
 			picker.Next(ctx, nil)
 			picker.(internal.Reusable).Recycle()
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				picker := balancer.GetPicker(e)
+				picker := balancer.GetPicker(ctx, e)
 				// picker.Next(ctx, nil)
 				if r, ok := picker.(internal.Reusable); ok {
 					r.Recycle()
@@ -337,13 +337,13 @@ func BenchmarkNewConsistPicker(bb *testing.B) {
 				CacheKey:  "test",
 				Instances: inss,
 			}
-			picker := balancer.GetPicker(e)
+			picker := balancer.GetPicker(ctx, e)
 			picker.Next(ctx, nil)
 			picker.(internal.Reusable).Recycle()
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				picker := balancer.GetPicker(e)
+				picker := balancer.GetPicker(ctx, e)
 				picker.Next(ctx, nil)
 				if r, ok := picker.(internal.Reusable); ok {
 					r.Recycle()

--- a/pkg/loadbalance/lbcache/cache.go
+++ b/pkg/loadbalance/lbcache/cache.go
@@ -207,10 +207,10 @@ func (bl *Balancer) GetResult() (res discovery.Result, ok bool) {
 }
 
 // GetPicker equal to loadbalance.Balancer without pass discovery.Result, because we cache the result
-func (bl *Balancer) GetPicker() loadbalance.Picker {
+func (bl *Balancer) GetPicker(ctx context.Context) loadbalance.Picker {
 	atomic.StoreInt32(&bl.expire, 0)
 	res := bl.res.Load().(discovery.Result)
-	return bl.b.balancer.GetPicker(res)
+	return bl.b.balancer.GetPicker(ctx, res)
 }
 
 func (bl *Balancer) close() {

--- a/pkg/loadbalance/lbcache/cache_test.go
+++ b/pkg/loadbalance/lbcache/cache_test.go
@@ -61,7 +61,7 @@ func TestBuilder(t *testing.T) {
 	test.Assert(t, b != nil)
 	bl, err := b.(*BalancerFactory).Get(context.Background(), nil)
 	test.Assert(t, err == nil)
-	test.Assert(t, bl.GetPicker() != nil)
+	test.Assert(t, bl.GetPicker(context.TODO()) != nil)
 	dump := Dump()
 	dumpJson, err := json.Marshal(dump)
 	test.Assert(t, err == nil)
@@ -94,7 +94,7 @@ func TestBalancerCache(t *testing.T) {
 		info := rpcinfo.NewEndpointInfo("svc", "", nil, nil)
 		b, err := blf.Get(context.Background(), info)
 		test.Assert(t, err == nil)
-		p := b.GetPicker()
+		p := b.GetPicker(context.TODO())
 		for a := 0; a < count; a++ {
 			addr := p.Next(context.Background(), nil).Address().String()
 			fmt.Printf("count: %d addr: %s\n", i, addr)

--- a/pkg/loadbalance/loadbalancer.go
+++ b/pkg/loadbalance/loadbalancer.go
@@ -29,7 +29,7 @@ type Picker interface {
 
 // Loadbalancer generates pickers for the given service discovery result.
 type Loadbalancer interface {
-	GetPicker(discovery.Result) Picker
+	GetPicker(context.Context, discovery.Result) Picker
 	Name() string // unique key
 }
 
@@ -56,7 +56,7 @@ type SynthesizedLoadbalancer struct {
 }
 
 // GetPicker implements the Loadbalancer interface.
-func (slb *SynthesizedLoadbalancer) GetPicker(entry discovery.Result) Picker {
+func (slb *SynthesizedLoadbalancer) GetPicker(ctx context.Context, entry discovery.Result) Picker {
 	if slb.GetPickerFunc == nil {
 		return nil
 	}

--- a/pkg/loadbalance/weighted_random.go
+++ b/pkg/loadbalance/weighted_random.go
@@ -178,7 +178,7 @@ func NewWeightedBalancer() Loadbalancer {
 }
 
 // GetPicker implements the Loadbalancer interface.
-func (wb *weightedBalancer) GetPicker(e discovery.Result) Picker {
+func (wb *weightedBalancer) GetPicker(ctx context.Context, e discovery.Result) Picker {
 	var w *weightInfo
 	if e.Cacheable {
 		wi, ok := wb.cachedWeightInfo.Load(e.CacheKey)

--- a/pkg/loadbalance/weighted_random_test.go
+++ b/pkg/loadbalance/weighted_random_test.go
@@ -31,13 +31,13 @@ import (
 func TestWeightedBalancer_GetPicker(t *testing.T) {
 	balancer := NewWeightedBalancer()
 	// nil
-	picker := balancer.GetPicker(discovery.Result{})
+	picker := balancer.GetPicker(context.TODO(), discovery.Result{})
 	test.Assert(t, picker != nil)
 	dp, ok := picker.(*DummyPicker)
 	test.Assert(t, ok && dp != nil)
 
 	// invalid
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(context.TODO(), discovery.Result{
 		Instances: []discovery.Instance{
 			discovery.NewInstance("tcp", "addr1", -10, nil),
 			discovery.NewInstance("tcp", "addr2", -20, nil),
@@ -51,7 +51,7 @@ func TestWeightedBalancer_GetPicker(t *testing.T) {
 	insList := []discovery.Instance{
 		discovery.NewInstance("tcp", "addr1", 10, nil),
 	}
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(context.TODO(), discovery.Result{
 		Instances: insList,
 	})
 	test.Assert(t, picker != nil)
@@ -64,7 +64,7 @@ func TestWeightedBalancer_GetPicker(t *testing.T) {
 		discovery.NewInstance("tcp", "addr2", 20, nil),
 		discovery.NewInstance("tcp", "addr3", 30, nil),
 	}
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(context.TODO(), discovery.Result{
 		Instances: insList,
 	})
 	test.Assert(t, picker != nil)
@@ -75,7 +75,7 @@ func TestWeightedBalancer_GetPicker(t *testing.T) {
 		discovery.NewInstance("tcp", "addr2", 10, nil),
 		discovery.NewInstance("tcp", "addr3", 10, nil),
 	}
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(context.TODO(), discovery.Result{
 		Instances: insList,
 	})
 	test.Assert(t, picker != nil)
@@ -88,12 +88,12 @@ func TestWeightedPicker_Next(t *testing.T) {
 	balancer := NewWeightedBalancer()
 	ctx := context.Background()
 	// nil
-	picker := balancer.GetPicker(discovery.Result{})
+	picker := balancer.GetPicker(ctx, discovery.Result{})
 	ins := picker.Next(ctx, nil)
 	test.Assert(t, ins == nil)
 
 	// empty instance
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(ctx, discovery.Result{
 		Instances: make([]discovery.Instance, 0),
 	})
 	ins = picker.Next(ctx, nil)
@@ -104,7 +104,7 @@ func TestWeightedPicker_Next(t *testing.T) {
 		discovery.NewInstance("tcp", "addr1", 10, nil),
 	}
 	for i := 0; i < 100; i++ {
-		picker := balancer.GetPicker(discovery.Result{
+		picker := balancer.GetPicker(ctx, discovery.Result{
 			Instances: insList,
 		})
 		ins := picker.Next(ctx, nil)
@@ -130,7 +130,7 @@ func TestWeightedPicker_Next(t *testing.T) {
 	n := 10000000
 	pickedStat := map[int]int{}
 	for i := 0; i < n; i++ {
-		picker := balancer.GetPicker(discovery.Result{
+		picker := balancer.GetPicker(ctx, discovery.Result{
 			Instances: insList,
 		})
 		ins := picker.Next(ctx, nil)
@@ -155,7 +155,7 @@ func TestWeightedPicker_Next(t *testing.T) {
 		discovery.NewInstance("tcp", "addr1", 10, nil),
 		discovery.NewInstance("tcp", "addr2", -10, nil),
 	}
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(ctx, discovery.Result{
 		Instances: insList,
 	})
 	test.Assert(t, picker.Next(ctx, nil) != nil)
@@ -166,7 +166,7 @@ func TestWeightedPicker_Next(t *testing.T) {
 		discovery.NewInstance("tcp", "addr1", 10, nil),
 		discovery.NewInstance("tcp", "addr2", -20, nil),
 	}
-	picker = balancer.GetPicker(discovery.Result{
+	picker = balancer.GetPicker(ctx, discovery.Result{
 		Instances: insList,
 	})
 	test.Assert(t, picker.Next(ctx, nil) != nil)
@@ -187,7 +187,7 @@ func TestWeightedPicker_NoMoreInstance(t *testing.T) {
 		discovery.NewInstance("tcp", "addr6", 500, nil),
 	}
 
-	picker := balancer.GetPicker(discovery.Result{
+	picker := balancer.GetPicker(ctx, discovery.Result{
 		Instances: insList,
 	})
 
@@ -227,13 +227,13 @@ func BenchmarkNewWeightedPicker(bb *testing.B) {
 				CacheKey:  "test",
 				Instances: inss,
 			}
-			picker := balancer.GetPicker(e)
+			picker := balancer.GetPicker(ctx, e)
 			picker.Next(ctx, nil)
 			picker.(internal.Reusable).Recycle()
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				picker := balancer.GetPicker(e)
+				picker := balancer.GetPicker(ctx, e)
 				picker.Next(ctx, nil)
 				if r, ok := picker.(internal.Reusable); ok {
 					r.Recycle()


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it (English/Chinese):

en:
Passthrough context when generating a picker to extend traffic route ability.

zh:
支持调用GetPicker构造picker时传入ctx，用于扩展动态路由能力。

#### Which issue(s) this PR fixes:

参考方案2的设计：
https://github.com/cloudwego/kitex/issues/421
