### PR TITLE
fix: method name no need to use nocopy

### DIFF
--- a/pkg/protocol/bthrift/binary.go
+++ b/pkg/protocol/bthrift/binary.go
@@ -47,15 +47,6 @@ func (binaryProtocol) WriteMessageBegin(buf []byte, name string, typeID thrift.T
 	return offset
 }
 
-func (binaryProtocol) WriteMessageBeginNocopy(buf []byte, binaryWriter BinaryWriter, name string, typeID thrift.TMessageType, seqid int32) int {
-	offset := 0
-	version := uint32(thrift.VERSION_1) | uint32(typeID)
-	offset += Binary.WriteI32(buf, int32(version))
-	offset += Binary.WriteStringNocopy(buf[offset:], binaryWriter, name)
-	offset += Binary.WriteI32(buf[offset:], seqid)
-	return offset
-}
-
 func (binaryProtocol) WriteMessageEnd(buf []byte) int {
 	return 0
 }

--- a/pkg/protocol/bthrift/interface.go
+++ b/pkg/protocol/bthrift/interface.go
@@ -29,7 +29,6 @@ type BinaryWriter interface {
 // BTProtocol .
 type BTProtocol interface {
 	WriteMessageBegin(buf []byte, name string, typeID thrift.TMessageType, seqid int32) int
-	WriteMessageBeginNocopy(buf []byte, binaryWriter BinaryWriter, name string, typeID thrift.TMessageType, seqid int32) int
 	WriteMessageEnd(buf []byte) int
 	WriteStructBegin(buf []byte, name string) int
 	WriteStructEnd(buf []byte) int

--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -103,7 +103,7 @@ func (c thriftCodec) Marshal(ctx context.Context, message remote.Message, out re
 			if err != nil {
 				return perrors.NewProtocolErrorWithMsg(fmt.Sprintf("thrift marshal, Malloc failed: %s", err.Error()))
 			}
-			offset := bthrift.Binary.WriteMessageBeginNocopy(buf, nw, methodName, thrift.TMessageType(msgType), seqID)
+			offset := bthrift.Binary.WriteMessageBegin(buf, methodName, thrift.TMessageType(msgType), seqID)
 			offset += msg.FastWriteNocopy(buf[offset:], nw)
 			bthrift.Binary.WriteMessageEnd(buf[offset:])
 			return nil


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en: no need to use nocopy when serialize method name 
zh: 序列化方法名时，不需要使用 nocopy

#### Which issue(s) this PR fixes:

