### PR TITLE
perf/fix: reuse rpcinfo to improve performance

### DIFF
--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -94,7 +94,7 @@ type ServerOption struct {
 
 	ReadWriteTimeout time.Duration
 
-	InitRPCInfoFunc func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context)
+	InitOrResetRPCInfoFunc func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context)
 
 	TracerCtl *internal_stats.Controller
 

--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -48,13 +48,12 @@ func NewDefaultSvrTransHandler(opt *remote.ServerOption, ext Extension) (remote.
 }
 
 type svrTransHandler struct {
-	opt           *remote.ServerOption
-	svcInfo       *serviceinfo.ServiceInfo
-	inkHdlFunc    endpoint.Endpoint
-	codec         remote.Codec
-	transPipe     *remote.TransPipeline
-	cachedRPCInfo rpcinfo.RPCInfo
-	ext           Extension
+	opt        *remote.ServerOption
+	svcInfo    *serviceinfo.ServiceInfo
+	inkHdlFunc endpoint.Endpoint
+	codec      remote.Codec
+	transPipe  *remote.TransPipeline
+	ext        Extension
 }
 
 // Write implements the remote.ServerTransHandler interface.
@@ -101,8 +100,9 @@ func (t *svrTransHandler) Read(ctx context.Context, conn net.Conn, recvMsg remot
 
 // OnRead implements the remote.ServerTransHandler interface.
 func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
-	ri := t.cachedRPCInfo
-	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
+	// reset rpcinfo
+	var ri rpcinfo.RPCInfo
+	ri, ctx = t.opt.InitOrResetRPCInfoFunc(ctx, conn.RemoteAddr())
 	t.ext.SetReadTimeout(ctx, conn, ri.Config(), remote.Server)
 	var err error
 	var closeConn bool
@@ -126,8 +126,6 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 		t.finishTracer(ctx, ri, err, panicErr)
 		remote.RecycleMessage(recvMsg)
 		remote.RecycleMessage(sendMsg)
-		// reset rpcinfo
-		t.cachedRPCInfo, _ = t.opt.InitOrResetRPCInfoFunc(ctx, conn.RemoteAddr())
 	}()
 	ctx = t.startTracer(ctx, ri)
 	recvMsg = remote.NewMessageWithNewer(t.svcInfo, ri, remote.Call, remote.Server)
@@ -183,14 +181,14 @@ func (t *svrTransHandler) OnMessage(ctx context.Context, args, result remote.Mes
 // OnActive implements the remote.ServerTransHandler interface.
 func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.Context, error) {
 	// init rpcinfo
-	t.cachedRPCInfo, _ = t.opt.InitOrResetRPCInfoFunc(ctx, conn.RemoteAddr())
+	_, ctx = t.opt.InitOrResetRPCInfoFunc(ctx, conn.RemoteAddr())
 	return ctx, nil
 }
 
 // OnInactive implements the remote.ServerTransHandler interface.
 func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 	// recycle rpcinfo
-	rpcinfo.PutRPCInfo(t.cachedRPCInfo)
+	rpcinfo.PutRPCInfo(rpcinfo.GetRPCInfo(ctx))
 }
 
 // OnError implements the remote.ServerTransHandler interface.

