### PR TITLE
fix(svrTransHandler.which): panic

### DIFF
--- a/pkg/remote/trans/detection/server_handler.go
+++ b/pkg/remote/trans/detection/server_handler.go
@@ -116,8 +116,10 @@ func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 }
 
 func (t *svrTransHandler) which(ctx context.Context) remote.ServerTransHandler {
-	if r, ok := ctx.Value(detectionKey{}).(*detectionHandler); ok && r.handler != nil {
-		return r.handler
+	if ctx.Value(detectionKey{}) != nil {
+		if r, ok := ctx.Value(detectionKey{}).(*detectionHandler); ok && r.handler != nil {
+			return r.handler
+		}
 	}
 	// use noop transHandler
 	return noopSvrTransHandler{}


### PR DESCRIPTION
when max connect limit, ctx no value detectionKey, it will panic.

#### What type of PR is this?

fix: sometime panic

#### What this PR does / why we need it (English/Chinese):

It'd better to check nil, avoid panic

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


### test code
#### client
```
func main() {
	// 请求成功数
	successNum := 0
	counterLock := sync.RWMutex{}
	echoNum := 0
	wg := sync.WaitGroup{}
	request := func() {
		defer wg.Done()
		cc, err := echo.NewClient("echo", client.WithHostPorts("[::1]:8888"))
		if err != nil {
			klog.Error(err)
		}
		req := &api.Request{Message: "my request"}
		_, err = cc.Echo(context.Background(), req)
		if err != nil {
			klog.Error(err)
			return
		}

		counterLock.Lock()
		successNum++
		counterLock.Unlock()
	}

	for echoNum < 100 {
		echoNum++
		wg.Add(1)
		go request()
	}
	wg.Wait()
	klog.Infof("echoNum: %d", echoNum)
	klog.Infof("success num: %d", successNum)
}
```
#### server
```
func main() {
	svr := echo.NewServer(new(EchoImpl), server.WithLimit(&limit.Option{MaxConnections: 10, MaxQPS: 1}))
	if err := svr.Run(); err != nil {
		klog.Error("server stopped with error:", err)
	} else {
		klog.Info("server stopped")
	}
}
```

#### panic
```
panic: interface conversion: interface {} is nil, not *detection.detectionHandler

goroutine 7 [running]:
github.com/cloudwego/kitex/pkg/remote/trans/detection.(*svrTransHandler).which(0x146e124?, {0x14f0588, 0xc00002c098})
        /Users/baiyutang/go/src/github.com/baiyutang/kitex/pkg/remote/trans/detection/server_handler.go:121 +0x11c
github.com/cloudwego/kitex/pkg/remote/trans/detection.(*svrTransHandler).OnError(0x122228e?, {0x14f0588, 0xc00002c098}, {0x14ece00, 0xc000034380}, {0x3117c58, 0xc000c53320})
        /Users/baiyutang/go/src/github.com/baiyutang/kitex/pkg/remote/trans/detection/server_handler.go:129 +0x37
github.com/cloudwego/kitex/pkg/remote.(*TransPipeline).OnError(0xc0000350c0?, {0x14f0588?, 0xc00002c098?}, {0x14ece00?, 0xc000034380?}, {0x3117c58?, 0xc000c53320?})
        /Users/baiyutang/go/src/github.com/baiyutang/kitex/pkg/remote/trans_pipeline.go:142 +0x3f
github.com/cloudwego/kitex/pkg/remote/trans/netpoll.(*transServer).onError(...)
        /Users/baiyutang/go/src/github.com/baiyutang/kitex/pkg/remote/trans/netpoll/trans_server.go:187
github.com/cloudwego/kitex/pkg/remote/trans/netpoll.(*transServer).onConnActive(0xc00007e780, {0x14f2cc8?, 0xc000c53320})
        /Users/baiyutang/go/src/github.com/baiyutang/kitex/pkg/remote/trans/netpoll/trans_server.go:165 +0x289
github.com/cloudwego/netpoll.(*connection).onPrepare(0xc000c53320, 0xc00019a3c0)
        /Users/baiyutang/go/pkg/mod/github.com/cloudwego/netpoll@v0.2.0/connection_onevent.go:97 +0xca
github.com/cloudwego/netpoll.(*connection).init(0xc000c53320, {0x14f2110, 0xc000c5e2a0}, 0x146a0e0?)
        /Users/baiyutang/go/pkg/mod/github.com/cloudwego/netpoll@v0.2.0/connection_impl.go:323 +0x25c
github.com/cloudwego/netpoll.(*server).OnRead(0xc000126f20, {0xc000b625a0?, 0xc000216000?})
        /Users/baiyutang/go/pkg/mod/github.com/cloudwego/netpoll@v0.2.0/netpoll_server.go:108 +0x93
github.com/cloudwego/netpoll.(*defaultPoll).Wait(0xc00002ccf0)
        /Users/baiyutang/go/pkg/mod/github.com/cloudwego/netpoll@v0.2.0/poll_default_bsd.go:91 +0x3b4
created by github.com/cloudwego/netpoll.(*manager).Run
        /Users/baiyutang/go/pkg/mod/github.com/cloudwego/netpoll@v0.2.0/poll_manager.go:100 +0x31
exit status 2
```