### PR TITLE
fix: nphttp2 client use OnRequest to read

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/bytedance/gopkg v0.0.0-20220509134931-d1878f638986
 	github.com/choleraehyq/pid v0.0.13
-	github.com/cloudwego/netpoll v0.2.4
+	github.com/cloudwego/netpoll v0.2.5-0.20220610094432-be0104887aa9
 	github.com/cloudwego/thriftgo v0.1.2
 	github.com/golang/mock v1.6.0
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/choleraehyq/pid v0.0.13/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4T
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/netpoll v0.2.4 h1:Kbo2HA1cXEgoy/bu1jSNrjcqZj2diENcJqLy6vKiROU=
 github.com/cloudwego/netpoll v0.2.4/go.mod h1:1T2WVuQ+MQw6h6DpE45MohSvDTKdy2DlzCx2KsnPI4E=
+github.com/cloudwego/netpoll v0.2.5-0.20220610094432-be0104887aa9 h1:5+a2dFtqX1H1syMOzlJ6zJ9t0ass/FZyVkPppKfZG8g=
+github.com/cloudwego/netpoll v0.2.5-0.20220610094432-be0104887aa9/go.mod h1:1T2WVuQ+MQw6h6DpE45MohSvDTKdy2DlzCx2KsnPI4E=
 github.com/cloudwego/thriftgo v0.1.2 h1:AXpGJiWE3VggfiRHwA6raRJUIcjxliEIfJfGlvRiYUA=
 github.com/cloudwego/thriftgo v0.1.2/go.mod h1:LzeafuLSiHA9JTiWC8TIMIq64iadeObgRUhmVG1OC/w=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: nphttp2 client need use OnRequest to read, fix read&close panic
zh: nphttp2 client 将 `loop read` 注册为 `OnRequest`，以修复 `read&close` 造成的 Panic

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none