### PR TITLE
feat:  js_conv annotation of generic call supports map type conversion

### DIFF
--- a/pkg/generic/descriptor/value_mapping.go
+++ b/pkg/generic/descriptor/value_mapping.go
@@ -59,6 +59,26 @@ func (m *apiJSConv) Request(ctx context.Context, val interface{}, field *FieldDe
 			}
 		}
 		return res, nil
+	case map[interface{}]interface{}:
+		nv := make(map[interface{}]interface{}, len(v))
+		for key, value := range v {
+			nvalue, err := m.Request(ctx, value, field)
+			if err != nil {
+				return nil, err
+			}
+			nv[key] = nvalue
+		}
+		return nv, nil
+	case map[string]interface{}:
+		nv := make(map[string]interface{}, len(v))
+		for key, value := range v {
+			nvalue, err := m.Request(ctx, value, field)
+			if err != nil {
+				return nil, err
+			}
+			nv[key] = nvalue
+		}
+		return nv, nil
 	}
 	return val, nil
 }
@@ -77,6 +97,26 @@ func (m *apiJSConv) Response(ctx context.Context, val interface{}, field *FieldD
 			}
 		}
 		return res, nil
+	case map[interface{}]interface{}:
+		nv := make(map[interface{}]interface{}, len(v))
+		for key, value := range v {
+			nvalue, err := m.Response(ctx, value, field)
+			if err != nil {
+				return nil, err
+			}
+			nv[key] = nvalue
+		}
+		return nv, nil
+	case map[string]interface{}:
+		nv := make(map[string]interface{}, len(v))
+		for key, value := range v {
+			nvalue, err := m.Response(ctx, value, field)
+			if err != nil {
+				return nil, err
+			}
+			nv[key] = nvalue
+		}
+		return nv, nil
 	}
 	return val, nil
 }

--- a/pkg/generic/descriptor/value_mapping_test.go
+++ b/pkg/generic/descriptor/value_mapping_test.go
@@ -39,6 +39,10 @@ func Test_apiJSConv_Request(t *testing.T) {
 		{"not_valid_string", args{context.Background(), "124x", nil}, int64(0), false},
 		{"[]string", args{context.Background(), []interface{}{"124", "567"}, nil}, []interface{}{int64(124), int64(567)}, false},
 		{"not_valid_[]string", args{context.Background(), []interface{}{"124x", "567"}, nil}, []interface{}{int64(0), int64(567)}, false},
+		{"map[string]string", args{context.Background(), map[string]interface{}{"a": "123"}, nil}, map[string]interface{}{"a": int64(123)}, false},
+		{"map[string][]string", args{context.Background(), map[string]interface{}{"a": []interface{}{"123", "321"}}, nil}, map[string]interface{}{"a": []interface{}{int64(123), int64(321)}}, false},
+		{"map[int][]string", args{context.Background(), map[interface{}]interface{}{789: []interface{}{"123", "321"}}, nil}, map[interface{}]interface{}{789: []interface{}{int64(123), int64(321)}}, false},
+		{"map[int]map[string]string", args{context.Background(), map[interface{}]interface{}{789: map[string]interface{}{"a": "123"}}, nil}, map[interface{}]interface{}{789: map[string]interface{}{"a": int64(123)}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +75,10 @@ func Test_apiJSConv_Response(t *testing.T) {
 		// TODO: Add test cases.
 		{"int64", args{context.Background(), int64(124), nil}, "124", false},
 		{"[]int64", args{context.Background(), []interface{}{int64(124), int64(567)}, nil}, []interface{}{"124", "567"}, false},
+		{"map[string]i64", args{context.Background(), map[string]interface{}{"a": int64(123)}, nil}, map[string]interface{}{"a": "123"}, false},
+		{"map[string][]i64", args{context.Background(), map[string]interface{}{"a": []interface{}{int64(123), int64(321)}}, nil}, map[string]interface{}{"a": []interface{}{"123", "321"}}, false},
+		{"map[int][]i64", args{context.Background(), map[interface{}]interface{}{789: []interface{}{int64(123), int64(321)}}, nil}, map[interface{}]interface{}{789: []interface{}{"123", "321"}}, false},
+		{"map[int]map[string]i64", args{context.Background(), map[interface{}]interface{}{789: map[string]interface{}{"a": int64(123)}}, nil}, map[interface{}]interface{}{789: map[string]interface{}{"a": "123"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### What this PR does / why we need it (en: English/zh: Chinese):
en: js_conv annotation of generic call supports map type conversion.
zh: 泛化调用js_conv注解支持map类型转换。

#### Which issue(s) this PR fixes:
