### PR TITLE
Revert "optimize(rpcinfo): RPCInfo.To().Tag() use instance tag instead of remoteinfo tag firstly"

### DIFF
--- a/pkg/rpcinfo/remoteinfo/remoteInfo.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo.go
@@ -111,12 +111,10 @@ func (ri *remoteInfo) Tag(key string) (value string, exist bool) {
 	ri.RLock()
 	defer ri.RUnlock()
 
-	if ri.instance != nil {
-		if value, exist = ri.instance.Tag(key); exist {
-			return
-		}
-	}
 	value, exist = ri.tags[key]
+	if !exist && ri.instance != nil {
+		value, exist = ri.instance.Tag(key)
+	}
 	return
 }
 


### PR DESCRIPTION
Reverts cloudwego/kitex#374

RPCInfo includes the code configuration, the priority should be higher than instance info. For example, env info should be transmited to downstream even though it doesn't match with the env of instance