### PR TITLE
feat: add address and protocol info to service info

### DIFF
--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/codec"
 	"github.com/cloudwego/kitex/pkg/remote/codec/protobuf"
 	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
+	"github.com/cloudwego/kitex/pkg/remote/trans"
 	"github.com/cloudwego/kitex/pkg/remote/trans/detection"
 	"github.com/cloudwego/kitex/pkg/remote/trans/netpoll"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
@@ -84,6 +85,8 @@ type Options struct {
 	Bus    event.Bus
 	Events event.Queue
 
+	SupportedTransportsFunc func(option remote.ServerOption) []string
+
 	// DebugInfo should only contain objects that are suitable for json serialization.
 	DebugInfo    utils.Slice
 	DebugService diagnosis.Service
@@ -105,6 +108,8 @@ func NewOptions(opts []Option) *Options {
 
 		Bus:    event.NewEventBus(),
 		Events: event.NewQueue(event.MaxEventNum),
+
+		SupportedTransportsFunc: DefaultSupportedTransportsFunc,
 
 		TracerCtl: &internal_stats.Controller{},
 		Registry:  registry.NoopRegistry,
@@ -157,4 +162,15 @@ func SysExitSignal() chan os.Signal {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
 	return signals
+}
+
+func DefaultSupportedTransportsFunc(option remote.ServerOption) []string {
+	if factory, ok := option.SvrHandlerFactory.(trans.MuxEnabledFlag); ok {
+		if factory.MuxEnabled() {
+			return []string{"ttheader_mux"}
+		} else {
+			return []string{"ttheader", "framed", "ttheader_framed", "grpc"}
+		}
+	}
+	return nil
 }

--- a/pkg/remote/trans/common.go
+++ b/pkg/remote/trans/common.go
@@ -61,3 +61,8 @@ func GetMethodInfo(ri rpcinfo.RPCInfo, svcInfo *serviceinfo.ServiceInfo) (servic
 	}
 	return nil, remote.NewTransErrorWithMsg(remote.UnknownMethod, fmt.Sprintf("unknown method %s", methodName))
 }
+
+// MuxEnabledFlag is used to determine whether a serverHandlerFactory is multiplexing.
+type MuxEnabledFlag interface {
+	MuxEnabled() bool
+}

--- a/pkg/remote/trans/detection/server_handler.go
+++ b/pkg/remote/trans/detection/server_handler.go
@@ -51,6 +51,10 @@ type svrTransHandlerFactory struct {
 	netpoll remote.ServerTransHandlerFactory
 }
 
+func (f *svrTransHandlerFactory) MuxEnabled() bool {
+	return false
+}
+
 func (f *svrTransHandlerFactory) NewTransHandler(opt *remote.ServerOption) (remote.ServerTransHandler, error) {
 	t := &svrTransHandler{}
 	var err error

--- a/pkg/remote/trans/netpollmux/server_handler.go
+++ b/pkg/remote/trans/netpollmux/server_handler.go
@@ -48,6 +48,11 @@ func NewSvrTransHandlerFactory() remote.ServerTransHandlerFactory {
 	return &svrTransHandlerFactory{}
 }
 
+// MuxEnabled returns true to mark svrTransHandlerFactory as a mux server factory.
+func (f *svrTransHandlerFactory) MuxEnabled() bool {
+	return true
+}
+
 // NewTransHandler implements the remote.ServerTransHandlerFactory interface.
 // TODO: use object pool?
 func (f *svrTransHandlerFactory) NewTransHandler(opt *remote.ServerOption) (remote.ServerTransHandler, error) {
@@ -371,7 +376,8 @@ func (t *svrTransHandler) SetPipeline(p *remote.TransPipeline) {
 }
 
 func (t *svrTransHandler) writeErrorReplyIfNeeded(
-	ctx context.Context, recvMsg remote.Message, conn net.Conn, ri rpcinfo.RPCInfo, err error, doOnMessage bool) (shouldCloseConn bool) {
+	ctx context.Context, recvMsg remote.Message, conn net.Conn, ri rpcinfo.RPCInfo, err error, doOnMessage bool,
+) (shouldCloseConn bool) {
 	if methodInfo, _ := trans.GetMethodInfo(ri, t.svcInfo); methodInfo != nil {
 		if methodInfo.OneWay() {
 			return

--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -169,3 +169,13 @@ func WithReusePort(reuse bool) Option {
 		o.RemoteOpt.ReusePort = reuse
 	}}
 }
+
+// WithSupportedTransportsFunc sets a function which converts supported transports from server option.
+func WithSupportedTransportsFunc(f func(option remote.ServerOption) []string) Option {
+	return Option{
+		F: func(o *internal_server.Options, di *utils.Slice) {
+			di.Push("WithSupportedTransportsFunc()")
+			o.SupportedTransportsFunc = f
+		},
+	}
+}

--- a/server/option_advanced_test.go
+++ b/server/option_advanced_test.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/acl"
 	"github.com/cloudwego/kitex/pkg/generic"
+	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
 
@@ -151,4 +153,50 @@ func TestExitSignalOption(t *testing.T) {
 	})
 	err = svr.Run()
 	test.Assert(t, err == stopErr, err)
+}
+
+func TestWithSupportedTransportsFunc(t *testing.T) {
+	cases := []struct {
+		options        []Option
+		wantTransports []string
+	}{
+		{
+			options: []Option{
+				WithSupportedTransportsFunc(func(option remote.ServerOption) []string {
+					return []string{"mock1", "mock2"}
+				}),
+			},
+			wantTransports: []string{"mock1", "mock2"},
+		},
+		{
+			options: []Option{
+				WithSupportedTransportsFunc(func(option remote.ServerOption) []string {
+					return []string{}
+				}),
+			},
+			wantTransports: []string{},
+		},
+		{
+			wantTransports: []string{"ttheader", "framed", "ttheader_framed", "grpc"},
+		},
+		{
+			options: []Option{
+				WithMuxTransport(),
+			},
+			wantTransports: []string{"ttheader_mux"},
+		},
+		{
+			options: []Option{
+				WithTransHandlerFactory(nil),
+			},
+			wantTransports: nil,
+		},
+	}
+	var svr Server
+	for _, tcase := range cases {
+		svr = NewServer(tcase.options...)
+		svr.RegisterService(mocks.ServiceInfo(), nil)
+		svr.(*server).fillMoreServiceInfo(nil)
+		test.Assert(t, reflect.DeepEqual(svr.GetServiceInfo().Extra["transports"], tcase.wantTransports))
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -49,6 +49,7 @@ import (
 // registered to it.
 type Server interface {
 	RegisterService(svcInfo *serviceinfo.ServiceInfo, handler interface{}) error
+	GetServiceInfo() *serviceinfo.ServiceInfo
 	Run() error
 	Stop() error
 }
@@ -159,6 +160,10 @@ func (s *server) RegisterService(svcInfo *serviceinfo.ServiceInfo, handler inter
 	return nil
 }
 
+func (s *server) GetServiceInfo() *serviceinfo.ServiceInfo {
+	return s.svcInfo
+}
+
 // Run runs the server.
 func (s *server) Run() (err error) {
 	if s.svcInfo == nil {
@@ -177,6 +182,7 @@ func (s *server) Run() (err error) {
 	}
 
 	s.richRemoteOption()
+	s.fillMoreServiceInfo(s.opt.RemoteOpt.Address)
 	transHdlr, err := s.newSvrTransHandler()
 	if err != nil {
 		return err
@@ -189,6 +195,11 @@ func (s *server) Run() (err error) {
 	}
 
 	errCh := s.svr.Start()
+	select {
+	case err = <-errCh:
+		klog.Fatalf("KITEX: server start error: error=%s", err.Error())
+	default:
+	}
 	muStartHooks.Lock()
 	for i := range onServerStart {
 		go onServerStart[i]()
@@ -395,6 +406,19 @@ func (s *server) buildRegistryInfo(lAddr net.Addr) {
 	if info.Weight == 0 {
 		info.Weight = discovery.DefaultWeight
 	}
+}
+
+func (s *server) fillMoreServiceInfo(lAddr net.Addr) {
+	ni := *s.svcInfo
+	si := &ni
+	extra := make(map[string]interface{}, len(si.Extra)+2)
+	for k, v := range si.Extra {
+		extra[k] = v
+	}
+	extra["address"] = lAddr
+	extra["transports"] = s.opt.SupportedTransportsFunc(*s.opt.RemoteOpt)
+	si.Extra = extra
+	s.svcInfo = si
 }
 
 func (s *server) waitExit(errCh chan error) error {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### What this PR does / why we need it (English/Chinese):

zh: 为serviceInfo填充监听地址和协议信息，并在server暴露获取serviceInfo的接口。
en: Fill in listening address and protocol info for serviceInfo, and expose GetServiceInfo interface on server.


#### Which issue(s) this PR fixes:

https://github.com/cloudwego/kitex/issues/455