--- a/pkg/remote/trans/gonet/trans_server.go
+++ b/pkg/remote/trans/gonet/trans_server.go
@@ -80,7 +80,7 @@ func (ts *transServer) BootstrapServer() (err error) {
 			os.Exit(1)
 		}
 		go func() {
-			ri, ctx := ts.opt.InitRPCInfoFunc(context.Background(), conn.RemoteAddr())
+			ri, ctx := ts.opt.InitOrResetRPCInfoFunc(context.Background(), conn.RemoteAddr())
 			defer func() {
 				transRecover(ctx, conn, "OnRead")
 				// recycle rpcinfo

--- a/pkg/remote/trans/gonet/trans_server_test.go
+++ b/pkg/remote/trans/gonet/trans_server_test.go
@@ -43,7 +43,7 @@ var (
 
 func TestMain(m *testing.M) {
 	svrOpt = &remote.ServerOption{
-		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 			fromInfo := rpcinfo.EmptyEndpointInfo()
 			rpcCfg := rpcinfo.NewRPCConfig()
 			mCfg := rpcinfo.AsMutableRPCConfig(rpcCfg)

--- a/pkg/remote/trans/netpoll/trans_server_test.go
+++ b/pkg/remote/trans/netpoll/trans_server_test.go
@@ -46,7 +46,7 @@ var (
 
 func TestMain(m *testing.M) {
 	svrOpt = &remote.ServerOption{
-		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 			fromInfo := rpcinfo.EmptyEndpointInfo()
 			rpcCfg := rpcinfo.NewRPCConfig()
 			mCfg := rpcinfo.AsMutableRPCConfig(rpcCfg)

--- a/pkg/remote/trans/netpollmux/mux_conn.go
+++ b/pkg/remote/trans/netpollmux/mux_conn.go
@@ -145,7 +145,7 @@ func newMuxSvrConn(connection netpoll.Connection, pool *sync.Pool) *muxSvrConn {
 
 type muxSvrConn struct {
 	muxConn
-	pool *sync.Pool // ctx with rpcInfo
+	pool *sync.Pool // value is rpcInfo
 }
 
 func newMuxConn(connection netpoll.Connection) muxConn {

--- a/pkg/remote/trans/netpollmux/mux_conn.go
+++ b/pkg/remote/trans/netpollmux/mux_conn.go
@@ -145,7 +145,7 @@ func newMuxSvrConn(connection netpoll.Connection, pool *sync.Pool) *muxSvrConn {
 
 type muxSvrConn struct {
 	muxConn
-	pool *sync.Pool // value is rpcInfo
+	pool *sync.Pool // ctx with rpcInfo
 }
 
 func newMuxConn(connection netpoll.Connection) muxConn {

--- a/pkg/remote/trans/netpollmux/server_handler_test.go
+++ b/pkg/remote/trans/netpollmux/server_handler_test.go
@@ -63,7 +63,7 @@ func init() {
 	rpcInfo := newTestRpcInfo()
 
 	opt = &remote.ServerOption{
-		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
 			return rpcInfo, ctx
 		},
@@ -436,7 +436,7 @@ func TestInvokeError(t *testing.T) {
 
 	body := "hello world"
 	opt := &remote.ServerOption{
-		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
 			return rpcInfo, ctx
 		},
@@ -575,7 +575,7 @@ func TestInvokeNoMethod(t *testing.T) {
 
 	body := "hello world"
 	opt := &remote.ServerOption{
-		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, rpcInfo)
 			return rpcInfo, ctx
 		},

--- a/pkg/remote/trans/nphttp2/mocks_test.go
+++ b/pkg/remote/trans/nphttp2/mocks_test.go
@@ -304,7 +304,7 @@ func newMockServerOption() *remote.ServerOption {
 		AcceptFailedDelayTime: 0,
 		MaxConnectionIdleTime: 0,
 		ReadWriteTimeout:      0,
-		InitRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 			return newMockRPCInfo(), context.Background()
 		},
 		TracerCtl: &stats.Controller{},

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -97,8 +97,12 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 	tr.HandleStreams(func(s *grpcTransport.Stream) {
 		gofunc.GoFunc(ctx, func() {
 			ri := svrTrans.pool.Get().(rpcinfo.RPCInfo)
-			defer svrTrans.pool.Put(ri)
 			rCtx := rpcinfo.NewCtxWithRPCInfo(s.Context(), ri)
+			defer func() {
+				// reset rpcinfo
+				ri, _ = t.opt.InitOrResetRPCInfoFunc(rCtx, conn.RemoteAddr())
+				svrTrans.pool.Put(ri)
+			}()
 
 			// set grpc transport flag before execute metahandler
 			rpcinfo.AsMutableRPCConfig(ri.Config()).SetTransportProtocol(transport.GRPC)
@@ -214,7 +218,7 @@ func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.
 	pool := &sync.Pool{
 		New: func() interface{} {
 			// init rpcinfo
-			ri, _ := t.opt.InitRPCInfoFunc(ctx, conn.RemoteAddr())
+			ri, _ := t.opt.InitOrResetRPCInfoFunc(ctx, conn.RemoteAddr())
 			return ri
 		},
 	}

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -228,8 +228,6 @@ func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.
 
 // 连接关闭时回调
 func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
-	// recycle rpcinfo
-	rpcinfo.PutRPCInfo(rpcinfo.GetRPCInfo(ctx))
 	tr := ctx.Value(ctxKeySvrTransport).(*SvrTrans).tr
 	tr.Close()
 }

--- a/pkg/rpcinfo/copy.go
+++ b/pkg/rpcinfo/copy.go
@@ -72,6 +72,8 @@ func copyEndpointInfo(ei EndpointInfo) EndpointInfo {
 	}
 	if v, ok := ei.(*endpointInfo); ok {
 		p.tags = copyMap(v.tags)
+	} else {
+		p.tags = make(map[string]string)
 	}
 	return p
 }

--- a/pkg/rpcinfo/endpointInfo.go
+++ b/pkg/rpcinfo/endpointInfo.go
@@ -100,6 +100,19 @@ func (ei *endpointInfo) ImmutableView() EndpointInfo {
 	return ei
 }
 
+// Reset implements the MutableEndpointInfo interface.
+func (ei *endpointInfo) Reset() {
+	ei.zero()
+}
+
+// ResetFromBasicInfo implements the MutableEndpointInfo interface.
+func (ei *endpointInfo) ResetFromBasicInfo(bi *EndpointBasicInfo) {
+	ei.serviceName = bi.ServiceName
+	ei.method = bi.Method
+	ei.address = nil
+	ei.tags = bi.Tags
+}
+
 func (ei *endpointInfo) zero() {
 	ei.serviceName = ""
 	ei.method = ""

--- a/pkg/rpcinfo/endpointInfo.go
+++ b/pkg/rpcinfo/endpointInfo.go
@@ -110,7 +110,12 @@ func (ei *endpointInfo) ResetFromBasicInfo(bi *EndpointBasicInfo) {
 	ei.serviceName = bi.ServiceName
 	ei.method = bi.Method
 	ei.address = nil
-	ei.tags = bi.Tags
+	for k := range ei.tags {
+		delete(ei.tags, k)
+	}
+	for k, v := range bi.Tags {
+		ei.tags[k] = v
+	}
 }
 
 func (ei *endpointInfo) zero() {

--- a/pkg/rpcinfo/invocation.go
+++ b/pkg/rpcinfo/invocation.go
@@ -36,6 +36,7 @@ type InvocationSetter interface {
 	SetServiceName(name string)
 	SetMethodName(name string)
 	SetSeqID(seqID int32)
+	Reset()
 }
 
 type invocation struct {
@@ -113,6 +114,11 @@ func (i *invocation) SetMethodName(name string) {
 	i.methodName = name
 }
 
+// Reset implements the InvocationSetter interface.
+func (i *invocation) Reset() {
+	i.zero()
+}
+
 // Recycle reuses the invocation.
 func (i *invocation) Recycle() {
 	i.zero()
@@ -121,6 +127,7 @@ func (i *invocation) Recycle() {
 
 func (i *invocation) zero() {
 	i.seqID = 0
+	i.packageName = ""
 	i.serviceName = ""
 	i.methodName = ""
 }

--- a/pkg/rpcinfo/mutable.go
+++ b/pkg/rpcinfo/mutable.go
@@ -31,6 +31,8 @@ type MutableEndpointInfo interface {
 	SetAddress(addr net.Addr) error
 	SetTag(key, value string) error
 	ImmutableView() EndpointInfo
+	Reset()
+	ResetFromBasicInfo(bi *EndpointBasicInfo)
 }
 
 // MutableRPCConfig is used to change the information in the RPCConfig.
@@ -46,6 +48,7 @@ type MutableRPCConfig interface {
 	SetInteractionMode(mode InteractionMode) error
 	LockConfig(bits int)
 	Clone() MutableRPCConfig
+	CopyFrom(from MutableRPCConfig)
 	ImmutableView() RPCConfig
 }
 

--- a/pkg/rpcinfo/mutable.go
+++ b/pkg/rpcinfo/mutable.go
@@ -48,7 +48,7 @@ type MutableRPCConfig interface {
 	SetInteractionMode(mode InteractionMode) error
 	LockConfig(bits int)
 	Clone() MutableRPCConfig
-	CopyFrom(from MutableRPCConfig)
+	CopyFrom(from RPCConfig)
 	ImmutableView() RPCConfig
 }
 

--- a/pkg/rpcinfo/rpcconfig.go
+++ b/pkg/rpcinfo/rpcconfig.go
@@ -184,7 +184,7 @@ func (r *rpcConfig) Clone() MutableRPCConfig {
 	return r2
 }
 
-func (r *rpcConfig) CopyFrom(from MutableRPCConfig) {
+func (r *rpcConfig) CopyFrom(from RPCConfig) {
 	f := from.(*rpcConfig)
 	*r = *f
 }

--- a/pkg/rpcinfo/rpcconfig.go
+++ b/pkg/rpcinfo/rpcconfig.go
@@ -71,7 +71,9 @@ func init() {
 }
 
 func newRPCConfig() interface{} {
-	return &rpcConfig{}
+	c := &rpcConfig{}
+	c.initialize()
+	return c
 }
 
 // LockConfig sets the bits of readonly mask to prevent sequential modification on certain configs.
@@ -182,28 +184,29 @@ func (r *rpcConfig) Clone() MutableRPCConfig {
 	return r2
 }
 
-func (r *rpcConfig) zero() {
-	r.rpcTimeout = 0
-	r.transportProtocol = 0
-	r.connectTimeout = 0
-	r.ioBufferSize = 0
+func (r *rpcConfig) CopyFrom(from MutableRPCConfig) {
+	f := from.(*rpcConfig)
+	*r = *f
+}
+
+func (r *rpcConfig) initialize() {
 	r.readOnlyMask = 0
-	r.readWriteTimeout = 0
+	r.rpcTimeout = defaultRPCTimeout
+	r.connectTimeout = defaultConnectTimeout
+	r.readWriteTimeout = defaultReadWriteTimeout
+	r.ioBufferSize = defaultBufferSize
+	r.transportProtocol = 0
+	r.interactionMode = defaultInteractionMode
 }
 
 // Recycle reuses the rpcConfig.
 func (r *rpcConfig) Recycle() {
-	r.zero()
+	r.initialize()
 	rpcConfigPool.Put(r)
 }
 
 // NewRPCConfig creates a default RPCConfig.
 func NewRPCConfig() RPCConfig {
 	r := rpcConfigPool.Get().(*rpcConfig)
-	r.rpcTimeout = defaultRPCTimeout
-	r.connectTimeout = defaultConnectTimeout
-	r.readWriteTimeout = defaultReadWriteTimeout
-	r.ioBufferSize = defaultBufferSize
-	r.interactionMode = defaultInteractionMode
 	return r
 }

--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,7 @@ func (s *server) initOrResetRPCInfoFunc() func(context.Context, net.Addr) (rpcin
 			if setter, ok := ri.Invocation().(rpcinfo.InvocationSetter); ok {
 				setter.Reset()
 			}
-			rpcinfo.AsMutableRPCConfig(ri.Config()).CopyFrom(rpcinfo.AsMutableRPCConfig(s.opt.Configs))
+			rpcinfo.AsMutableRPCConfig(ri.Config()).CopyFrom(s.opt.Configs)
 			rpcStats := rpcinfo.AsMutableRPCStats(ri.Stats())
 			rpcStats.Reset()
 			if s.opt.StatsLevel != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -121,10 +121,28 @@ func newErrorHandleMW(errHandle func(error) error) endpoint.Middleware {
 	}
 }
 
-func (s *server) initRPCInfoFunc() func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context) {
+func (s *server) initOrResetRPCInfoFunc() func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context) {
 	return func(ctx context.Context, rAddr net.Addr) (rpcinfo.RPCInfo, context.Context) {
 		if ctx == nil {
 			ctx = context.Background()
+		}
+		var ri rpcinfo.RPCInfo
+		// Reset rpcinfo if it exists in ctx.
+		if ri = rpcinfo.GetRPCInfo(ctx); ri != nil {
+			fi := rpcinfo.AsMutableEndpointInfo(ri.From())
+			fi.Reset()
+			fi.SetAddress(rAddr)
+			rpcinfo.AsMutableEndpointInfo(ri.To()).ResetFromBasicInfo(s.opt.Svr)
+			if setter, ok := ri.Invocation().(rpcinfo.InvocationSetter); ok {
+				setter.Reset()
+			}
+			rpcinfo.AsMutableRPCConfig(ri.Config()).CopyFrom(rpcinfo.AsMutableRPCConfig(s.opt.Configs))
+			rpcStats := rpcinfo.AsMutableRPCStats(ri.Stats())
+			rpcStats.Reset()
+			if s.opt.StatsLevel != nil {
+				rpcStats.SetLevel(*s.opt.StatsLevel)
+			}
+			return ri, ctx
 		}
 		rpcStats := rpcinfo.AsMutableRPCStats(rpcinfo.NewRPCStats())
 		if s.opt.StatsLevel != nil {
@@ -132,7 +150,7 @@ func (s *server) initRPCInfoFunc() func(context.Context, net.Addr) (rpcinfo.RPCI
 		}
 
 		// Export read-only views to external users and keep a mapping for internal users.
-		ri := rpcinfo.NewRPCInfo(
+		ri = rpcinfo.NewRPCInfo(
 			rpcinfo.EmptyEndpointInfo(),
 			rpcinfo.FromBasicInfo(s.opt.Svr),
 			rpcinfo.NewServerInvocation(),
@@ -275,7 +293,7 @@ func (s *server) invokeHandleEndpoint() endpoint.Endpoint {
 func (s *server) initBasicRemoteOption() {
 	remoteOpt := s.opt.RemoteOpt
 	remoteOpt.SvcInfo = s.svcInfo
-	remoteOpt.InitRPCInfoFunc = s.initRPCInfoFunc()
+	remoteOpt.InitOrResetRPCInfoFunc = s.initOrResetRPCInfoFunc()
 	remoteOpt.TracerCtl = s.opt.TracerCtl
 	remoteOpt.ReadWriteTimeout = s.opt.Configs.ReadWriteTimeout()
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -39,8 +39,10 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	"github.com/cloudwego/kitex/pkg/stats"
 	"github.com/cloudwego/kitex/pkg/transmeta"
 	"github.com/cloudwego/kitex/pkg/utils"
+	"github.com/cloudwego/kitex/transport"
 	"github.com/golang/mock/gomock"
 )
 
@@ -98,7 +100,7 @@ func TestReusePortServerRun(t *testing.T) {
 	wg.Wait()
 }
 
-func TestInitRPCInfo(t *testing.T) {
+func TestInitOrResetRPCInfo(t *testing.T) {
 	var opts []Option
 	rwTimeout := time.Millisecond
 	opts = append(opts, WithReadWriteTimeout(rwTimeout))
@@ -115,11 +117,111 @@ func TestInitRPCInfo(t *testing.T) {
 		return remoteAddr
 	}
 	ctx := context.Background()
-	rpcInfoInitFunc := svr.initRPCInfoFunc()
+	rpcInfoInitFunc := svr.initOrResetRPCInfoFunc()
 	ri, ctx := rpcInfoInitFunc(ctx, conn.RemoteAddr())
 	test.Assert(t, rpcinfo.GetRPCInfo(ctx) != nil)
 	test.Assert(t, ri.From().Address().String() == remoteAddr.String())
 	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
+
+	// modify rpcinfo
+	fi := rpcinfo.AsMutableEndpointInfo(ri.From())
+	fi.SetServiceName("mock service")
+	fi.SetMethod("mock method")
+	fi.SetTag("key", "value")
+
+	ti := rpcinfo.AsMutableEndpointInfo(ri.To())
+	ti.SetServiceName("mock service")
+	ti.SetMethod("mock method")
+	ti.SetTag("key", "value")
+
+	if setter, ok := ri.Invocation().(rpcinfo.InvocationSetter); ok {
+		setter.SetSeqID(123)
+		setter.SetPackageName("mock package")
+		setter.SetServiceName("mock service")
+		setter.SetMethodName("mock method")
+	}
+
+	mc := rpcinfo.AsMutableRPCConfig(ri.Config())
+	mc.SetTransportProtocol(transport.TTHeader)
+	mc.SetConnectTimeout(10 * time.Second)
+	mc.SetRPCTimeout(20 * time.Second)
+	mc.SetInteractionMode(rpcinfo.Streaming)
+	mc.SetIOBufferSize(1024)
+	mc.SetReadWriteTimeout(30 * time.Second)
+
+	rpcStats := rpcinfo.AsMutableRPCStats(ri.Stats())
+	rpcStats.SetRecvSize(1024)
+	rpcStats.SetSendSize(1024)
+	rpcStats.SetPanicked(errors.New("panic"))
+	rpcStats.SetError(errors.New("err"))
+	rpcStats.SetLevel(stats.LevelDetailed)
+
+	// check setting
+	test.Assert(t, rpcinfo.GetRPCInfo(ctx) == ri)
+
+	test.Assert(t, ri.From().ServiceName() == "mock service")
+	test.Assert(t, ri.From().Method() == "mock method")
+	value, exist := ri.From().Tag("key")
+	test.Assert(t, exist && value == "value")
+
+	test.Assert(t, ri.To().ServiceName() == "mock service")
+	test.Assert(t, ri.To().Method() == "mock method")
+	value, exist = ri.To().Tag("key")
+	test.Assert(t, exist && value == "value")
+
+	test.Assert(t, ri.Invocation().SeqID() == 123)
+	test.Assert(t, ri.Invocation().PackageName() == "mock package")
+	test.Assert(t, ri.Invocation().ServiceName() == "mock service")
+	test.Assert(t, ri.Invocation().MethodName() == "mock method")
+
+	test.Assert(t, ri.Config().TransportProtocol() == transport.TTHeader)
+	test.Assert(t, ri.Config().ConnectTimeout() == 10*time.Second)
+	test.Assert(t, ri.Config().RPCTimeout() == 20*time.Second)
+	test.Assert(t, ri.Config().InteractionMode() == rpcinfo.Streaming)
+	test.Assert(t, ri.Config().IOBufferSize() == 1024)
+	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
+
+	test.Assert(t, ri.Stats().RecvSize() == 1024)
+	test.Assert(t, ri.Stats().SendSize() == 1024)
+	hasPanicked, _ := ri.Stats().Panicked()
+	test.Assert(t, hasPanicked)
+	test.Assert(t, ri.Stats().Error() != nil)
+	test.Assert(t, ri.Stats().Level() == stats.LevelDetailed)
+
+	// test reset
+	ri, ctx = rpcInfoInitFunc(ctx, conn.RemoteAddr())
+	test.Assert(t, rpcinfo.GetRPCInfo(ctx) == ri)
+	test.Assert(t, ri.From().Address().String() == remoteAddr.String())
+	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
+
+	test.Assert(t, ri.From().ServiceName() == "")
+	test.Assert(t, ri.From().Method() == "")
+	_, exist = ri.From().Tag("key")
+	test.Assert(t, !exist)
+
+	test.Assert(t, ri.To().ServiceName() == "")
+	test.Assert(t, ri.To().Method() == "")
+	_, exist = ri.To().Tag("key")
+	test.Assert(t, !exist)
+
+	test.Assert(t, ri.Invocation().SeqID() == 0)
+	test.Assert(t, ri.Invocation().PackageName() == "")
+	test.Assert(t, ri.Invocation().ServiceName() == "")
+	test.Assert(t, ri.Invocation().MethodName() == "")
+
+	test.Assert(t, ri.Config().TransportProtocol() == 0)
+	test.Assert(t, ri.Config().ConnectTimeout() == 50*time.Millisecond)
+	test.Assert(t, ri.Config().RPCTimeout() == 0)
+	test.Assert(t, ri.Config().InteractionMode() == rpcinfo.Unary)
+	test.Assert(t, ri.Config().IOBufferSize() == 4096)
+	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
+
+	test.Assert(t, ri.Stats().RecvSize() == 0)
+	test.Assert(t, ri.Stats().SendSize() == 0)
+	_, panicked := ri.Stats().Panicked()
+	test.Assert(t, panicked == nil)
+	test.Assert(t, ri.Stats().Error() == nil)
+	test.Assert(t, ri.Stats().Level() == 0)
 }
 
 func TestServiceRegisterFailed(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
perf/fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: reuse rpcinfo to improve performance in long connection and gRPC scene, and fix the dirty data problem of rpcinfo multiplexing in netpollmux scene.
zh: 在长连接和gRPC场景下复用rpcinfo来提高性能，修复多路复用场景下rpcinfo复用导致的脏数据问题。

#### Which issue(s) this PR fixes:
