### PR TITLE
fix: grpc OnActive doesn't work

### DIFF
--- a/pkg/remote/trans/detection/server_handler.go
+++ b/pkg/remote/trans/detection/server_handler.go
@@ -88,7 +88,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 	// only need detect once when connection is reused
 	r := ctx.Value(handlerKey{}).(*handlerWrapper)
 	if r.handler != nil {
-		return r.handler.OnRead(ctx, conn)
+		return r.handler.OnRead(r.ctx, conn)
 	}
 	// Check the validity of client preface.
 	zr := conn.(netpoll.Connection).Reader()
@@ -106,7 +106,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 			return err
 		}
 	}
-	r.handler = which
+	r.ctx, r.handler = ctx, which
 	return which.OnRead(ctx, conn)
 }
 
@@ -159,5 +159,6 @@ func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.
 type handlerKey struct{}
 
 type handlerWrapper struct {
+	ctx     context.Context
 	handler remote.ServerTransHandler
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix: the function `serverTransHandler.OnActive` doesn't work on grpc
zh: 修复 serverTransHandler OnActive 方法在 grpc 下失效的问题 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none