### PR TITLE
refactor: error handler of client/server side

### DIFF
--- a/client/middlewares_test.go
+++ b/client/middlewares_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/event"
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/remote/codec/protobuf"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/rpcinfo/remoteinfo"
 )
@@ -119,23 +120,27 @@ func TestResolverMWOutOfInstance(t *testing.T) {
 
 func TestDefaultErrorHandler(t *testing.T) {
 	// Test TApplicationException
-	err := defaultErrorHandler(thrift.NewTApplicationException(100, "mock"))
-	test.Assert(t, err.Error() == "remote or network error: [remote] mock")
+	err := DefaultClientErrorHandler(thrift.NewTApplicationException(100, "mock"))
+	test.Assert(t, err.Error() == "remote or network error[remote]: mock", err.Error())
 	var te thrift.TApplicationException
 	ok := errors.As(err, &te)
 	test.Assert(t, ok)
 	test.Assert(t, te.TypeId() == 100)
 
 	// Test PbError
-	err = defaultErrorHandler(protobuf.NewPbError(100, "mock"))
-	test.Assert(t, err.Error() == "remote or network error: [remote] mock")
+	err = DefaultClientErrorHandler(protobuf.NewPbError(100, "mock"))
+	test.Assert(t, err.Error() == "remote or network error[remote]: mock")
 	var pe protobuf.PBError
 	ok = errors.As(err, &pe)
 	test.Assert(t, ok)
 	test.Assert(t, te.TypeId() == 100)
 
+	// Test status.Error
+	err = DefaultClientErrorHandler(status.Err(100, "mock"))
+	test.Assert(t, err.Error() == "remote or network error: rpc error: code = 100 desc = mock", err.Error())
+
 	// Test other error
-	err = defaultErrorHandler(errors.New("mock"))
+	err = DefaultClientErrorHandler(errors.New("mock"))
 	test.Assert(t, err.Error() == "remote or network error: mock")
 }
 

--- a/pkg/remote/codec/default_codec.go
+++ b/pkg/remote/codec/default_codec.go
@@ -176,7 +176,7 @@ func (c *defaultCodec) Decode(ctx context.Context, message remote.Message, in re
 	}
 
 	// 2. decode body
-	if err := c.decodePayload(ctx, message, in); err != nil {
+	if err = c.decodePayload(ctx, message, in); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/remote/codec/protobuf/protobuf.go
+++ b/pkg/remote/codec/protobuf/protobuf.go
@@ -145,7 +145,7 @@ func (c protobufCodec) Unmarshal(ctx context.Context, message remote.Message, in
 		if err := exception.Unmarshal(actualMsgBuf); err != nil {
 			return perrors.NewProtocolErrorWithMsg(fmt.Sprintf("protobuf unmarshal Exception failed: %s", err.Error()))
 		}
-		return &exception
+		return remote.NewTransError(exception.TypeID(), &exception)
 	}
 
 	if err = codec.NewDataIfNeeded(methodName, message); err != nil {

--- a/pkg/remote/codec/protobuf/protobuf_test.go
+++ b/pkg/remote/codec/protobuf/protobuf_test.go
@@ -93,11 +93,11 @@ func TestException(t *testing.T) {
 	in := remote.NewReaderBuffer(buf)
 	err = payloadCodec.Unmarshal(ctx, recvMsg, in)
 	test.Assert(t, err != nil)
-	pbErr, ok := err.(*pbError)
+	transErr, ok := err.(*remote.TransError)
 	test.Assert(t, ok)
 	test.Assert(t, err.Error() == errInfo)
-	test.Assert(t, pbErr.errProto.Message == errInfo)
-	test.Assert(t, pbErr.errProto.TypeID == remote.UnknownMethod)
+	test.Assert(t, transErr.Error() == errInfo)
+	test.Assert(t, transErr.TypeID() == remote.UnknownMethod)
 }
 
 func TestTransErrorUnwrap(t *testing.T) {

--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -124,7 +124,7 @@ func (c thriftCodec) Unmarshal(ctx context.Context, message remote.Message, in r
 		if err := tProt.ReadMessageEnd(); err != nil {
 			return perrors.NewProtocolErrorWithErrMsg(err, fmt.Sprintf("thrift unmarshal, ReadMessageEnd failed: %s", err.Error()))
 		}
-		return exception
+		return remote.NewTransError(exception.TypeId(), exception)
 	}
 	// Must check after Exception handle.
 	// For server side, the following error can be sent back and 'SetSeqID' should be executed first to ensure the seqID

--- a/pkg/remote/codec/thrift/thrift_test.go
+++ b/pkg/remote/codec/thrift/thrift_test.go
@@ -177,10 +177,10 @@ func TestException(t *testing.T) {
 	in := remote.NewReaderBuffer(buf)
 	err = payloadCodec.Unmarshal(ctx, recvMsg, in)
 	test.Assert(t, err != nil)
-	thriftErr, ok := err.(thrift.TApplicationException)
+	transErr, ok := err.(*remote.TransError)
 	test.Assert(t, ok)
 	test.Assert(t, err.Error() == errInfo)
-	test.Assert(t, thriftErr.TypeId() == remote.UnknownMethod)
+	test.Assert(t, transErr.TypeID() == remote.UnknownMethod)
 }
 
 func TestTransErrorUnwrap(t *testing.T) {

--- a/pkg/remote/trans/netpollmux/server_handler.go
+++ b/pkg/remote/trans/netpollmux/server_handler.go
@@ -358,10 +358,13 @@ func (t *svrTransHandler) OnError(ctx context.Context, err error, conn net.Conn)
 		}
 		remote := rpcinfo.AsMutableEndpointInfo(ri.From())
 		remote.SetTag(rpcinfo.RemoteClosedTag, "1")
-	} else if pe, ok := err.(*kerrors.DetailedError); ok {
-		klog.CtxErrorf(ctx, "KITEX: processing request error, remoteService=%s, remoteAddr=%v, error=%s\nstack=%s", rService, rAddr, err.Error(), pe.Stack())
 	} else {
-		klog.CtxErrorf(ctx, "KITEX: processing request error, remoteService=%s, remoteAddr=%v, error=%s", rService, rAddr, err.Error())
+		var de *kerrors.DetailedError
+		if ok := errors.As(err, &de); ok && de.Stack() != "" {
+			klog.CtxErrorf(ctx, "KITEX: processing request error, remoteService=%s, remoteAddr=%v, error=%s\nstack=%s", rService, rAddr, err.Error(), de.Stack())
+		} else {
+			klog.CtxErrorf(ctx, "KITEX: processing request error, remoteService=%s, remoteAddr=%v, error=%s", rService, rAddr, err.Error())
+		}
 	}
 }
 

--- a/pkg/remote/trans/nphttp2/client_conn.go
+++ b/pkg/remote/trans/nphttp2/client_conn.go
@@ -92,7 +92,7 @@ func (c *clientConn) Read(b []byte) (n int, err error) {
 			err = statusErr
 		}
 	}
-	return n, convertErrorFromGrpcToKitex(err)
+	return n, err
 }
 
 func (c *clientConn) Write(b []byte) (n int, err error) {
@@ -109,7 +109,7 @@ func (c *clientConn) WriteFrame(hdr, data []byte) (n int, err error) {
 		grpcConnOpt.Last = true
 	}
 	err = c.tr.Write(c.s, hdr, data, grpcConnOpt)
-	return len(hdr) + len(data), convertErrorFromGrpcToKitex(err)
+	return len(hdr) + len(data), err
 }
 
 func (c *clientConn) LocalAddr() net.Addr                { return c.tr.LocalAddr() }

--- a/pkg/remote/trans/nphttp2/codes_test.go
+++ b/pkg/remote/trans/nphttp2/codes_test.go
@@ -17,44 +17,20 @@
 package nphttp2
 
 import (
-	"context"
+	"errors"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/kerrors"
+	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 
-func TestConvertFromKitexToGrpc(t *testing.T) {
-	// test convertFromKitexToGrpc() ok status
-	status := convertFromKitexToGrpc(nil)
-	test.Assert(t, status.Code() == codes.OK)
-
-	// test convertFromKitexToGrpc() kitex err status
-	status = convertFromKitexToGrpc(kerrors.ErrACL)
-	test.Assert(t, status.Code() == codes.PermissionDenied)
-
-	// test convertFromKitexToGrpc() err status
-	status = convertFromKitexToGrpc(context.Canceled)
-	test.Assert(t, status.Code() == codes.Internal)
-}
-
-func TestConvertErrorFromGrpcToKitex(t *testing.T) {
-	// test convertErrorFromGrpcToKitex() no err
-	err := convertErrorFromGrpcToKitex(nil)
-	test.Assert(t, err == nil, err)
-
-	// test convertErrorFromGrpcToKitex() not grpc err
-	err = convertErrorFromGrpcToKitex(context.Canceled)
-	test.Assert(t, err == context.Canceled, err)
-
-	// test convertErrorFromGrpcToKitex() grpc err
-	permissionDeniedErr := status.Errorf(codes.PermissionDenied, "grpc permission denied")
-	err = convertErrorFromGrpcToKitex(permissionDeniedErr)
-	test.Assert(t, err != nil, err)
-
-	notFoundErr := status.Errorf(codes.NotFound, "grpc not found")
-	err = convertErrorFromGrpcToKitex(notFoundErr)
-	test.Assert(t, err != nil, err)
+func TestConvertStatus(t *testing.T) {
+	test.Assert(t, convertStatus(nil).Code() == codes.OK)
+	test.Assert(t, convertStatus(errors.New("mock")).Code() == codes.Internal)
+	test.Assert(t, convertStatus(status.Err(100, "mock")).Code() == 100)
+	test.Assert(t, convertStatus(remote.NewTransErrorWithMsg(100, "mock")).Code() == 100)
+	test.Assert(t, convertStatus(kerrors.ErrInternalException).Code() == codes.Internal)
 }

--- a/pkg/remote/trans/nphttp2/server_conn.go
+++ b/pkg/remote/trans/nphttp2/server_conn.go
@@ -46,13 +46,13 @@ func (c *serverConn) ReadFrame() (hdr, data []byte, err error) {
 	hdr = make([]byte, 5)
 	_, err = c.Read(hdr)
 	if err != nil {
-		return nil, nil, convertErrorFromGrpcToKitex(err)
+		return nil, nil, err
 	}
 	dLen := int(binary.BigEndian.Uint32(hdr[1:]))
 	data = make([]byte, dLen)
 	_, err = c.Read(data)
 	if err != nil {
-		return nil, nil, convertErrorFromGrpcToKitex(err)
+		return nil, nil, err
 	}
 	return hdr, data, nil
 }
@@ -74,7 +74,7 @@ func GetServerConn(st streaming.Stream) (GRPCConn, error) {
 // impl net.Conn
 func (c *serverConn) Read(b []byte) (n int, err error) {
 	n, err = c.s.Read(b)
-	return n, convertErrorFromGrpcToKitex(err)
+	return n, err
 }
 
 func (c *serverConn) Write(b []byte) (n int, err error) {
@@ -91,7 +91,7 @@ func (c *serverConn) WriteFrame(hdr, data []byte) (n int, err error) {
 		grpcConnOpt.Last = true
 	}
 	err = c.tr.Write(c.s, hdr, data, grpcConnOpt)
-	return len(hdr) + len(data), convertErrorFromGrpcToKitex(err)
+	return len(hdr) + len(data), err
 }
 
 func (c *serverConn) LocalAddr() net.Addr                { return c.tr.LocalAddr() }

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -18,6 +18,7 @@ package nphttp2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"runtime/debug"
@@ -90,36 +91,36 @@ func (t *svrTransHandler) Read(ctx context.Context, conn net.Conn, msg remote.Me
 
 // 只 return write err
 func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
-	tr, err := grpcTransport.NewServerTransport(ctx, conn.(netpoll.Connection), t.opt.GRPCCfg)
-	if err != nil {
-		return err
+	tr, e := grpcTransport.NewServerTransport(ctx, conn.(netpoll.Connection), t.opt.GRPCCfg)
+	if e != nil {
+		return e
 	}
 	defer tr.Close()
 
 	tr.HandleStreams(func(s *grpcTransport.Stream) {
 		gofunc.GoFunc(ctx, func() {
-			ri, ctx := t.opt.InitRPCInfoFunc(s.Context(), tr.RemoteAddr())
+			ri, rCtx := t.opt.InitRPCInfoFunc(s.Context(), tr.RemoteAddr())
 			// set grpc transport flag before execute metahandler
 			rpcinfo.AsMutableRPCConfig(ri.Config()).SetTransportProtocol(transport.GRPC)
 			var err error
 			for _, shdlr := range t.opt.StreamingMetaHandlers {
-				ctx, err = shdlr.OnReadStream(ctx)
+				rCtx, err = shdlr.OnReadStream(rCtx)
 				if err != nil {
-					tr.WriteStatus(s, convertFromKitexToGrpc(err))
+					tr.WriteStatus(s, convertStatus(err))
 					return
 				}
 			}
-			ctx = t.startTracer(ctx, ri)
+			rCtx = t.startTracer(rCtx, ri)
 			defer func() {
 				panicErr := recover()
 				if panicErr != nil {
 					if conn != nil {
-						klog.CtxErrorf(ctx, "KITEX: panic happened, close conn, remoteAddress=%s, error=%s\nstack=%s", conn.RemoteAddr(), panicErr, string(debug.Stack()))
+						klog.CtxErrorf(rCtx, "KITEX: gRPC panic happened, close conn, remoteAddress=%s, error=%s\nstack=%s", conn.RemoteAddr(), panicErr, string(debug.Stack()))
 					} else {
-						klog.CtxErrorf(ctx, "KITEX: panic happened, error=%v\nstack=%s", panicErr, string(debug.Stack()))
+						klog.CtxErrorf(rCtx, "KITEX: gRPC panic happened, error=%v\nstack=%s", panicErr, string(debug.Stack()))
 					}
 				}
-				t.finishTracer(ctx, ri, err, panicErr)
+				t.finishTracer(rCtx, ri, err, panicErr)
 			}()
 
 			ink := ri.Invocation().(rpcinfo.InvocationSetter)
@@ -137,7 +138,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 			ink.SetMethodName(methodName)
 
 			if mutableTo := rpcinfo.AsMutableEndpointInfo(ri.To()); mutableTo != nil {
-				if err := mutableTo.SetMethod(methodName); err != nil {
+				if err = mutableTo.SetMethod(methodName); err != nil {
 					errDesc := fmt.Sprintf("setMethod failed in streaming, method=%s, error=%s", methodName, err.Error())
 					_ = tr.WriteStatus(s, status.New(codes.Internal, errDesc))
 					return
@@ -153,7 +154,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 				ink.SetServiceName(sm[idx+1 : pos])
 			}
 
-			st := NewStream(ctx, t.svcInfo, newServerConn(tr, s), t)
+			st := NewStream(rCtx, t.svcInfo, newServerConn(tr, s), t)
 			streamArg := &streaming.Args{Stream: st}
 
 			// check grpc method
@@ -161,8 +162,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 			if targetMethod == nil {
 				unknownServiceHandlerFunc := t.opt.GRPCUnknownServiceHandler
 				if unknownServiceHandlerFunc != nil {
-					internal_stats.Record(ctx, ri, stats.ServerHandleStart, nil)
-					err = unknownServiceHandlerFunc(ctx, methodName, st)
+					internal_stats.Record(rCtx, ri, stats.ServerHandleStart, nil)
+					err = unknownServiceHandlerFunc(rCtx, methodName, st)
 					if err != nil {
 						err = kerrors.ErrBiz.WithCause(err)
 					}
@@ -170,11 +171,12 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 					err = remote.NewTransErrorWithMsg(remote.UnknownMethod, fmt.Sprintf("unknown method %s", methodName))
 				}
 			} else {
-				err = t.inkHdlFunc(ctx, streamArg, nil)
+				err = t.inkHdlFunc(rCtx, streamArg, nil)
 			}
 
 			if err != nil {
-				tr.WriteStatus(s, convertFromKitexToGrpc(err))
+				tr.WriteStatus(s, convertStatus(err))
+				t.OnError(rCtx, err, conn)
 				return
 			}
 			tr.WriteStatus(s, status.New(codes.OK, ""))
@@ -206,10 +208,11 @@ func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 
 // 传输层 error 回调
 func (t *svrTransHandler) OnError(ctx context.Context, err error, conn net.Conn) {
-	if pe, ok := err.(*kerrors.DetailedError); ok {
-		klog.Errorf("KITEX: processing request error, remoteAddr=%s, error=%s\nstack=%s", conn.RemoteAddr(), err.Error(), pe.Stack())
+	var de *kerrors.DetailedError
+	if ok := errors.As(err, &de); ok && de.Stack() != "" {
+		klog.Errorf("KITEX: processing gRPC request error, remoteAddr=%s, error=%s\nstack=%s", conn.RemoteAddr(), err.Error(), de.Stack())
 	} else {
-		klog.Errorf("KITEX: processing request error, remoteAddr=%s, error=%s", conn.RemoteAddr(), err.Error())
+		klog.Errorf("KITEX: processing gRPC request error, remoteAddr=%s, error=%s", conn.RemoteAddr(), err.Error())
 	}
 }
 

--- a/pkg/remote/trans/nphttp2/status/status.go
+++ b/pkg/remote/trans/nphttp2/status/status.go
@@ -18,10 +18,10 @@
  * Modifications are Copyright 2021 CloudWeGo Authors.
  */
 
-// Package status implements errors returned by gRPC.  These errors are
+// Package status implements errors returned by gRPC. These errors are
 // serialized and transmitted on the wire between server and client, and allow
 // for additional data to be transmitted via the Details field in the status
-// proto.  gRPC service handlers should return an error created by this
+// proto. gRPC service handlers should return an error created by this
 // package, and gRPC clients should expect a corresponding error to be
 // returned from the RPC call.
 //
@@ -34,12 +34,17 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cloudwego/kitex/pkg/kerrors"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 )
+
+type Iface interface {
+	GRPCStatus() *Status
+}
 
 // Status represents an RPC status code, message, and details.  It is immutable
 // and should be created with New, Newf, or FromProto.
@@ -91,6 +96,15 @@ func (s *Status) Message() string {
 		return ""
 	}
 	return s.s.Message
+}
+
+// AppendMessage append extra msg for Status
+func (s *Status) AppendMessage(extraMsg string) *Status {
+	if s == nil || s.s == nil || extraMsg == "" {
+		return s
+	}
+	s.s.Message = fmt.Sprintf("%s %s", s.s.Message, extraMsg)
+	return s
 }
 
 // Proto returns s's status as an spb.Status proto message.
@@ -176,6 +190,9 @@ func (e *Error) Is(target error) bool {
 func FromError(err error) (s *Status, ok bool) {
 	if err == nil {
 		return nil, true
+	}
+	if kerrors.IsKitexError(err) {
+		err = errors.Unwrap(err)
 	}
 	if se, ok := err.(interface {
 		GRPCStatus() *Status

--- a/pkg/remote/trans_errors_test.go
+++ b/pkg/remote/trans_errors_test.go
@@ -30,8 +30,6 @@ func TestTransError(t *testing.T) {
 	test.Assert(t, errors.Is(transErr, io.ErrShortWrite))
 
 	transErr = NewTransError(InternalError, NewTransErrorWithMsg(100, errMsg))
-	uwErr, ok := errors.Unwrap(transErr).(*TransError)
-	test.Assert(t, ok)
-	test.Assert(t, uwErr.TypeID() == 100)
+	test.Assert(t, transErr.TypeID() == 100)
 	test.Assert(t, transErr.Error() == errMsg, transErr.Error())
 }


### PR DESCRIPTION
#### What type of PR is this?
refactor

#### What this PR does / why we need it (en: English/zh: Chinese):
en: refactor: error handler  refactor of the client/server side, try to unify the error handling of different protocols
zh: refactor: 重构 client/server 的错误处理，尽量统一不同协议的错误处理

#### Which issue(s) this PR fixes:
none
