### PR TITLE
refactor(ttheader): change protocol id of Kitex Protobuf in TTHeader and promise the change is compatible with old version

### DIFF
--- a/pkg/remote/codec/default_codec.go
+++ b/pkg/remote/codec/default_codec.go
@@ -277,8 +277,7 @@ func checkRPCState(ctx context.Context, message remote.Message) error {
 }
 
 func checkPayload(
-	flagBuf []byte, message remote.Message, in remote.ByteBuffer, isTTHeader bool, maxPayloadSize int,
-) error {
+	flagBuf []byte, message remote.Message, in remote.ByteBuffer, isTTHeader bool, maxPayloadSize int) error {
 	var transProto transport.Protocol
 	var codecType serviceinfo.PayloadCodec
 	if isThriftBinary(flagBuf) {

--- a/pkg/remote/codec/header_codec.go
+++ b/pkg/remote/codec/header_codec.go
@@ -97,10 +97,11 @@ type ProtocolID uint8
 
 // Supported ProtocolID values.
 const (
-	ProtocolIDThriftBinary  ProtocolID = 0x00
-	ProtocolIDThriftCompact ProtocolID = 0x02
-	ProtocolIDProtobufKitex ProtocolID = 0x03
-	ProtocolIDDefault                  = ProtocolIDThriftBinary
+	ProtocolIDThriftBinary    ProtocolID = 0x00
+	ProtocolIDThriftCompact   ProtocolID = 0x02 // Kitex not support
+	ProtocolIDThriftCompactV2 ProtocolID = 0x03 // Kitex not support
+	ProtocolIDKitexProtobuf   ProtocolID = 0x04
+	ProtocolIDDefault                    = ProtocolIDThriftBinary
 )
 
 type InfoIDType uint8 // uint8
@@ -382,7 +383,12 @@ func setFlags(flags uint16, message remote.Message) {
 func getProtocolID(pi remote.ProtocolInfo) ProtocolID {
 	switch pi.CodecType {
 	case serviceinfo.Protobuf:
-		return ProtocolIDProtobufKitex
+		// ProtocolIDKitexProtobuf is 0x03 at old version(<=v1.9.1) , but it conflicts with ThriftCompactV2.
+		// Change the ProtocolIDKitexProtobuf to 0x04 from v1.9.2. But notice! that it is an incompatible change of protocol.
+		// For keeping compatible, Kitex use ProtocolIDDefault send ttheader+KitexProtobuf request to ignore the old version
+		// check failed if use 0x04. It doesn't make sense, but it won't affect the correctness of RPC call because the actual
+		// protocol check at checkPayload func which check payload with HEADER MAGIC bytes of payload.
+		return ProtocolIDDefault
 	}
 	return ProtocolIDDefault
 }
@@ -390,12 +396,12 @@ func getProtocolID(pi remote.ProtocolInfo) ProtocolID {
 // protoID just for ttheader
 func checkProtocolID(protoID uint8, message remote.Message) error {
 	switch protoID {
-	case uint8(ProtocolIDProtobufKitex):
-		// rpcCfg := internal.AsMutableRPCConfig(message.RPCInfo().Config())
-		// rpcCfg.SetCodecType(kitex.TTHeaderProtobufKitex)
 	case uint8(ProtocolIDThriftBinary):
+	case uint8(ProtocolIDKitexProtobuf):
+	case uint8(ProtocolIDThriftCompactV2):
+		// just for compatibility
 	default:
-		return fmt.Errorf("unsupported ProtocolID[%d]", protoID)
+		klog.Warnf("KITEX: ProtocolID[%d] is not supported, do double check for payload", protoID)
 	}
 	return nil
 }

--- a/pkg/remote/codec/header_codec.go
+++ b/pkg/remote/codec/header_codec.go
@@ -401,7 +401,7 @@ func checkProtocolID(protoID uint8, message remote.Message) error {
 	case uint8(ProtocolIDThriftCompactV2):
 		// just for compatibility
 	default:
-		klog.Warnf("KITEX: ProtocolID[%d] is not supported, do double check for payload", protoID)
+		return fmt.Errorf("unsupported ProtocolID[%d]", protoID)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
refactor

#### What this PR does / why we need it (English/Chinese):
en: refactor(ttheader): change protocol id of Kitex Protobuf in TTHeader and promise the change is compatible with old version
zn: refactor(ttheader):  修改Kitex Protobuf 在 TTHeader 中的 protocolID 同时保证该变更与低版本的兼容性

#### Which issue(s) this PR fixes:
none
