### PR TITLE
ci: run skywalking-eyes only on x64 runners

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   compliant:
-    runs-on: self-hosted
+    runs-on: [self-hosted, X64]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
#### What type of PR is this?
ci

#### What this PR does / why we need it (en: English/zh: Chinese):
en: run skywalking-eyes only on x64 runners
zh: 只在 x64 的 runner 上运行 skywalking-eyes

#### Which issue(s) this PR fixes:
none