### PR TITLE
optimize: use wrap func to check timeout err in timeout middleware which can ignore logs custimized timeout err

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -117,11 +117,11 @@ func rpcTimeoutMW(mwCtx context.Context) endpoint.Middleware {
 				}()
 				err = next(ctx, request, response)
 				if err != nil && ctx.Err() != nil &&
-					!errors.Is(err, kerrors.ErrRPCTimeout) && !errors.Is(err, kerrors.ErrRPCFinish) {
+					!kerrors.IsTimeoutError(err) && !errors.Is(err, kerrors.ErrRPCFinish) {
 					// error occurs after the wait goroutine returns(RPCTimeout happens),
 					// we should log this error for troubleshooting, or it will be discarded.
 					// but ErrRPCTimeout and ErrRPCFinish can be ignored:
-					//    ErrRPCTimeout: it is same with outer timeout, here only care about non timeout err.
+					//    ErrRPCTimeout: it is same with outer timeout, here only care about non-timeout err.
 					//    ErrRPCFinish: it happens in retry scene, previous call returns first.
 					var errMsg string
 					if ri.To().Address() != nil {


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (en: English/zh: Chinese):
en: optimize: use wrap func to check under layer timeout err in timeout middleware which can ignore logs of customized timeout err log
zh: optimize: 在超时中间件中使用超时封装方法判断底层超时，用来忽略一些定制超时错误日志

#### Which issue(s) this PR fixes:
none
