### PR TITLE
optimize(mux): wrap ErrReadTimeout with ErrRPCTimeout in mux scenario

### DIFF
--- a/pkg/remote/trans/default_client_handler.go
+++ b/pkg/remote/trans/default_client_handler.go
@@ -76,7 +76,7 @@ func (t *cliTransHandler) Read(ctx context.Context, conn net.Conn, recvMsg remot
 	err = t.codec.Decode(ctx, recvMsg, bufReader)
 	if err != nil {
 		if t.ext.IsTimeoutErr(err) {
-			return kerrors.ErrRPCTimeout.WithCause(err)
+			err = kerrors.ErrRPCTimeout.WithCause(err)
 		}
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: optimize(mux): wrap ErrReadTimeout with ErrRPCTimeout in mux scenario
zh: optimize(mux): 连接多路复用场景的 ErrReadTimeout 用 ErrRPCTimeout 封装返回

#### Which issue(s) this PR fixes:
none
