### PR TITLE
perf: grpc encode header&data into a same slice

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/controlbuf.go
+++ b/pkg/remote/trans/nphttp2/grpc/controlbuf.go
@@ -134,8 +134,12 @@ func (c *cleanupStream) isTransportResponseFrame() bool { return c.rst } // Resu
 type dataFrame struct {
 	streamID  uint32
 	endStream bool
-	h         []byte
-	d         []byte
+	// h is optional, d is required.
+	// you can assign the header to h and the payload to the d;
+	// or just assign the header + payload together to the d.
+	// In other words, h = nil means d = header + payload.
+	h []byte
+	d []byte
 	// onEachWrite is called every time
 	// a part of d is written out.
 	onEachWrite func()


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

perf
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: grpc encode header&data into a same slice,  benchmark shown as:

qps ↑1%-2%, latency ↓1%-2%
```
unary: 
[KITEX],100,1024,116429.66,2.26,2.89      =>   [KITEX],100,1024,118309.69,2.22,2.85
[KITEX],1000,1024,151249.71,15.23,21.44   =>   [KITEX],1000,1024,153938.68,14.94,20.48

streaming:
[KITEX],100,1024,260574.19,1.41,1.68      =>   [KITEX],100,1024,262352.00,1.40,1.62
[KITEX],1000,1024,346010.57,7.85,10.01    =>   [KITEX],1000,1024,354359.35,7.67,9.26
```

zh: grpc 合并编码 header 和 data，代替原先的拷贝合并 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none