### PR TITLE
fix (tool/protoc) :  import proto files prefix (#563)

### DIFF
--- a/tool/internal/pkg/pluginmode/protoc/plugin.go
+++ b/tool/internal/pkg/pluginmode/protoc/plugin.go
@@ -162,7 +162,7 @@ func (pp *protocPlugin) process(gen *protogen.Plugin) {
 	// iterate over all proto files
 	idl := gen.Request.FileToGenerate[0]
 	for _, f := range gen.Files {
-		if pp.Config.Use != "" && f.Proto.GetName() != idl {
+		if pp.Config.Use != "" || f.Proto.GetName() != idl {
 			continue
 		}
 		pp.GenerateFile(gen, f)

--- a/tool/internal/pkg/pluginmode/protoc/protoc.go
+++ b/tool/internal/pkg/pluginmode/protoc/protoc.go
@@ -83,6 +83,9 @@ func run(opts protogen.Options) error {
 	}
 	// fix proto file go_package to correct dependency import
 	for _, f := range req.ProtoFile {
+		if *f.Name != pp.IDL {
+			continue
+		}
 		if !strings.Contains(*f.Options.GoPackage, generator.KitexGenPath) {
 			if pp.completeImportPath {
 				return errors.New("mix use of new/old proto file standard")


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en:  fix the bug  . when use proto and import the others proto will add packagePrefix and regenerate  the pb.go
zh:  修复 导入其他proto文件时会添加包前缀 并重新pb.go文件的问题 

#### Which issue(s) this PR fixes:
#563 


