### PR TITLE
perf: grpc uses mcache to reuse buffer when encoding

### DIFF
--- a/pkg/remote/codec/protobuf/grpc.go
+++ b/pkg/remote/codec/protobuf/grpc.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/bytedance/gopkg/lang/mcache"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/cloudwego/kitex/pkg/protocol/bprotoc"
@@ -56,14 +57,14 @@ func (c *grpcCodec) Encode(ctx context.Context, message remote.Message, out remo
 	case bprotoc.FastWrite:
 		// TODO: reuse data buffer when we can free it safely
 		size := t.Size()
-		data = make([]byte, size+5)
+		data = mcache.Malloc(size + 5)
 		t.FastWrite(data[5:])
 		binary.BigEndian.PutUint32(data[1:5], uint32(size))
 		return writer.WriteData(data)
 	case marshaler:
 		// TODO: reuse data buffer when we can free it safely
 		size := t.Size()
-		data = make([]byte, size+5)
+		data = mcache.Malloc(size + 5)
 		if _, err = t.MarshalTo(data[5:]); err != nil {
 			return err
 		}

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -594,6 +594,9 @@ func (t *http2Client) Write(s *Stream, hdr, data []byte, opts *Options) error {
 		h:         hdr,
 		d:         data,
 	}
+	if len(hdr) == 0 && len(data) != 0 {
+		df.dcache = data
+	}
 	if hdr != nil || data != nil { // If it's not an empty data frame, check quota.
 		if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 			return err

--- a/pkg/remote/trans/nphttp2/grpc/http2_server.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_server.go
@@ -822,6 +822,9 @@ func (t *http2Server) Write(s *Stream, hdr, data []byte, opts *Options) error {
 		d:           data,
 		onEachWrite: t.setResetPingStrikes,
 	}
+	if len(hdr) == 0 && len(data) != 0 {
+		df.dcache = data
+	}
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
 		select {
 		case <-t.done:


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

feat
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: grpc uses mcache to reuse buffer when encoding,  benchmark shown as:

unary qps ↑2.5%-3.8%, streaming qps ↑15.7%-19.4%
```
unary: 
[KITEX],100,1024,126494.83,2.10,2.61      =>   [KITEX],100,1024,131297.97,2.10,2.61
[KITEX],1000,1024,174776.32,12.60,18.44   =>   [KITEX],1000,1024,179182.75,12.08,18.04

streaming:
[KITEX],100,1024,256200.16,1.33,1.53      =>   [KITEX],100,1024,296348.53,1.24,1.44
[KITEX],1000,1024,371476.67,6.94,8.29    =>   [KITEX],1000,1024,443618.21,6.87,8.30
```

zh: kitex grpc 编码阶段使用 mcache 复用内存 (此优化存在代码耦合，未来会重新整理)。

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none