### PR TITLE
fix: avoid nil panic if server not ready for shutdown

### DIFF
--- a/pkg/remote/trans/netpoll/trans_server.go
+++ b/pkg/remote/trans/netpoll/trans_server.go
@@ -145,11 +145,13 @@ func (ts *transServer) Shutdown() (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ts.opt.ExitWaitTime)
 	defer cancel()
 	if g, ok := ts.transHdlr.(remote.GracefulShutdown); ok {
-		// 1. stop listener
-		ts.ln.Close()
+		if ts.ln != nil {
+			// 1. stop listener
+			ts.ln.Close()
 
-		// 2. signal all active connections to close gracefully
-		g.GracefulShutdown(ctx)
+			// 2. signal all active connections to close gracefully
+			g.GracefulShutdown(ctx)
+		}
 	}
 	if ts.evl != nil {
 		err = ts.evl.Shutdown(ctx)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: avoid nil panic if server not ready for shutdown
zh: 当 server 未准备好被 shutdown 时，避免出现 nil panic 

#### Which issue(s) this PR fixes:
