### PR TITLE
fix: return server start err rather than fatal

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -197,7 +197,8 @@ func (s *server) Run() (err error) {
 	errCh := s.svr.Start()
 	select {
 	case err = <-errCh:
-		klog.Fatalf("KITEX: server start error: error=%s", err.Error())
+		klog.Errorf("KITEX: server start error: error=%s", err.Error())
+		return err
 	default:
 	}
 	muStartHooks.Lock()


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en: server.Run() return start err rather than fatal
zh: server.Run() 返回错误本身，而不是直接 fatal

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
