### PR TITLE
perf: use inline function to improve hyper codec check

### DIFF
--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -82,7 +82,8 @@ func (c thriftCodec) Marshal(ctx context.Context, message remote.Message, out re
 
 	// 2. encode thrift
 	// encode with hyper codec
-	if c.hasHyperMarshal(data) {
+	// NOTE: to ensure hyperMarshalEnabled is inlined so split the check logic, or it may cause performance loss
+	if c.hyperMarshalEnabled() && hyperMarshalAvailable(data) {
 		if err := c.hyperMarshal(data, message, out); err != nil {
 			return err
 		}
@@ -171,7 +172,7 @@ func (c thriftCodec) Unmarshal(ctx context.Context, message remote.Message, in r
 	data := message.Data()
 
 	// decode with hyper unmarshal
-	if c.hasHyperMessageUnmarshal(data, message) {
+	if c.hyperMarshalEnabled() && hyperMessageUnmarshalAvailable(data, message) {
 		msgBeginLen := bthrift.Binary.MessageBeginLength(methodName, msgType, seqID)
 		ri := message.RPCInfo()
 		internal_stats.Record(ctx, ri, stats.WaitReadStart, nil)

--- a/pkg/remote/codec/thrift/thrift_amd64.go
+++ b/pkg/remote/codec/thrift/thrift_amd64.go
@@ -34,11 +34,13 @@ const (
 	FrugalRead
 )
 
-// hasHyperMarshal indicates that if there are high priority message codec for current platform.
-func (c thriftCodec) hasHyperMarshal(data interface{}) bool {
-	if c.CodecType&FrugalWrite == 0 {
-		return false
-	}
+// hyperMarshalEnabled indicates that if there are high priority message codec for current platform.
+func (c thriftCodec) hyperMarshalEnabled() bool {
+	return c.CodecType&FrugalWrite != 0
+}
+
+// hyperMarshalAvailable indicates that if high priority message codec is available.
+func hyperMarshalAvailable(data interface{}) bool {
 	dt := reflect.TypeOf(data).Elem()
 	if dt.NumField() > 0 && dt.Field(0).Tag.Get("frugal") == "" {
 		return false
@@ -46,11 +48,13 @@ func (c thriftCodec) hasHyperMarshal(data interface{}) bool {
 	return true
 }
 
-// hasHyperUnmarshal indicates that if there are high priority message codec for current platform.
-func (c thriftCodec) hasHyperMessageUnmarshal(data interface{}, message remote.Message) bool {
-	if c.CodecType&FrugalRead == 0 {
-		return false
-	}
+// hyperMessageUnmarshalEnabled indicates that if there are high priority message codec for current platform.
+func (c thriftCodec) hyperMessageUnmarshalEnabled() bool {
+	return c.CodecType&FrugalRead != 0
+}
+
+// hyperMessageUnmarshalAvailable indicates that if high priority message codec is available.
+func hyperMessageUnmarshalAvailable(data interface{}, message remote.Message) bool {
 	if message.PayloadLen() == 0 {
 		return false
 	}

--- a/pkg/remote/codec/thrift/thrift_amd64_test.go
+++ b/pkg/remote/codec/thrift/thrift_amd64_test.go
@@ -72,28 +72,28 @@ func initFrugalTagRecvMsg() remote.Message {
 	return msg
 }
 
-func TestHasHyperCodec(t *testing.T) {
+func TestHyperCodecCheck(t *testing.T) {
 	msg := initFrugalTagRecvMsg()
 	msg.SetPayloadLen(0)
 	codec := &thriftCodec{}
 
 	// test CodecType check
-	test.Assert(t, codec.hasHyperMarshal(&MockFrugalTagArgs{}) == false)
+	test.Assert(t, codec.hyperMarshalEnabled() == false)
 	msg.SetPayloadLen(1)
-	test.Assert(t, codec.hasHyperMessageUnmarshal(&MockFrugalTagArgs{}, msg) == false)
+	test.Assert(t, codec.hyperMessageUnmarshalEnabled() == false)
 	msg.SetPayloadLen(0)
 
 	// test hyperMarshal check
 	codec = &thriftCodec{FrugalWrite}
-	test.Assert(t, codec.hasHyperMarshal(&MockNoTagArgs{}) == false)
-	test.Assert(t, codec.hasHyperMarshal(&MockFrugalTagArgs{}) == true)
+	test.Assert(t, hyperMarshalAvailable(&MockNoTagArgs{}) == false)
+	test.Assert(t, hyperMarshalAvailable(&MockFrugalTagArgs{}) == true)
 
 	// test hyperMessageUnmarshal check
 	codec = &thriftCodec{FrugalRead}
-	test.Assert(t, codec.hasHyperMessageUnmarshal(&MockNoTagArgs{}, msg) == false)
-	test.Assert(t, codec.hasHyperMessageUnmarshal(&MockFrugalTagArgs{}, msg) == false)
+	test.Assert(t, hyperMessageUnmarshalAvailable(&MockNoTagArgs{}, msg) == false)
+	test.Assert(t, hyperMessageUnmarshalAvailable(&MockFrugalTagArgs{}, msg) == false)
 	msg.SetPayloadLen(1)
-	test.Assert(t, codec.hasHyperMessageUnmarshal(&MockFrugalTagArgs{}, msg) == true)
+	test.Assert(t, hyperMessageUnmarshalAvailable(&MockFrugalTagArgs{}, msg) == true)
 }
 
 func TestFrugalCodec(t *testing.T) {

--- a/pkg/remote/codec/thrift/thrift_others.go
+++ b/pkg/remote/codec/thrift/thrift_others.go
@@ -23,13 +23,23 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote"
 )
 
-// hasHyperMarshal indicates that if there are high priority message codec for current platform.
-func (c thriftCodec) hasHyperMarshal(data interface{}) bool {
+// hyperMarshalEnabled indicates that if there are high priority message codec for current platform.
+func (c thriftCodec) hyperMarshalEnabled() bool {
 	return false
 }
 
-// hasHyperUnmarshal indicates that if there are high priority message codec for current platform.
-func (c thriftCodec) hasHyperMessageUnmarshal(data interface{}, message remote.Message) bool {
+// hyperMarshalAvailable indicates that if high priority message codec is available.
+func hyperMarshalAvailable(data interface{}) bool {
+	return false
+}
+
+// hyperMessageUnmarshalEnabled indicates that if there are high priority message codec for current platform.
+func (c thriftCodec) hyperMessageUnmarshalEnabled() bool {
+	return false
+}
+
+// hyperMessageUnmarshalAvailable indicates that if high priority message codec is available.
+func hyperMessageUnmarshalAvailable(data interface{}, message remote.Message) bool {
 	return false
 }
 


### PR DESCRIPTION
#### What type of PR is this?
perf

#### What this PR does / why we need it (en: English/zh: Chinese):
en: use inline function to improve hyper codec check
zh: 使用 inline 函数优化 hyper codec 检测的性能

benchmark:
```text
goos: darwin
goarch: amd64
pkg: github.com/cloudwego/kitex/pkg/remote/codec/thrift
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkNormalParallel
BenchmarkNormalParallel-12              129355              9625 ns/op            2271 B/op         39 allocs/op
BenchmarkNormalParallelInLine
BenchmarkNormalParallelInLine-12        144250              8187 ns/op            2271 B/op         39 allocs/op
```

#### Which issue(s) this PR fixes:
none
