### PR TITLE
WIP: feat: support specify Listener for server by option `WithListener`

### DIFF
--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -79,6 +79,10 @@ type ServerOption struct {
 
 	PayloadCodec PayloadCodec
 
+	// Listener is used for customized need to listen addr, the priority is higher than Address.
+	Listener net.Listener
+
+	// Address is the listener addr
 	Address net.Addr
 
 	ReusePort bool

--- a/pkg/remote/remotesvr/server.go
+++ b/pkg/remote/remotesvr/server.go
@@ -65,11 +65,15 @@ func (s *server) Start() chan error {
 	s.listener = ln
 	s.Unlock()
 
-	go func() { errCh <- s.transSvr.BootstrapServer() }()
+	go func() { errCh <- s.transSvr.BootstrapServer(ln) }()
 	return errCh
 }
 
 func (s *server) buildListener() (ln net.Listener, err error) {
+	if s.opt.Listener != nil {
+		klog.Infof("KITEX: server listen at addr=%s", s.opt.Listener.Addr().String())
+		return s.opt.Listener, nil
+	}
 	addr := s.opt.Address
 	if ln, err = s.transSvr.CreateListener(addr); err != nil {
 		klog.Errorf("KITEX: server listen failed, addr=%s error=%s", addr.String(), err)

--- a/pkg/remote/trans_server.go
+++ b/pkg/remote/trans_server.go
@@ -30,7 +30,7 @@ type TransServerFactory interface {
 // TransServer is the abstraction for remote server.
 type TransServer interface {
 	CreateListener(net.Addr) (net.Listener, error)
-	BootstrapServer() (err error)
+	BootstrapServer(net.Listener) (err error)
 	Shutdown() error
 	ConnCount() utils.AtomicInt
 }

--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -22,6 +22,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 
 	internal_server "github.com/cloudwego/kitex/internal/server"
 	"github.com/cloudwego/kitex/pkg/acl"
@@ -161,7 +162,18 @@ func WithExitSignal(f func() <-chan error) Option {
 	}}
 }
 
-// WithReusePort sets SO_REUSEPORT on listener.
+// WithListener sets the listener for server, which is used for customized need to listen addr,
+// the priority is higher than WithServiceAddr
+func WithListener(ln net.Listener) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithListener(%+v)", ln))
+
+		o.RemoteOpt.Listener = ln
+	}}
+}
+
+// WithReusePort sets SO_REUSEPORT on listener, it is only used with Option `WithServiceAddr`.
+// It cannot be effective for specifying Listener by `WithListener`.
 func WithReusePort(reuse bool) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithReusePort(%+v)", reuse))


### PR DESCRIPTION
#### What type of PR is this?
feature

#### What this PR does / why we need it (en: English/zh: Chinese):
en: feat: support specify Listener for server by option `WithListener`, the priority is higher than `WithServiceAddr`
zh: feat: 服务端支持通过 `WithListener` 配置 listener，其优先级高于 `WithServiceAddr`

#### Which issue(s) this PR fixes:
related https://github.com/cloudwego/kitex/pull/518/files
