### PR TITLE
fix: fix detection handler panic when conn inactive early

### DIFF
--- a/pkg/remote/trans/detection/server_handler.go
+++ b/pkg/remote/trans/detection/server_handler.go
@@ -116,7 +116,7 @@ func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 }
 
 func (t *svrTransHandler) which(ctx context.Context) remote.ServerTransHandler {
-	if r := ctx.Value(detectionKey{}).(*detectionHandler); r.handler != nil {
+	if r, ok := ctx.Value(detectionKey{}).(*detectionHandler); ok && r.handler != nil {
 		return r.handler
 	}
 	// use noop transHandler


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: add nil guard in detection handler to prevent panic when OnInactive is before OnActive or OnActive returns an error
zh: 在 detection handler 中增加检测。当 OnInactive 比 OnActive 先发生，或者 OnActive 返回 error时，防止空指针 panic

#### Which issue(s) this PR fixes:

none
