### PR TITLE
optimize(callopt): add EmptyOption for call option

### DIFF
--- a/client/callopt/options.go
+++ b/client/callopt/options.go
@@ -188,3 +188,7 @@ func Apply(cos []Option, cfg rpcinfo.RPCConfig, svr remoteinfo.RemoteInfo, locks
 	co.Recycle()
 	return buf.String()
 }
+
+func EmptyOption() Option {
+	return Option{f: func(o *callOptions, di *strings.Builder) {}}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -337,7 +337,7 @@ func (kc *kClient) Call(ctx context.Context, method string, request, response in
 	if recycleRI {
 		// why need check recycleRI to decide if recycle RPCInfo?
 		// 1. no retry, rpc timeout happen will cause panic when response return
-		// 2. retry success, will cause panic when first call return
+		// 2. timeout retry success, will cause panic when first call return
 		// 3. backup request may cause panic, cannot recycle first RPCInfo
 		// RPCInfo will be recycled after rpc is finished,
 		// holding RPCInfo in a new goroutine is forbidden.

--- a/client/option.go
+++ b/client/option.go
@@ -259,7 +259,7 @@ func WithTimeoutProvider(p rpcinfo.TimeoutProvider) Option {
 	}}
 }
 
-// WithTag sets the customize tag for service discovery, eg: idc, cluster.
+// WithTag sets the customized tag for service discovery, eg: idc, cluster.
 func WithTag(key, val string) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithTag(%s=%s)", key, val))


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: optimize(callopt): add EmptyOption for call option, for using in extension library
zh: optimize(callopt): 给 call option 添加 EmptyOption,  便于扩展库使用

#### Which issue(s) this PR fixes:
none
