### PR TITLE
fix: cbsuite need set default config when new

### DIFF
--- a/pkg/circuitbreak/cbsuite.go
+++ b/pkg/circuitbreak/cbsuite.go
@@ -84,6 +84,7 @@ type CBSuite struct {
 // because event.Queue and event.Bus are not shared with all clients now.
 func NewCBSuite(genKey GenServiceCBKeyFunc) *CBSuite {
 	s := &CBSuite{genServiceCBKey: genKey}
+	s.instanceCBConfig = instanceCBConfig{CBConfig: defaultCBConfig}
 	return s
 }
 
@@ -199,7 +200,6 @@ func (s *CBSuite) initInstanceCB() {
 	if s.instancePanel != nil && s.instanceControl != nil {
 		return
 	}
-	s.instanceCBConfig = instanceCBConfig{CBConfig: defaultCBConfig}
 	opts := circuitbreaker.Options{
 		ShouldTripWithKey: s.insTripFunc,
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: `cbsuite` need set default config when `new`, lazy loading in `init` will invalidate user-defined config.
zh: `cbsuite` 应该在 `New` 方法里设置默认值，`init` 懒加载会导致用户自定义配置失效。

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none