### PR TITLE
optimize: add ServiceInfo's getter

### DIFF
--- a/pkg/serviceinfo/serviceinfo.go
+++ b/pkg/serviceinfo/serviceinfo.go
@@ -18,6 +18,7 @@ package serviceinfo
 
 import (
 	"context"
+	"net"
 )
 
 // PayloadCodec alias type
@@ -75,6 +76,24 @@ func (i *ServiceInfo) GetPackageName() (pkg string) {
 	}
 	pkg, _ = i.Extra["PackageName"].(string)
 	return
+}
+
+// GetAddress returns server listen address.
+func (i *ServiceInfo) GetAddress() net.Addr {
+	addr, _ := i.Extra["address"].(net.Addr)
+	return addr
+}
+
+// IsStreaming if server use grpc streaming return true,otherwise return false.
+func (i *ServiceInfo) IsStreaming() bool {
+	isStreaming, _ := i.Extra["streaming"].(bool)
+	return isStreaming
+}
+
+// GetTransports return server protocol info list.
+func (i *ServiceInfo) GetTransports() []string {
+	transports, _ := i.Extra["transports"].([]string)
+	return transports
 }
 
 // MethodInfo gets MethodInfo.

--- a/pkg/serviceinfo/serviceinfo_test.go
+++ b/pkg/serviceinfo/serviceinfo_test.go
@@ -18,6 +18,8 @@ package serviceinfo_test
 
 import (
 	"context"
+	"net"
+	"reflect"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
@@ -32,13 +34,23 @@ func TestServiceInfo(t *testing.T) {
 		},
 	}
 	test.Assert(t, si.GetPackageName() == "123")
+	test.Assert(t, si.IsStreaming() == false)
+	test.Assert(t, si.GetAddress() == nil)
+	test.Assert(t, len(si.GetTransports()) == 0)
 
+	var addr net.Addr = &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8888}
 	si = &serviceinfo.ServiceInfo{
 		Extra: map[string]interface{}{
 			"PackageName": "456",
+			"streaming":   true,
+			"transports":  []string{"ttheader_mux"},
+			"address":     addr,
 		},
 	}
 	test.Assert(t, si.GetPackageName() == "456")
+	test.Assert(t, si.IsStreaming() == true)
+	test.Assert(t, si.GetAddress() == addr)
+	test.Assert(t, reflect.DeepEqual(si.GetTransports(), []string{"ttheader_mux"}))
 }
 
 func TestMethodInfo(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
en:  add Serviceinfo's getter method.
zh:  添加 `Serviceinfo` 的 `getter` 方法
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
