### PR TITLE
perf: nphttp2 server reuse rpcinfo to improve performance

### DIFF
--- a/pkg/remote/trans/nphttp2/server_handler_test.go
+++ b/pkg/remote/trans/nphttp2/server_handler_test.go
@@ -62,19 +62,19 @@ func TestServerHandler(t *testing.T) {
 	// mock a headerFrame so onRead() can start working
 	npConn.mockMetaHeaderFrame()
 	go func() {
-		handler.OnRead(newMockCtxWithRPCInfo(), npConn)
+		// test OnActive()
+		ctx, err := handler.OnActive(newMockCtxWithRPCInfo(), npConn)
+		test.Assert(t, err == nil, err)
+
+		handler.OnRead(ctx, npConn)
+
+		// test OnInactive()
+		handler.OnInactive(ctx, npConn)
 		test.Assert(t, err == nil, err)
 	}()
 
 	// sleep 50 mills so server can handle metaHeader frame
 	time.Sleep(time.Millisecond * 50)
-
-	// test OnActive()
-	_, err = handler.OnActive(context.Background(), npConn)
-	test.Assert(t, err == nil, err)
-
-	// test OnInactive()
-	handler.OnInactive(newMockCtxWithRPCInfo(), npConn)
 
 	// test OnError()
 	handler.OnError(context.Background(), context.Canceled, npConn)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

perf
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: reuse rpcinfo mainly improve grpc unary,  `./script/benchmark_grpc.sh` shown as:

qps ↑5%-8%, latency ↓2%-10%
```
[KITEX],100,1024,116785.23,2.25,2.87      =>   [KITEX],100,1024,122147.10,2.20,2.81
[KITEX],1000,1024,150162.24,15.84,22.06   =>   [KITEX],1000,1024,163393.56,14.20,20.96
```

zh: 复用 rpcinfo 主要在 grpc unary 场景下提升性能

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none