### PR TITLE
WIP: perf: dataFrame use netpoll.Reader

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -10,9 +10,11 @@ header:
   paths-ignore:
     - internal/mocks/thrift/test.go
     - pkg/remote/trans/nphttp2/codes/codes.go
+    - pkg/remote/trans/nphttp2/grpc/grpcframe/
     - pkg/remote/trans/nphttp2/grpc/bdp_estimator.go
     - pkg/remote/trans/nphttp2/grpc/controlbuf.go
     - pkg/remote/trans/nphttp2/grpc/defaults.go
+    - pkg/remote/trans/nphttp2/grpc/framer.go
     - pkg/remote/trans/nphttp2/grpc/flowcontrol.go
     - pkg/remote/trans/nphttp2/grpc/http2_client.go
     - pkg/remote/trans/nphttp2/grpc/http2_server.go

--- a/pkg/remote/trans/nphttp2/grpc/controlbuf.go
+++ b/pkg/remote/trans/nphttp2/grpc/controlbuf.go
@@ -134,8 +134,12 @@ func (c *cleanupStream) isTransportResponseFrame() bool { return c.rst } // Resu
 type dataFrame struct {
 	streamID  uint32
 	endStream bool
-	h         []byte
-	d         []byte
+	// h is optional, d is required.
+	// you can assign the header to h and the payload to the d;
+	// or just assign the header + payload together to the d.
+	// In other words, h = nil means d = header + payload.
+	h []byte
+	d []byte
 	// onEachWrite is called every time
 	// a part of d is written out.
 	onEachWrite func()

--- a/pkg/remote/trans/nphttp2/grpc/framer.go
+++ b/pkg/remote/trans/nphttp2/grpc/framer.go
@@ -1,0 +1,86 @@
+package grpc
+
+import (
+	"io"
+	"net"
+
+	"github.com/cloudwego/netpoll"
+	"golang.org/x/net/http2/hpack"
+
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/grpcframe"
+)
+
+type framer struct {
+	*grpcframe.Framer
+	reader netpoll.Reader
+	writer *bufWriter
+}
+
+func newFramer(conn net.Conn, writeBufferSize, readBufferSize, maxHeaderListSize uint32) *framer {
+	var r netpoll.Reader
+	if npconn, ok := conn.(netpoll.Connection); ok {
+		r = npconn.Reader()
+	} else {
+		r = netpoll.NewReader(conn)
+	}
+	w := newBufWriter(conn, int(writeBufferSize))
+	fr := &framer{
+		reader: r,
+		writer: w,
+		Framer: grpcframe.NewFramer(w, r),
+	}
+	fr.SetMaxReadFrameSize(http2MaxFrameLen)
+	// Opt-in to Frame reuse API on framer to reduce garbage.
+	// Frames aren't safe to read from after a subsequent call to ReadFrame.
+	fr.SetReuseFrames()
+	fr.MaxHeaderListSize = maxHeaderListSize
+	fr.ReadMetaHeaders = hpack.NewDecoder(http2InitHeaderTableSize, nil)
+	return fr
+}
+
+type bufWriter struct {
+	writer    io.Writer
+	buf       []byte
+	offset    int
+	batchSize int
+	err       error
+}
+
+func newBufWriter(writer io.Writer, batchSize int) *bufWriter {
+	return &bufWriter{
+		buf:       make([]byte, batchSize*2),
+		batchSize: batchSize,
+		writer:    writer,
+	}
+}
+
+func (w *bufWriter) Write(b []byte) (n int, err error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	if w.batchSize == 0 { // buffer has been disabled.
+		return w.writer.Write(b)
+	}
+	for len(b) > 0 {
+		nn := copy(w.buf[w.offset:], b)
+		b = b[nn:]
+		w.offset += nn
+		n += nn
+		if w.offset >= w.batchSize {
+			err = w.Flush()
+		}
+	}
+	return n, err
+}
+
+func (w *bufWriter) Flush() error {
+	if w.err != nil {
+		return w.err
+	}
+	if w.offset == 0 {
+		return nil
+	}
+	_, w.err = w.writer.Write(w.buf[:w.offset])
+	w.offset = 0
+	return w.err
+}

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/errors.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/errors.go
@@ -1,0 +1,57 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grpcframe
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/net/http2"
+)
+
+// connError represents an HTTP/2 ConnectionError error code, along
+// with a string (for debugging) explaining why.
+//
+// Errors of this type are only returned by the frame parser functions
+// and converted into ConnectionError(Code), after stashing away
+// the Reason into the Framer's errDetail field, accessible via
+// the (*Framer).ErrorDetail method.
+type connError struct {
+	Code   http2.ErrCode // the ConnectionError error code
+	Reason string        // additional reason
+}
+
+func (e connError) Error() string {
+	return fmt.Sprintf("http2: connection error: %v: %v", e.Code, e.Reason)
+}
+
+type pseudoHeaderError string
+
+func (e pseudoHeaderError) Error() string {
+	return fmt.Sprintf("invalid pseudo-header %q", string(e))
+}
+
+type duplicatePseudoHeaderError string
+
+func (e duplicatePseudoHeaderError) Error() string {
+	return fmt.Sprintf("duplicate pseudo-header %q", string(e))
+}
+
+type headerFieldNameError string
+
+func (e headerFieldNameError) Error() string {
+	return fmt.Sprintf("invalid header field name %q", string(e))
+}
+
+type headerFieldValueError string
+
+func (e headerFieldValueError) Error() string {
+	return fmt.Sprintf("invalid header field value %q", string(e))
+}
+
+var (
+	errMixPseudoHeaderTypes = errors.New("mix of request and response pseudo headers")
+	errPseudoAfterRegular   = errors.New("pseudo header field after regular")
+)

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/errors_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/errors_test.go
@@ -1,0 +1,28 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grpcframe
+
+import (
+	"testing"
+
+	"golang.org/x/net/http2"
+)
+
+func TestErrCodeString(t *testing.T) {
+	tests := []struct {
+		err  http2.ErrCode
+		want string
+	}{
+		{http2.ErrCodeProtocol, "PROTOCOL_ERROR"},
+		{0xd, "HTTP_1_1_REQUIRED"},
+		{0xf, "unknown error code 0xf"},
+	}
+	for i, tt := range tests {
+		got := tt.err.String()
+		if got != tt.want {
+			t.Errorf("%d. Error = %q; want %q", i, got, tt.want)
+		}
+	}
+}

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_parser.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_parser.go
@@ -1,0 +1,570 @@
+/*
+ * Copyright 2021 The Go Authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ *
+ * This file may have been modified by CloudWeGo authors. All CloudWeGo
+ * Modifications are Copyright 2022 CloudWeGo Authors.
+ */
+
+package grpcframe
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cloudwego/netpoll"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+/* struct:
+ * DataFrame
+ * HeadersFrame
+ * SettingsFrame
+ * PushPromiseFrame
+ * GoAwayFrame
+ * ContinuationFrame
+ * MetaHeadersFrame
+ */
+
+// a frameParser parses a frame given its FrameHeader and payload
+// bytes. The length of payload will always equal fh.Length (which
+// might be 0).
+type frameParser func(fc *frameCache, fh http2.FrameHeader, payload []byte) (http2.Frame, error)
+
+var frameParsers = []frameParser{
+	// FrameData:         parseDataFrame,
+	http2.FrameHeaders:      parseHeadersFrame,
+	http2.FramePriority:     parsePriorityFrame,
+	http2.FrameRSTStream:    parseRSTStreamFrame,
+	http2.FrameSettings:     parseSettingsFrame,
+	http2.FramePushPromise:  parsePushPromise,
+	http2.FramePing:         parsePingFrame,
+	http2.FrameGoAway:       parseGoAwayFrame,
+	http2.FrameWindowUpdate: parseWindowUpdateFrame,
+	http2.FrameContinuation: parseContinuationFrame,
+}
+
+func typeFrameParser(t http2.FrameType) frameParser {
+	if 1 <= t && t <= 9 {
+		return frameParsers[t]
+	}
+	return parseUnknownFrame
+}
+
+// A DataFrame conveys arbitrary, variable-length sequences of octets
+// associated with a stream.
+// See http://http2.github.io/http2-spec/#rfc.section.6.1
+type DataFrame struct {
+	http2.FrameHeader
+	data []byte // TODO: data = netpoll.Reader here
+}
+
+func (f *DataFrame) StreamEnded() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagDataEndStream)
+}
+
+// Data returns the frame's data octets, not including any padding
+// size byte or padding suffix bytes.
+// The caller must not retain the returned memory past the next
+// call to ReadFrame.
+func (f *DataFrame) Data() []byte {
+	return f.data
+}
+
+func parseDataFrame(fc *frameCache, fh http2.FrameHeader, payload netpoll.Reader) (http2.Frame, error) {
+	if fh.StreamID == 0 {
+		// DATA frames MUST be associated with a stream. If a
+		// DATA frame is received whose stream identifier
+		// field is 0x0, the recipient MUST respond with a
+		// connection error (Section 5.4.1) of type
+		// PROTOCOL_ERROR.
+		return nil, connError{http2.ErrCodeProtocol, "DATA frame with stream ID 0"}
+	}
+	f := fc.getDataFrame()
+	f.FrameHeader = fh
+
+	var padSize byte
+	payloadLen := int(fh.Length)
+	if fh.Flags.Has(http2.FlagDataPadded) {
+		var err error
+		padSize, err = payload.ReadByte()
+		payloadLen--
+		if err != nil {
+			return nil, err
+		}
+	}
+	if int(padSize) > payloadLen {
+		// If the length of the padding is greater than the
+		// length of the frame payload, the recipient MUST
+		// treat this as a connection error.
+		// Filed: https://github.com/http2/http2-spec/issues/610
+		return nil, connError{http2.ErrCodeProtocol, "pad size larger than data payload"}
+	}
+	data, err := payload.Next(payloadLen)
+	f.data = data[:payloadLen-int(padSize)]
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// A HeadersFrame is used to open a stream and additionally carries a
+// header block fragment.
+type HeadersFrame struct {
+	http2.FrameHeader
+
+	// Priority is set if FlagHeadersPriority is set in the FrameHeader.
+	Priority http2.PriorityParam
+
+	headerFragBuf []byte // not owned
+}
+
+func (f *HeadersFrame) HeaderBlockFragment() []byte {
+	return f.headerFragBuf
+}
+
+func (f *HeadersFrame) HeadersEnded() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagHeadersEndHeaders)
+}
+
+func (f *HeadersFrame) StreamEnded() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagHeadersEndStream)
+}
+
+func (f *HeadersFrame) HasPriority() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagHeadersPriority)
+}
+
+func parseHeadersFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (_ http2.Frame, err error) {
+	hf := &HeadersFrame{
+		FrameHeader: fh,
+	}
+	if fh.StreamID == 0 {
+		// HEADERS frames MUST be associated with a stream. If a HEADERS frame
+		// is received whose stream identifier field is 0x0, the recipient MUST
+		// respond with a connection error (Section 5.4.1) of type
+		// PROTOCOL_ERROR.
+		return nil, connError{http2.ErrCodeProtocol, "HEADERS frame with stream ID 0"}
+	}
+	var padLength uint8
+	if fh.Flags.Has(http2.FlagHeadersPadded) {
+		if p, padLength, err = readByte(p); err != nil {
+			return
+		}
+	}
+	if fh.Flags.Has(http2.FlagHeadersPriority) {
+		var v uint32
+		p, v, err = readUint32(p)
+		if err != nil {
+			return nil, err
+		}
+		hf.Priority.StreamDep = v & 0x7fffffff
+		hf.Priority.Exclusive = (v != hf.Priority.StreamDep) // high bit was set
+		p, hf.Priority.Weight, err = readByte(p)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(p)-int(padLength) <= 0 {
+		return nil, http2.StreamError{StreamID: fh.StreamID, Code: http2.ErrCodeProtocol}
+	}
+	hf.headerFragBuf = p[:len(p)-int(padLength)]
+	return hf, nil
+}
+
+func parsePriorityFrame(_ *frameCache, fh http2.FrameHeader, payload []byte) (http2.Frame, error) {
+	if fh.StreamID == 0 {
+		return nil, connError{http2.ErrCodeProtocol, "PRIORITY frame with stream ID 0"}
+	}
+	if len(payload) != 5 {
+		return nil, connError{http2.ErrCodeFrameSize, fmt.Sprintf("PRIORITY frame payload size was %d; want 5", len(payload))}
+	}
+	v := binary.BigEndian.Uint32(payload[:4])
+	streamID := v & 0x7fffffff // mask off high bit
+	return &http2.PriorityFrame{
+		FrameHeader: fh,
+		PriorityParam: http2.PriorityParam{
+			Weight:    payload[4],
+			StreamDep: streamID,
+			Exclusive: streamID != v, // was high bit set?
+		},
+	}, nil
+}
+
+func parseRSTStreamFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (http2.Frame, error) {
+	if len(p) != 4 {
+		return nil, http2.ConnectionError(http2.ErrCodeFrameSize)
+	}
+	if fh.StreamID == 0 {
+		return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+	}
+	return &http2.RSTStreamFrame{FrameHeader: fh, ErrCode: http2.ErrCode(binary.BigEndian.Uint32(p[:4]))}, nil
+}
+
+// A SettingsFrame conveys configuration parameters that affect how
+// endpoints communicate, such as preferences and constraints on peer
+// behavior.
+//
+// See http://http2.github.io/http2-spec/#SETTINGS
+type SettingsFrame struct {
+	http2.FrameHeader
+	p []byte
+}
+
+func parseSettingsFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (http2.Frame, error) {
+	if fh.Flags.Has(http2.FlagSettingsAck) && fh.Length > 0 {
+		// When this (ACK 0x1) bit is set, the payload of the
+		// SETTINGS frame MUST be empty. Receipt of a
+		// SETTINGS frame with the ACK flag set and a length
+		// field value other than 0 MUST be treated as a
+		// connection error (Section 5.4.1) of type
+		// FRAME_SIZE_ERROR.
+		return nil, http2.ConnectionError(http2.ErrCodeFrameSize)
+	}
+	if fh.StreamID != 0 {
+		// SETTINGS frames always apply to a connection,
+		// never a single stream. The stream identifier for a
+		// SETTINGS frame MUST be zero (0x0).  If an endpoint
+		// receives a SETTINGS frame whose stream identifier
+		// field is anything other than 0x0, the endpoint MUST
+		// respond with a connection error (Section 5.4.1) of
+		// type PROTOCOL_ERROR.
+		return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+	}
+	if len(p)%6 != 0 {
+		// Expecting even number of 6 byte settings.
+		return nil, http2.ConnectionError(http2.ErrCodeFrameSize)
+	}
+	f := &SettingsFrame{FrameHeader: fh, p: p}
+	if v, ok := f.Value(http2.SettingInitialWindowSize); ok && v > (1<<31)-1 {
+		// Values above the maximum flow control window size of 2^31 - 1 MUST
+		// be treated as a connection error (Section 5.4.1) of type
+		// FLOW_CONTROL_ERROR.
+		return nil, http2.ConnectionError(http2.ErrCodeFlowControl)
+	}
+	return f, nil
+}
+
+func (f *SettingsFrame) IsAck() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagSettingsAck)
+}
+
+func (f *SettingsFrame) Value(id http2.SettingID) (v uint32, ok bool) {
+	for i := 0; i < f.NumSettings(); i++ {
+		if s := f.Setting(i); s.ID == id {
+			return s.Val, true
+		}
+	}
+	return 0, false
+}
+
+// Setting returns the setting from the frame at the given 0-based index.
+// The index must be >= 0 and less than f.NumSettings().
+func (f *SettingsFrame) Setting(i int) http2.Setting {
+	buf := f.p
+	return http2.Setting{
+		ID:  http2.SettingID(binary.BigEndian.Uint16(buf[i*6 : i*6+2])),
+		Val: binary.BigEndian.Uint32(buf[i*6+2 : i*6+6]),
+	}
+}
+
+func (f *SettingsFrame) NumSettings() int { return len(f.p) / 6 }
+
+// HasDuplicates reports whether f contains any duplicate setting IDs.
+func (f *SettingsFrame) HasDuplicates() bool {
+	num := f.NumSettings()
+	if num == 0 {
+		return false
+	}
+	// If it's small enough (the common case), just do the n^2
+	// thing and avoid a map allocation.
+	if num < 10 {
+		for i := 0; i < num; i++ {
+			idi := f.Setting(i).ID
+			for j := i + 1; j < num; j++ {
+				idj := f.Setting(j).ID
+				if idi == idj {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	seen := map[http2.SettingID]bool{}
+	for i := 0; i < num; i++ {
+		id := f.Setting(i).ID
+		if seen[id] {
+			return true
+		}
+		seen[id] = true
+	}
+	return false
+}
+
+// ForeachSetting runs fn for each setting.
+// It stops and returns the first error.
+func (f *SettingsFrame) ForeachSetting(fn func(http2.Setting) error) error {
+	for i := 0; i < f.NumSettings(); i++ {
+		if err := fn(f.Setting(i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// A PushPromiseFrame is used to initiate a server stream.
+// See http://http2.github.io/http2-spec/#rfc.section.6.6
+
+// A PushPromiseFrame is used to initiate a server stream.
+// See http://http2.github.io/http2-spec/#rfc.section.6.6
+type PushPromiseFrame struct {
+	http2.FrameHeader
+	PromiseID     uint32
+	headerFragBuf []byte // not owned
+}
+
+func (f *PushPromiseFrame) HeaderBlockFragment() []byte {
+	return f.headerFragBuf
+}
+
+func (f *PushPromiseFrame) HeadersEnded() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagPushPromiseEndHeaders)
+}
+
+func parsePushPromise(_ *frameCache, fh http2.FrameHeader, p []byte) (_ http2.Frame, err error) {
+	pp := &PushPromiseFrame{
+		FrameHeader: fh,
+	}
+	if pp.StreamID == 0 {
+		// PUSH_PROMISE frames MUST be associated with an existing,
+		// peer-initiated stream. The stream identifier of a
+		// PUSH_PROMISE frame indicates the stream it is associated
+		// with. If the stream identifier field specifies the value
+		// 0x0, a recipient MUST respond with a connection error
+		// (Section 5.4.1) of type PROTOCOL_ERROR.
+		return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+	}
+	// The PUSH_PROMISE frame includes optional padding.
+	// Padding fields and flags are identical to those defined for DATA frames
+	var padLength uint8
+	if fh.Flags.Has(http2.FlagPushPromisePadded) {
+		if p, padLength, err = readByte(p); err != nil {
+			return
+		}
+	}
+
+	p, pp.PromiseID, err = readUint32(p)
+	if err != nil {
+		return
+	}
+	pp.PromiseID = pp.PromiseID & (1<<31 - 1)
+
+	if int(padLength) > len(p) {
+		// like the DATA frame, error out if padding is longer than the body.
+		return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+	}
+	pp.headerFragBuf = p[:len(p)-int(padLength)]
+	return pp, nil
+}
+
+func parsePingFrame(_ *frameCache, fh http2.FrameHeader, payload []byte) (http2.Frame, error) {
+	if len(payload) != 8 {
+		return nil, http2.ConnectionError(http2.ErrCodeFrameSize)
+	}
+	if fh.StreamID != 0 {
+		return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+	}
+	f := &http2.PingFrame{FrameHeader: fh}
+	copy(f.Data[:], payload)
+	return f, nil
+}
+
+// A GoAwayFrame informs the remote peer to stop creating streams on this connection.
+// See http://http2.github.io/http2-spec/#rfc.section.6.8
+type GoAwayFrame struct {
+	http2.FrameHeader
+	LastStreamID uint32
+	ErrCode      http2.ErrCode
+	debugData    []byte
+}
+
+// DebugData returns any debug data in the GOAWAY frame. Its contents
+// are not defined.
+// The caller must not retain the returned memory past the next
+// call to ReadFrame.
+func (f *GoAwayFrame) DebugData() []byte {
+	return f.debugData
+}
+
+func parseGoAwayFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (http2.Frame, error) {
+	if fh.StreamID != 0 {
+		return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+	}
+	if len(p) < 8 {
+		return nil, http2.ConnectionError(http2.ErrCodeFrameSize)
+	}
+	return &GoAwayFrame{
+		FrameHeader:  fh,
+		LastStreamID: binary.BigEndian.Uint32(p[:4]) & (1<<31 - 1),
+		ErrCode:      http2.ErrCode(binary.BigEndian.Uint32(p[4:8])),
+		debugData:    p[8:],
+	}, nil
+}
+
+func parseWindowUpdateFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (http2.Frame, error) {
+	if len(p) != 4 {
+		return nil, http2.ConnectionError(http2.ErrCodeFrameSize)
+	}
+	inc := binary.BigEndian.Uint32(p[:4]) & 0x7fffffff // mask off high reserved bit
+	if inc == 0 {
+		// A receiver MUST treat the receipt of a
+		// WINDOW_UPDATE frame with an flow control window
+		// increment of 0 as a stream error (Section 5.4.2) of
+		// type PROTOCOL_ERROR; errors on the connection flow
+		// control window MUST be treated as a connection
+		// error (Section 5.4.1).
+		if fh.StreamID == 0 {
+			return nil, http2.ConnectionError(http2.ErrCodeProtocol)
+		}
+		return nil, http2.StreamError{StreamID: fh.StreamID, Code: http2.ErrCodeProtocol}
+	}
+	return &http2.WindowUpdateFrame{
+		FrameHeader: fh,
+		Increment:   inc,
+	}, nil
+}
+
+// A ContinuationFrame is used to continue a sequence of header block fragments.
+// See http://http2.github.io/http2-spec/#rfc.section.6.10
+type ContinuationFrame struct {
+	http2.FrameHeader
+	headerFragBuf []byte
+}
+
+func parseContinuationFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (http2.Frame, error) {
+	if fh.StreamID == 0 {
+		return nil, connError{http2.ErrCodeProtocol, "CONTINUATION frame with stream ID 0"}
+	}
+	return &ContinuationFrame{FrameHeader: fh, headerFragBuf: p}, nil
+}
+
+func (f *ContinuationFrame) HeaderBlockFragment() []byte {
+	return f.headerFragBuf
+}
+
+func (f *ContinuationFrame) HeadersEnded() bool {
+	return f.FrameHeader.Flags.Has(http2.FlagContinuationEndHeaders)
+}
+
+// An UnknownFrame is the frame type returned when the frame type is unknown
+// or no specific frame type parser exists.
+type UnknownFrame struct {
+	http2.FrameHeader
+	p []byte
+}
+
+// Payload returns the frame's payload (after the header).  It is not
+// valid to call this method after a subsequent call to
+// Framer.ReadFrame, nor is it valid to retain the returned slice.
+// The memory is owned by the Framer and is invalidated when the next
+// frame is read.
+func (f *UnknownFrame) Payload() []byte {
+	return f.p
+}
+
+func parseUnknownFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (http2.Frame, error) {
+	return &UnknownFrame{fh, p}, nil
+}
+
+// A MetaHeadersFrame is the representation of one HEADERS frame and
+// zero or more contiguous CONTINUATION frames and the decoding of
+// their HPACK-encoded contents.
+//
+// This type of frame does not appear on the wire and is only returned
+// by the Framer when Framer.ReadMetaHeaders is set.
+type MetaHeadersFrame struct {
+	*HeadersFrame
+
+	// Fields are the fields contained in the HEADERS and
+	// CONTINUATION frames. The underlying slice is owned by the
+	// Framer and must not be retained after the next call to
+	// ReadFrame.
+	//
+	// Fields are guaranteed to be in the correct http2 order and
+	// not have unknown pseudo header fields or invalid header
+	// field names or values. Required pseudo header fields may be
+	// missing, however. Use the MetaHeadersFrame.Pseudo accessor
+	// method access pseudo headers.
+	Fields []hpack.HeaderField
+
+	// Truncated is whether the max header list size limit was hit
+	// and Fields is incomplete. The hpack decoder state is still
+	// valid, however.
+	Truncated bool
+}
+
+// PseudoValue returns the given pseudo header field's value.
+// The provided pseudo field should not contain the leading colon.
+func (mh *MetaHeadersFrame) PseudoValue(pseudo string) string {
+	for _, hf := range mh.Fields {
+		if !hf.IsPseudo() {
+			return ""
+		}
+		if hf.Name[1:] == pseudo {
+			return hf.Value
+		}
+	}
+	return ""
+}
+
+// RegularFields returns the regular (non-pseudo) header fields of mh.
+// The caller does not own the returned slice.
+func (mh *MetaHeadersFrame) RegularFields() []hpack.HeaderField {
+	for i, hf := range mh.Fields {
+		if !hf.IsPseudo() {
+			return mh.Fields[i:]
+		}
+	}
+	return nil
+}
+
+// PseudoFields returns the pseudo header fields of mh.
+// The caller does not own the returned slice.
+func (mh *MetaHeadersFrame) PseudoFields() []hpack.HeaderField {
+	for i, hf := range mh.Fields {
+		if !hf.IsPseudo() {
+			return mh.Fields[:i]
+		}
+	}
+	return mh.Fields
+}
+
+func (mh *MetaHeadersFrame) checkPseudos() error {
+	var isRequest, isResponse bool
+	pf := mh.PseudoFields()
+	for i, hf := range pf {
+		switch hf.Name {
+		case ":method", ":path", ":scheme", ":authority":
+			isRequest = true
+		case ":status":
+			isResponse = true
+		default:
+			return pseudoHeaderError(hf.Name)
+		}
+		// Check for duplicates.
+		// This would be a bad algorithm, but N is 4.
+		// And this doesn't allocate.
+		for _, hf2 := range pf[:i] {
+			if hf.Name == hf2.Name {
+				return duplicatePseudoHeaderError(hf.Name)
+			}
+		}
+	}
+	if isRequest && isResponse {
+		return errMixPseudoHeaderTypes
+	}
+	return nil
+}

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader.go
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2021 The Go Authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ *
+ * This file may have been modified by CloudWeGo authors. All CloudWeGo
+ * Modifications are Copyright 2022 CloudWeGo Authors.
+ */
+
+package grpcframe
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cloudwego/netpoll"
+	"golang.org/x/net/http/httpguts"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+// A Framer reads and writes Frames.
+type Framer struct {
+	errDetail error
+
+	// lastHeaderStream is non-zero if the last frame was an
+	// unfinished HEADERS/CONTINUATION.
+	lastHeaderStream uint32
+	lastFrame        http2.Frame
+
+	reader      netpoll.Reader
+	maxReadSize uint32
+
+	writer io.Writer
+	wbuf   []byte
+	// maxWriteSize uint32 // zero means unlimited; TODO: implement
+
+	// AllowIllegalWrites permits the Framer's Write methods to
+	// write frames that do not conform to the HTTP/2 spec. This
+	// permits using the Framer to test other HTTP/2
+	// implementations' conformance to the spec.
+	// If false, the Write methods will prefer to return an error
+	// rather than comply.
+	AllowIllegalWrites bool
+
+	// AllowIllegalReads permits the Framer's ReadFrame method
+	// to return non-compliant frames or frame orders.
+	// This is for testing and permits using the Framer to test
+	// other HTTP/2 implementations' conformance to the spec.
+	// It is not compatible with ReadMetaHeaders.
+	AllowIllegalReads bool
+
+	// ReadMetaHeaders if non-nil causes ReadFrame to merge
+	// HEADERS and CONTINUATION frames together and return
+	// MetaHeadersFrame instead.
+	ReadMetaHeaders *hpack.Decoder
+
+	// MaxHeaderListSize is the http2 MAX_HEADER_LIST_SIZE.
+	// It's used only if ReadMetaHeaders is set; 0 means a sane default
+	// (currently 16MB)
+	// If the limit is hit, MetaHeadersFrame.Truncated is set true.
+	MaxHeaderListSize uint32
+
+	frameCache *frameCache // nil if frames aren't reused (default)
+}
+
+func (fr *Framer) maxHeaderListSize() uint32 {
+	if fr.MaxHeaderListSize == 0 {
+		return 16 << 20 // sane default, per docs
+	}
+	return fr.MaxHeaderListSize
+}
+
+const (
+	minMaxFrameSize = 1 << 14
+	maxFrameSize    = 1<<24 - 1
+)
+
+// SetReuseFrames allows the Framer to reuse Frames.
+// If called on a Framer, Frames returned by calls to ReadFrame are only
+// valid until the next call to ReadFrame.
+func (fr *Framer) SetReuseFrames() {
+	if fr.frameCache != nil {
+		return
+	}
+	fr.frameCache = &frameCache{}
+}
+
+type frameCache struct {
+	dataFrame DataFrame
+}
+
+func (fc *frameCache) getDataFrame() *DataFrame {
+	if fc == nil {
+		return &DataFrame{}
+	}
+	return &fc.dataFrame
+}
+
+// NewFramer returns a Framer that writes frames to w and reads them from r.
+func NewFramer(w io.Writer, r netpoll.Reader) *Framer {
+	fr := &Framer{
+		writer: w,
+		reader: r,
+	}
+	fr.SetMaxReadFrameSize(maxFrameSize)
+	return fr
+}
+
+// SetMaxReadFrameSize sets the maximum size of a frame
+// that will be read by a subsequent call to ReadFrame.
+// It is the caller's responsibility to advertise this
+// limit with a SETTINGS frame.
+func (fr *Framer) SetMaxReadFrameSize(v uint32) {
+	if v > maxFrameSize {
+		v = maxFrameSize
+	}
+	fr.maxReadSize = v
+}
+
+// ErrorDetail returns a more detailed error of the last error
+// returned by Framer.ReadFrame. For instance, if ReadFrame
+// returns a StreamError with code PROTOCOL_ERROR, ErrorDetail
+// will say exactly what was invalid. ErrorDetail is not guaranteed
+// to return a non-nil value and like the rest of the http2 package,
+// its return value is not protected by an API compatibility promise.
+// ErrorDetail is reset after the next call to ReadFrame.
+func (fr *Framer) ErrorDetail() error {
+	return fr.errDetail
+}
+
+// ReadFrame reads a single frame. The returned Frame is only valid
+// until the next call to ReadFrame.
+//
+// If the frame is larger than previously set with SetMaxReadFrameSize, the
+// returned error is ErrFrameTooLarge. Other errors may be of type
+// ConnectionError, StreamError, or anything else from the underlying
+// reader.
+func (fr *Framer) ReadFrame() (http2.Frame, error) {
+	fr.errDetail = nil
+
+	fh, err := readFrameHeader(fr.reader)
+	if err != nil {
+		return nil, err
+	}
+	if fh.Length > fr.maxReadSize {
+		return nil, http2.ErrFrameTooLarge
+	}
+	// payload := fr.getReadBuf(fh.Length)
+	var f http2.Frame
+	if fh.Type == http2.FrameData {
+		f, err = parseDataFrame(fr.frameCache, fh, fr.reader)
+	} else {
+		var payload []byte
+		payload, err = fr.reader.Next(int(fh.Length))
+		if err != nil {
+			return nil, err
+		}
+		f, err = typeFrameParser(fh.Type)(fr.frameCache, fh, payload)
+	}
+	if err != nil {
+		if ce, ok := err.(connError); ok {
+			return nil, fr.connError(ce.Code, ce.Reason)
+		}
+		return nil, err
+	}
+	if err = fr.checkFrameOrder(f); err != nil {
+		return nil, err
+	}
+	if fh.Type == http2.FrameHeaders && fr.ReadMetaHeaders != nil {
+		return fr.readMetaFrame(f.(*HeadersFrame))
+	}
+	return f, nil
+}
+
+// connError returns ConnectionError(code) but first
+// stashes away a public reason to the caller can optionally relay it
+// to the peer before hanging up on them. This might help others debug
+// their implementations.
+func (fr *Framer) connError(code http2.ErrCode, reason string) error {
+	fr.errDetail = errors.New(reason)
+	return http2.ConnectionError(code)
+}
+
+// checkFrameOrder reports an error if f is an invalid frame to return
+// next from ReadFrame. Mostly it checks whether HEADERS and
+// CONTINUATION frames are contiguous.
+func (fr *Framer) checkFrameOrder(f http2.Frame) error {
+	last := fr.lastFrame
+	fr.lastFrame = f
+	if fr.AllowIllegalReads {
+		return nil
+	}
+
+	fh := f.Header()
+	if fr.lastHeaderStream != 0 {
+		if fh.Type != http2.FrameContinuation {
+			return fr.connError(http2.ErrCodeProtocol,
+				fmt.Sprintf("got %s for stream %d; expected CONTINUATION following %s for stream %d",
+					fh.Type, fh.StreamID,
+					last.Header().Type, fr.lastHeaderStream))
+		}
+		if fh.StreamID != fr.lastHeaderStream {
+			return fr.connError(http2.ErrCodeProtocol,
+				fmt.Sprintf("got CONTINUATION for stream %d; expected stream %d",
+					fh.StreamID, fr.lastHeaderStream))
+		}
+	} else if fh.Type == http2.FrameContinuation {
+		return fr.connError(http2.ErrCodeProtocol, fmt.Sprintf("unexpected CONTINUATION for stream %d", fh.StreamID))
+	}
+
+	switch fh.Type {
+	case http2.FrameHeaders, http2.FrameContinuation:
+		if fh.Flags.Has(http2.FlagHeadersEndHeaders) {
+			fr.lastHeaderStream = 0
+		} else {
+			fr.lastHeaderStream = fh.StreamID
+		}
+	}
+
+	return nil
+}
+
+type headersEnder interface {
+	HeadersEnded() bool
+}
+
+type headersOrContinuation interface {
+	headersEnder
+	HeaderBlockFragment() []byte
+}
+
+func (fr *Framer) maxHeaderStringLen() int {
+	v := fr.maxHeaderListSize()
+	if uint32(int(v)) == v {
+		return int(v)
+	}
+	// They had a crazy big number for MaxHeaderBytes anyway,
+	// so give them unlimited header lengths:
+	return 0
+}
+
+// readMetaFrame returns 0 or more CONTINUATION frames from fr and
+// merge them into the provided hf and returns a MetaHeadersFrame
+// with the decoded hpack values.
+func (fr *Framer) readMetaFrame(hf *HeadersFrame) (*MetaHeadersFrame, error) {
+	if fr.AllowIllegalReads {
+		return nil, errors.New("illegal use of AllowIllegalReads with ReadMetaHeaders")
+	}
+	mh := &MetaHeadersFrame{
+		HeadersFrame: hf,
+	}
+	remainSize := fr.maxHeaderListSize()
+	var sawRegular bool
+
+	var invalid error // pseudo header field errors
+	hdec := fr.ReadMetaHeaders
+	hdec.SetEmitEnabled(true)
+	hdec.SetMaxStringLength(fr.maxHeaderStringLen())
+	hdec.SetEmitFunc(func(hf hpack.HeaderField) {
+		if !httpguts.ValidHeaderFieldValue(hf.Value) {
+			invalid = headerFieldValueError(hf.Value)
+		}
+		isPseudo := strings.HasPrefix(hf.Name, ":")
+		if isPseudo {
+			if sawRegular {
+				invalid = errPseudoAfterRegular
+			}
+		} else {
+			sawRegular = true
+			if !validWireHeaderFieldName(hf.Name) {
+				invalid = headerFieldNameError(hf.Name)
+			}
+		}
+
+		if invalid != nil {
+			hdec.SetEmitEnabled(false)
+			return
+		}
+
+		size := hf.Size()
+		if size > remainSize {
+			hdec.SetEmitEnabled(false)
+			mh.Truncated = true
+			return
+		}
+		remainSize -= size
+
+		mh.Fields = append(mh.Fields, hf)
+	})
+	// Lose reference to MetaHeadersFrame:
+	defer hdec.SetEmitFunc(func(hf hpack.HeaderField) {})
+
+	var hc headersOrContinuation = hf
+	for {
+		frag := hc.HeaderBlockFragment()
+		if _, err := hdec.Write(frag); err != nil {
+			return nil, http2.ConnectionError(http2.ErrCodeCompression)
+		}
+
+		if hc.HeadersEnded() {
+			break
+		}
+		if f, err := fr.ReadFrame(); err != nil {
+			return nil, err
+		} else {
+			hc = f.(*ContinuationFrame) // guaranteed by checkFrameOrder
+		}
+	}
+
+	mh.HeadersFrame.headerFragBuf = nil
+	// mh.HeadersFrame.invalidate()
+
+	if err := hdec.Close(); err != nil {
+		return nil, http2.ConnectionError(http2.ErrCodeCompression)
+	}
+	if invalid != nil {
+		fr.errDetail = invalid
+		return nil, http2.StreamError{StreamID: mh.StreamID, Code: http2.ErrCodeProtocol, Cause: invalid}
+	}
+	if err := mh.checkPseudos(); err != nil {
+		fr.errDetail = err
+		return nil, http2.StreamError{StreamID: mh.StreamID, Code: http2.ErrCodeProtocol, Cause: err}
+	}
+	return mh, nil
+}
+
+// validWireHeaderFieldName reports whether v is a valid header field
+// name (key). See httpguts.ValidHeaderName for the base rules.
+//
+// Further, http2 says:
+//   "Just as in HTTP/1.x, header field names are strings of ASCII
+//   characters that are compared in a case-insensitive
+//   fashion. However, header field names MUST be converted to
+//   lowercase prior to their encoding in HTTP/2. "
+func validWireHeaderFieldName(v string) bool {
+	if len(v) == 0 {
+		return false
+	}
+	for _, r := range v {
+		if !httpguts.IsTokenRune(r) {
+			return false
+		}
+		if 'A' <= r && r <= 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+func readByte(p []byte) (remain []byte, b byte, err error) {
+	if len(p) == 0 {
+		return nil, 0, io.ErrUnexpectedEOF
+	}
+	return p[1:], p[0], nil
+}
+
+func readUint32(p []byte) (remain []byte, v uint32, err error) {
+	if len(p) < 4 {
+		return nil, 0, io.ErrUnexpectedEOF
+	}
+	return p[4:], binary.BigEndian.Uint32(p[:4]), nil
+}
+
+func readFrameHeader(r netpoll.Reader) (http2.FrameHeader, error) {
+	buf, err := r.Next(frameHeaderLen)
+	if err != nil {
+		return http2.FrameHeader{}, err
+	}
+	return http2.FrameHeader{
+		Length:   uint32(buf[0])<<16 | uint32(buf[1])<<8 | uint32(buf[2]),
+		Type:     http2.FrameType(buf[3]),
+		Flags:    http2.Flags(buf[4]),
+		StreamID: binary.BigEndian.Uint32(buf[5:]) & (1<<31 - 1),
+		// valid:    true,
+	}, nil
+}

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_writer.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_writer.go
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2021 The Go Authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ *
+ * This file may have been modified by CloudWeGo authors. All CloudWeGo
+ * Modifications are Copyright 2022 CloudWeGo Authors.
+ */
+
+package grpcframe
+
+import (
+	"errors"
+
+	"golang.org/x/net/http2"
+)
+
+const frameHeaderLen = 9
+
+var padZeros = make([]byte, 255) // zeros for padding
+
+var (
+	errStreamID    = errors.New("invalid stream ID")
+	errDepStreamID = errors.New("invalid dependent stream ID")
+)
+
+func (fr *Framer) startWrite(ftype http2.FrameType, flags http2.Flags, streamID uint32, payloadLen int) (err error) {
+	if payloadLen >= (1 << 24) {
+		return http2.ErrFrameTooLarge
+	}
+	fr.wbuf = append(fr.wbuf[:0],
+		byte(payloadLen>>16),
+		byte(payloadLen>>8),
+		byte(payloadLen),
+		byte(ftype),
+		byte(flags),
+		byte(streamID>>24),
+		byte(streamID>>16),
+		byte(streamID>>8),
+		byte(streamID))
+	return nil
+}
+
+func (fr *Framer) endWrite() (err error) {
+	_, err = fr.writer.Write(fr.wbuf)
+	return err
+}
+
+func (fr *Framer) writeByte(v byte)     { fr.wbuf = append(fr.wbuf, v) }
+func (fr *Framer) writeBytes(v []byte)  { fr.wbuf = append(fr.wbuf, v...) }
+func (fr *Framer) writeUint16(v uint16) { fr.wbuf = append(fr.wbuf, byte(v>>8), byte(v)) }
+func (fr *Framer) writeUint32(v uint32) {
+	fr.wbuf = append(fr.wbuf, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// WriteData writes a DATA frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility not to violate the maximum frame size
+// and to not call other Write methods concurrently.
+func (fr *Framer) WriteData(streamID uint32, endStream bool, data []byte) error {
+	if !validStreamID(streamID) && !fr.AllowIllegalWrites {
+		return errStreamID
+	}
+
+	var flags http2.Flags
+	if endStream {
+		flags |= http2.FlagDataEndStream
+	}
+
+	err := fr.startWrite(http2.FrameData, flags, streamID, len(data))
+	if err != nil {
+		return err
+	}
+	fr.writeBytes(data)
+	return fr.endWrite()
+}
+
+// WriteHeaders writes a single HEADERS frame.
+//
+// This is a low-level header writing method. Encoding headers and
+// splitting them into any necessary CONTINUATION frames is handled
+// elsewhere.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WriteHeaders(p http2.HeadersFrameParam) error {
+	if !validStreamID(p.StreamID) && !fr.AllowIllegalWrites {
+		return errStreamID
+	}
+	var payloadLen int
+	var flags http2.Flags
+	if p.PadLength != 0 {
+		flags |= http2.FlagHeadersPadded
+		payloadLen += 1 + int(p.PadLength)
+	}
+	if p.EndStream {
+		flags |= http2.FlagHeadersEndStream
+	}
+	if p.EndHeaders {
+		flags |= http2.FlagHeadersEndHeaders
+	}
+	if !p.Priority.IsZero() {
+		v := p.Priority.StreamDep
+		if !validStreamIDOrZero(v) && !fr.AllowIllegalWrites {
+			return errDepStreamID
+		}
+		flags |= http2.FlagHeadersPriority
+		payloadLen += 5
+	}
+	payloadLen += len(p.BlockFragment)
+	err := fr.startWrite(http2.FrameHeaders, flags, p.StreamID, payloadLen)
+	if err != nil {
+		return err
+	}
+	if p.PadLength != 0 {
+		fr.writeByte(p.PadLength)
+	}
+	if !p.Priority.IsZero() {
+		v := p.Priority.StreamDep
+		if p.Priority.Exclusive {
+			v |= 1 << 31
+		}
+		fr.writeUint32(v)
+		fr.writeByte(p.Priority.Weight)
+	}
+	fr.writeBytes(p.BlockFragment)
+	fr.writeBytes(padZeros[:p.PadLength])
+	return fr.endWrite()
+}
+
+// WritePriority writes a PRIORITY frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WritePriority(streamID uint32, p http2.PriorityParam) error {
+	if !validStreamID(streamID) && !fr.AllowIllegalWrites {
+		return errStreamID
+	}
+	if !validStreamIDOrZero(p.StreamDep) {
+		return errDepStreamID
+	}
+
+	err := fr.startWrite(http2.FramePriority, 0, streamID, 5)
+	if err != nil {
+		return err
+	}
+
+	v := p.StreamDep
+	if p.Exclusive {
+		v |= 1 << 31
+	}
+	fr.writeUint32(v)
+	fr.writeByte(p.Weight)
+	return fr.endWrite()
+}
+
+// WriteRSTStream writes a RST_STREAM frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WriteRSTStream(streamID uint32, code http2.ErrCode) error {
+	if !validStreamID(streamID) && !fr.AllowIllegalWrites {
+		return errStreamID
+	}
+	err := fr.startWrite(http2.FrameRSTStream, 0, streamID, 4)
+	if err != nil {
+		return err
+	}
+	fr.writeUint32(uint32(code))
+	return fr.endWrite()
+}
+
+// WriteSettings writes a SETTINGS frame with zero or more settings
+// specified and the ACK bit not set.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WriteSettings(settings ...http2.Setting) error {
+	payloadLen := 6 * len(settings)
+	err := fr.startWrite(http2.FrameSettings, 0, 0, payloadLen)
+	if err != nil {
+		return err
+	}
+	for _, s := range settings {
+		fr.writeUint16(uint16(s.ID))
+		fr.writeUint32(s.Val)
+	}
+	return fr.endWrite()
+}
+
+// WriteSettingsAck writes an empty SETTINGS frame with the ACK bit set.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WriteSettingsAck() error {
+	err := fr.startWrite(http2.FrameSettings, http2.FlagSettingsAck, 0, 0)
+	if err != nil {
+		return err
+	}
+	return fr.endWrite()
+}
+
+// WritePushPromise writes a single PushPromise Frame.
+//
+// As with Header Frames, This is the low level call for writing
+// individual frames. Continuation frames are handled elsewhere.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WritePushPromise(p http2.PushPromiseParam) error {
+	if !fr.AllowIllegalWrites && (!validStreamID(p.StreamID) || !validStreamID(p.PromiseID)) {
+		return errStreamID
+	}
+	if !validStreamID(p.PromiseID) && !fr.AllowIllegalWrites {
+		return errStreamID
+	}
+	var payloadLen int
+	var flags http2.Flags
+	if p.PadLength != 0 {
+		flags |= http2.FlagPushPromisePadded
+		payloadLen += 1 + int(p.PadLength)
+	}
+	if p.EndHeaders {
+		flags |= http2.FlagPushPromiseEndHeaders
+	}
+	payloadLen += 4 + len(p.BlockFragment)
+	err := fr.startWrite(http2.FramePushPromise, flags, p.StreamID, payloadLen)
+	if err != nil {
+		return err
+	}
+	if p.PadLength != 0 {
+		fr.writeByte(p.PadLength)
+	}
+	fr.writeUint32(p.PromiseID)
+	fr.writeBytes(p.BlockFragment)
+	fr.writeBytes(padZeros[:p.PadLength])
+	return fr.endWrite()
+}
+
+func (fr *Framer) WritePing(ack bool, data [8]byte) error {
+	var flags http2.Flags
+	if ack {
+		flags = http2.FlagPingAck
+	}
+	err := fr.startWrite(http2.FramePing, flags, 0, len(data))
+	if err != nil {
+		return err
+	}
+	fr.writeBytes(data[:])
+	return fr.endWrite()
+}
+
+func (fr *Framer) WriteGoAway(maxStreamID uint32, code http2.ErrCode, debugData []byte) error {
+	payloadLen := 8 + len(debugData)
+	err := fr.startWrite(http2.FrameGoAway, 0, 0, payloadLen)
+	if err != nil {
+		return err
+	}
+	fr.writeUint32(maxStreamID & (1<<31 - 1))
+	fr.writeUint32(uint32(code))
+	fr.writeBytes(debugData)
+	return fr.endWrite()
+}
+
+// WriteWindowUpdate writes a WINDOW_UPDATE frame.
+// The increment value must be between 1 and 2,147,483,647, inclusive.
+// If the Stream ID is zero, the window update applies to the
+// connection as a whole.
+func (fr *Framer) WriteWindowUpdate(streamID, incr uint32) error {
+	// "The legal range for the increment to the flow control window is 1 to 2^31-1 (2,147,483,647) octets."
+	if (incr < 1 || incr > 2147483647) && !fr.AllowIllegalWrites {
+		return errors.New("illegal window increment value")
+	}
+
+	err := fr.startWrite(http2.FrameWindowUpdate, 0, streamID, 4)
+	if err != nil {
+		return err
+	}
+	fr.writeUint32(incr)
+	return fr.endWrite()
+}
+
+// WriteContinuation writes a CONTINUATION frame.
+//
+// It will perform exactly one Write to the underlying Writer.
+// It is the caller's responsibility to not call other Write methods concurrently.
+func (fr *Framer) WriteContinuation(streamID uint32, endHeaders bool, headerBlockFragment []byte) error {
+	if !validStreamID(streamID) && !fr.AllowIllegalWrites {
+		return errStreamID
+	}
+	var flags http2.Flags
+	if endHeaders {
+		flags |= http2.FlagContinuationEndHeaders
+	}
+	err := fr.startWrite(http2.FrameContinuation, flags, streamID, len(headerBlockFragment))
+	if err != nil {
+		return err
+	}
+	fr.writeBytes(headerBlockFragment)
+	return fr.endWrite()
+}
+
+// WriteRawFrame writes a raw frame. This can be used to write
+// extension frames unknown to this package.
+func (fr *Framer) WriteRawFrame(t http2.FrameType, flags http2.Flags, streamID uint32, payload []byte) error {
+	err := fr.startWrite(t, flags, streamID, len(payload))
+	if err != nil {
+		return err
+	}
+	fr.writeBytes(payload)
+	return fr.endWrite()
+}
+
+func validStreamIDOrZero(streamID uint32) bool {
+	return streamID&(1<<31) == 0
+}
+
+func validStreamID(streamID uint32) bool {
+	return streamID != 0 && streamID&(1<<31) == 0
+}

--- a/pkg/remote/trans/nphttp2/grpc/http2_server.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_server.go
@@ -34,14 +34,16 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cloudwego/kitex/pkg/gofunc"
-	"github.com/cloudwego/kitex/pkg/klog"
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"github.com/cloudwego/netpoll"
-	http2 "golang.org/x/net/http2"
+	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/cloudwego/kitex/pkg/gofunc"
+	"github.com/cloudwego/kitex/pkg/klog"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/grpcframe"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 
 var (
@@ -254,7 +256,7 @@ func newHTTP2Server(ctx context.Context, conn net.Conn, config *ServerConfig) (_
 		return nil, connectionErrorf(false, err, "transport: http2Server.HandleStreams failed to read initial settings frame: %v", err)
 	}
 	atomic.StoreInt64(&t.lastRead, time.Now().UnixNano())
-	sf, ok := frame.(*http2.SettingsFrame)
+	sf, ok := frame.(*grpcframe.SettingsFrame)
 	if !ok {
 		return nil, connectionErrorf(false, nil, "transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
 	}
@@ -275,7 +277,7 @@ func newHTTP2Server(ctx context.Context, conn net.Conn, config *ServerConfig) (_
 }
 
 // operateHeader takes action on the decoded headers.
-func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(*Stream), traceCtx func(context.Context, string) context.Context) (fatal bool) {
+func (t *http2Server) operateHeaders(frame *grpcframe.MetaHeadersFrame, handle func(*Stream), traceCtx func(context.Context, string) context.Context) (fatal bool) {
 	streamID := frame.Header().StreamID
 	state := &decodeState{
 		serverSide: true,
@@ -408,26 +410,27 @@ func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.
 			return
 		}
 		switch frame := frame.(type) {
-		case *http2.MetaHeadersFrame:
+		case *grpcframe.MetaHeadersFrame:
 			if t.operateHeaders(frame, handle, traceCtx) {
 				t.Close()
 				break
 			}
-		case *http2.DataFrame:
+		case *grpcframe.DataFrame:
 			t.handleData(frame)
 		case *http2.RSTStreamFrame:
 			t.handleRSTStream(frame)
-		case *http2.SettingsFrame:
+		case *grpcframe.SettingsFrame:
 			t.handleSettings(frame)
 		case *http2.PingFrame:
 			t.handlePing(frame)
 		case *http2.WindowUpdateFrame:
 			t.handleWindowUpdate(frame)
-		case *http2.GoAwayFrame:
+		case *grpcframe.GoAwayFrame:
 			// TODO: Handle GoAway from the client appropriately.
 		default:
 			klog.CtxErrorf(t.ctx, "transport: http2Server.HandleStreams found unhandled frame type %v.", frame)
 		}
+		t.framer.reader.Release()
 	}
 }
 
@@ -491,7 +494,7 @@ func (t *http2Server) updateWindow(s *Stream, n uint32) {
 	}
 }
 
-func (t *http2Server) handleData(f *http2.DataFrame) {
+func (t *http2Server) handleData(f *grpcframe.DataFrame) {
 	size := f.Header().Length
 	var sendBDPPing bool
 	if t.bdpEst != nil {
@@ -569,7 +572,7 @@ func (t *http2Server) handleRSTStream(f *http2.RSTStreamFrame) {
 	})
 }
 
-func (t *http2Server) handleSettings(f *http2.SettingsFrame) {
+func (t *http2Server) handleSettings(f *grpcframe.SettingsFrame) {
 	if f.IsAck() {
 		return
 	}

--- a/pkg/remote/trans/nphttp2/grpc/http_util.go
+++ b/pkg/remote/trans/nphttp2/grpc/http_util.go
@@ -21,26 +21,25 @@
 package grpc
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"math"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/cloudwego/kitex/pkg/klog"
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/cloudwego/kitex/pkg/klog"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/grpcframe"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 
 const (
@@ -273,7 +272,7 @@ func decodeMetadataHeader(k, v string) (string, error) {
 	return v, nil
 }
 
-func (d *decodeState) decodeHeader(frame *http2.MetaHeadersFrame) error {
+func (d *decodeState) decodeHeader(frame *grpcframe.MetaHeadersFrame) error {
 	// frame.Truncated is set to true when framer detects that the current header
 	// list size hits MaxHeaderListSize limit.
 	if frame.Truncated {
@@ -609,82 +608,4 @@ func decodeGrpcMessageUnchecked(msg string) string {
 		}
 	}
 	return buf.String()
-}
-
-type framer struct {
-	*http2.Framer
-	writer *bufWriter
-}
-
-func newFramer(conn net.Conn, writeBufferSize, readBufferSize, maxHeaderListSize uint32) *framer {
-	w := newBufWriter(conn, int(writeBufferSize))
-
-	var r io.Reader = conn
-	if readBufferSize > 0 {
-		r = bufio.NewReaderSize(r, int(readBufferSize))
-	}
-
-	fr := &framer{
-		writer: w,
-		Framer: http2.NewFramer(w, r),
-	}
-	fr.SetMaxReadFrameSize(http2MaxFrameLen)
-	// Opt-in to Frame reuse API on framer to reduce garbage.
-	// Frames aren't safe to read from after a subsequent call to ReadFrame.
-	fr.SetReuseFrames()
-	fr.MaxHeaderListSize = maxHeaderListSize
-	fr.ReadMetaHeaders = hpack.NewDecoder(http2InitHeaderTableSize, nil)
-	return fr
-}
-
-type bufWriter struct {
-	buf       []byte
-	offset    int
-	batchSize int
-	conn      net.Conn
-	err       error
-
-	onFlush func()
-}
-
-func newBufWriter(conn net.Conn, batchSize int) *bufWriter {
-	return &bufWriter{
-		buf:       make([]byte, batchSize*2),
-		batchSize: batchSize,
-		conn:      conn,
-	}
-}
-
-func (w *bufWriter) Write(b []byte) (n int, err error) {
-	if w.err != nil {
-		return 0, w.err
-	}
-	if w.batchSize == 0 { // buffer has been disabled.
-		return w.conn.Write(b)
-	}
-	for len(b) > 0 {
-		nn := copy(w.buf[w.offset:], b)
-		b = b[nn:]
-		w.offset += nn
-		n += nn
-		if w.offset >= w.batchSize {
-			err = w.Flush()
-		}
-	}
-	return n, err
-}
-
-func (w *bufWriter) Flush() error {
-	if w.err != nil {
-		return w.err
-	}
-	if w.offset == 0 {
-		return nil
-	}
-	if w.onFlush != nil {
-		w.onFlush()
-	}
-	_, w.err = w.conn.Write(w.buf[:w.offset])
-	w.offset = 0
-	return w.err
 }

--- a/pkg/remote/trans/nphttp2/grpc/mocks_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/mocks_test.go
@@ -44,17 +44,13 @@ var _ netpoll.Connection = &mockNetpollConn{}
 // mockNetpollConn implements netpoll.Connection.
 type mockNetpollConn struct {
 	mockConn
-	ReaderFunc func() (r netpoll.Reader)
-	WriterFunc func() (r netpoll.Writer)
 }
 
 func (m *mockNetpollConn) Reader() netpoll.Reader {
-	// TODO implement me
 	panic("implement me")
 }
 
 func (m *mockNetpollConn) Writer() netpoll.Writer {
-	// TODO implement me
 	panic("implement me")
 }
 
@@ -82,7 +78,7 @@ func (m *mockNetpollConn) WriteFrame(hdr, data []byte) (n int, err error) {
 	return
 }
 
-func (c *mockNetpollConn) ReadFrame() (hdr, data []byte, err error) {
+func (m *mockNetpollConn) ReadFrame() (hdr, data []byte, err error) {
 	return
 }
 

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -1738,16 +1738,17 @@ func TestReadGivesSameErrorAfterAnyErrorOccurs(t *testing.T) {
 	}
 	s.trReader = &transportReader{
 		reader: &recvBufferReader{
-			ctx:        s.ctx,
-			ctxDone:    s.ctx.Done(),
-			recv:       s.buf,
-			freeBuffer: func(*bytes.Buffer) {},
+			ctx:     s.ctx,
+			ctxDone: s.ctx.Done(),
+			recv:    s.buf,
 		},
 		windowHandler: func(int) {},
 	}
 	testData := make([]byte, 1)
 	testData[0] = 5
-	testBuffer := bytes.NewBuffer(testData)
+	testBuffer := netpoll.NewLinkBuffer()
+	testBuffer.WriteBinary(testData)
+	testBuffer.Flush()
 	testErr := errors.New("test error")
 	s.write(recvMsg{buffer: testBuffer, err: testErr})
 

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -36,12 +36,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/testutils"
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"github.com/cloudwego/netpoll"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
+
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/grpcframe"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/testutils"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 
 type server struct {
@@ -1186,7 +1188,7 @@ func TestServerWithMisbehavedClient(t *testing.T) {
 	// success chan indicates that reader received a RSTStream from server.
 	success := make(chan struct{})
 	var mu sync.Mutex
-	framer := http2.NewFramer(mconn, mconn)
+	framer := grpcframe.NewFramer(mconn, mconn.(netpoll.Connection).Reader())
 	if err := framer.WriteSettings(); err != nil {
 		t.Fatalf("Error while writing settings: %v", err)
 	}
@@ -1807,7 +1809,7 @@ func TestReadGivesSameErrorAfterAnyErrorOccurs(t *testing.T) {
 //				return
 //			}
 //			switch frame := frame.(type) {
-//			case *http2.SettingsFrame:
+//			case *grpcframe.SettingsFrame:
 //				// Do nothing. A settings frame is expected from server preface.
 //			case *http2.RSTStreamFrame:
 //				if frame.Header().StreamID != 1 || http2.ErrCode(frame.ErrCode) != http2.ErrCodeProtocol {

--- a/pkg/remote/trans/nphttp2/mocks_test.go
+++ b/pkg/remote/trans/nphttp2/mocks_test.go
@@ -20,10 +20,15 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/cloudwego/netpoll"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/runtime/protoimpl"
 
 	"github.com/cloudwego/kitex/internal/stats"
 	"github.com/cloudwego/kitex/pkg/remote"
@@ -31,9 +36,6 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/utils"
-	"github.com/cloudwego/netpoll"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/runtime/protoimpl"
 )
 
 var (
@@ -54,6 +56,7 @@ func newMockNpConn(address string) *mockNetpollConn {
 		mockQueue: []mockFrame{},
 	}
 	mc.mockConn.ReadFunc = mc.mockReader
+	mc.reader = &mockNetpollReader{reader: mc.mockConn}
 	return mc
 }
 
@@ -119,20 +122,17 @@ var _ netpoll.Connection = &mockNetpollConn{}
 // mockNetpollConn implements netpoll.Connection.
 type mockNetpollConn struct {
 	mockConn
-	ReaderFunc   func() (r netpoll.Reader)
-	WriterFunc   func() (r netpoll.Writer)
 	mockQueue    []mockFrame
 	queueCounter int
 	counterLock  sync.Mutex
+	reader       *mockNetpollReader
 }
 
 func (m *mockNetpollConn) Reader() netpoll.Reader {
-	// TODO implement me
-	panic("implement me")
+	return m.reader
 }
 
 func (m *mockNetpollConn) Writer() netpoll.Writer {
-	// TODO implement me
 	panic("implement me")
 }
 
@@ -160,9 +160,35 @@ func (m *mockNetpollConn) WriteFrame(hdr, data []byte) (n int, err error) {
 	return
 }
 
-func (c *mockNetpollConn) ReadFrame() (hdr, data []byte, err error) {
+func (m *mockNetpollConn) ReadFrame() (hdr, data []byte, err error) {
 	return
 }
+
+var _ netpoll.Reader = &mockNetpollReader{}
+
+// mockNetpollReader implements netpoll.Reader.
+type mockNetpollReader struct {
+	reader io.Reader
+}
+
+func (m *mockNetpollReader) Next(n int) (p []byte, err error) {
+	p = make([]byte, n)
+	_, err = m.reader.Read(p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (m *mockNetpollReader) Peek(n int) (buf []byte, err error)        { return }
+func (m *mockNetpollReader) Skip(n int) (err error)                    { return }
+func (m *mockNetpollReader) Until(delim byte) (line []byte, err error) { return }
+func (m *mockNetpollReader) ReadString(n int) (s string, err error)    { return }
+func (m *mockNetpollReader) ReadBinary(n int) (p []byte, err error)    { return }
+func (m *mockNetpollReader) ReadByte() (b byte, err error)             { return }
+func (m *mockNetpollReader) Slice(n int) (r netpoll.Reader, err error) { return }
+func (m *mockNetpollReader) Release() (err error)                      { return }
+func (m *mockNetpollReader) Len() (length int)                         { return }
 
 var _ net.Conn = &mockConn{}
 

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -23,10 +23,9 @@ import (
 	"net"
 	"runtime/debug"
 	"strings"
+	"sync"
 
 	internal_stats "github.com/cloudwego/kitex/internal/stats"
-	"github.com/cloudwego/kitex/pkg/stats"
-
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/gofunc"
 	"github.com/cloudwego/kitex/pkg/kerrors"
@@ -38,6 +37,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	"github.com/cloudwego/kitex/pkg/stats"
 	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/transport"
 	"github.com/cloudwego/netpoll"
@@ -91,15 +91,15 @@ func (t *svrTransHandler) Read(ctx context.Context, conn net.Conn, msg remote.Me
 
 // 只 return write err
 func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
-	tr, e := grpcTransport.NewServerTransport(ctx, conn.(netpoll.Connection), t.opt.GRPCCfg)
-	if e != nil {
-		return e
-	}
-	defer tr.Close()
+	svrTrans := ctx.Value(ctxKeySvrTransport).(*SvrTrans)
+	tr := svrTrans.tr
 
 	tr.HandleStreams(func(s *grpcTransport.Stream) {
 		gofunc.GoFunc(ctx, func() {
-			ri, rCtx := t.opt.InitRPCInfoFunc(s.Context(), tr.RemoteAddr())
+			ri := svrTrans.pool.Get().(rpcinfo.RPCInfo)
+			defer svrTrans.pool.Put(ri)
+			rCtx := rpcinfo.NewCtxWithRPCInfo(s.Context(), ri)
+
 			// set grpc transport flag before execute metahandler
 			rpcinfo.AsMutableRPCConfig(ri.Config()).SetTransportProtocol(transport.GRPC)
 			var err error
@@ -192,11 +192,33 @@ func (t *svrTransHandler) OnMessage(ctx context.Context, args, result remote.Mes
 	panic("unimplemented")
 }
 
+type svrTransKey int
+
+const ctxKeySvrTransport svrTransKey = 1
+
+type SvrTrans struct {
+	tr   grpcTransport.ServerTransport
+	pool *sync.Pool // value is rpcInfo
+}
+
 // 新连接建立时触发，主要用于服务端，对应 netpoll onPrepare
 func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.Context, error) {
 	// set readTimeout to infinity to avoid streaming break
 	// use keepalive to check the health of connection
 	conn.(netpoll.Connection).SetReadTimeout(grpcTransport.Infinity)
+
+	tr, err := grpcTransport.NewServerTransport(ctx, conn.(netpoll.Connection), t.opt.GRPCCfg)
+	if err != nil {
+		return nil, err
+	}
+	pool := &sync.Pool{
+		New: func() interface{} {
+			// init rpcinfo
+			ri, _ := t.opt.InitRPCInfoFunc(ctx, conn.RemoteAddr())
+			return ri
+		},
+	}
+	ctx = context.WithValue(ctx, ctxKeySvrTransport, &SvrTrans{tr: tr, pool: pool})
 	return ctx, nil
 }
 
@@ -204,6 +226,8 @@ func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.
 func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 	// recycle rpcinfo
 	rpcinfo.PutRPCInfo(rpcinfo.GetRPCInfo(ctx))
+	tr := ctx.Value(ctxKeySvrTransport).(*SvrTrans).tr
+	tr.Close()
 }
 
 // 传输层 error 回调

--- a/pkg/remote/trans/nphttp2/server_handler_test.go
+++ b/pkg/remote/trans/nphttp2/server_handler_test.go
@@ -62,19 +62,19 @@ func TestServerHandler(t *testing.T) {
 	// mock a headerFrame so onRead() can start working
 	npConn.mockMetaHeaderFrame()
 	go func() {
-		handler.OnRead(newMockCtxWithRPCInfo(), npConn)
+		// test OnActive()
+		ctx, err := handler.OnActive(newMockCtxWithRPCInfo(), npConn)
+		test.Assert(t, err == nil, err)
+
+		handler.OnRead(ctx, npConn)
+
+		// test OnInactive()
+		handler.OnInactive(ctx, npConn)
 		test.Assert(t, err == nil, err)
 	}()
 
 	// sleep 50 mills so server can handle metaHeader frame
 	time.Sleep(time.Millisecond * 50)
-
-	// test OnActive()
-	_, err = handler.OnActive(context.Background(), npConn)
-	test.Assert(t, err == nil, err)
-
-	// test OnInactive()
-	handler.OnInactive(newMockCtxWithRPCInfo(), npConn)
 
 	// test OnError()
 	handler.OnError(context.Background(), context.Canceled, npConn)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

feat
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: dataFrame use netpoll.Reader with nocopy,  benchmark shown as:

unary is same, streaming qps ↑12.9%-18%
```
unary: 
[KITEX],100,1024,126452.82,2.13,2.62      =>   [KITEX],100,1024,127147.27,2.10,2.60
[KITEX],1000,1024,177085.31,13.11,19.04   =>   [KITEX],1000,1024,178931.25,13.19,18.91

streaming:
[KITEX],100,1024,293635.41,1.33,1.54      =>   [KITEX],100,1024,283548.03,1.35,1.56
[KITEX],1000,1024,416697.32,6.94,8.34    =>   [KITEX],1000,1024,394419.28,7.10,8.50
```

zh: kitex grpc dataFrame 使用 netpoll.Reader 代替 bytes.Buffer，减少一次内存复制。

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none