### PR TITLE
fix(tool): skip proto files with external import paths

### DIFF
--- a/tool/cmd/kitex/main.go
+++ b/tool/cmd/kitex/main.go
@@ -163,8 +163,11 @@ func buildCmd(a *arguments, out io.Writer) *exec.Cmd {
 		cmd.Args = append(cmd.Args,
 			"--kitex_out="+outPath,
 			"--kitex_opt="+kas,
-			a.IDL,
 		)
+		for _, po := range a.ProtobufOptions {
+			cmd.Args = append(cmd.Args, "--kitex_opt="+po)
+		}
+		cmd.Args = append(cmd.Args, a.IDL)
 	}
 	log.Info(strings.ReplaceAll(strings.Join(cmd.Args, " "), kas, fmt.Sprintf("%q", kas)))
 	return cmd

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -190,6 +190,7 @@ func (c *Config) Unpack(args []string) error {
 			}
 		}
 	}
+	log.Verbose = c.Verbose
 	return nil
 }
 

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -53,7 +53,7 @@ func (p *PackageInfo) AddImport(pkg, path string) {
 			parts := strings.Split(path, KitexGenPath)
 			path = filepath.Join(p.ExternalKitexGen, parts[len(parts)-1])
 		}
-		if strings.HasSuffix(path, "/"+pkg) || path == pkg {
+		if path == pkg {
 			p.Imports[path] = ""
 		} else {
 			p.Imports[path] = pkg

--- a/tool/internal_pkg/log/log.go
+++ b/tool/internal_pkg/log/log.go
@@ -52,13 +52,13 @@ func Warnf(format string, v ...interface{}) {
 // Info .
 func Info(v ...interface{}) {
 	if Verbose {
-		defaultLogger.Println(os.Stdout, v...)
+		defaultLogger.Println(os.Stderr, v...)
 	}
 }
 
 // Infof .
 func Infof(format string, v ...interface{}) {
 	if Verbose {
-		defaultLogger.Printf(os.Stdout, format, v...)
+		defaultLogger.Printf(os.Stderr, format, v...)
 	}
 }

--- a/tool/internal_pkg/pluginmode/protoc/plugin.go
+++ b/tool/internal_pkg/pluginmode/protoc/plugin.go
@@ -125,6 +125,10 @@ func (pp *protocPlugin) GenerateFile(gen *protogen.Plugin, file *protogen.File) 
 		return
 	}
 	log.Infof("[INFO] Generate %q at %q\n", file.Proto.GetName(), gopkg)
+
+	if parts := strings.Split(gopkg, ";"); len(parts) > 1 {
+		gopkg = parts[0] // remove package alias from file path
+	}
 	pp.Namespace = strings.TrimPrefix(gopkg, pp.PackagePrefix)
 
 	ss := pp.convertTypes(file)

--- a/tool/internal_pkg/pluginmode/protoc/plugin.go
+++ b/tool/internal_pkg/pluginmode/protoc/plugin.go
@@ -27,16 +27,17 @@ import (
 	"google.golang.org/protobuf/compiler/protogen"
 
 	"github.com/cloudwego/kitex/tool/internal_pkg/generator"
+	"github.com/cloudwego/kitex/tool/internal_pkg/log"
 	"github.com/cloudwego/kitex/tool/internal_pkg/util"
 )
 
 type protocPlugin struct {
 	generator.Config
 	generator.PackageInfo
-	Services           []*generator.ServiceInfo
-	kg                 generator.Generator
-	completeImportPath bool // indicates whether proto file go_package contains complete package path
-	err                error
+	Services    []*generator.ServiceInfo
+	kg          generator.Generator
+	err         error
+	importPaths map[string]string // file -> import path
 }
 
 // Name implements the protobuf_generator.Plugin interface.
@@ -48,6 +49,31 @@ func (pp *protocPlugin) Name() string {
 func (pp *protocPlugin) init() {
 	pp.Dependencies = map[string]string{
 		"proto": "google.golang.org/protobuf/proto",
+	}
+}
+
+// parse the 'M*' option
+// See https://developers.google.com/protocol-buffers/docs/reference/go-generated for more information.
+func (pp *protocPlugin) parseM() {
+	pp.importPaths = make(map[string]string)
+	for _, po := range pp.Config.ProtobufOptions {
+		if po == "" || po[0] != 'M' {
+			continue
+		}
+		idx := strings.Index(po, "=")
+		if idx < 0 {
+			continue
+		}
+		key := po[1:idx]
+		val := po[idx+1:]
+		if val == "" {
+			continue
+		}
+		idx = strings.Index(val, ";")
+		if idx >= 0 {
+			val = val[:idx]
+		}
+		pp.importPaths[key] = val
 	}
 }
 
@@ -93,13 +119,13 @@ func (pp *protocPlugin) GenerateFile(gen *protogen.Plugin, file *protogen.File) 
 		return
 	}
 	gopkg := file.Proto.GetOptions().GetGoPackage()
-	if pp.completeImportPath {
-		if parts := strings.SplitN(gopkg, generator.KitexGenPath, 2); len(parts) == 2 {
-			pp.Namespace = parts[1]
-		}
-	} else {
-		pp.Namespace = strings.TrimPrefix(gopkg, pp.PackagePrefix)
+	if !strings.HasPrefix(gopkg, pp.PackagePrefix) {
+		log.Warnf("[WARN] %q is skipped because its import path %q is not located in ./kitex_gen. Change the go_package option or use '--protobuf M%s=A-Import-Path-In-kitex_gen' to override it if you want this file to be generated under kitex_gen.\n",
+			file.Proto.GetName(), gopkg, file.Proto.GetName())
+		return
 	}
+	log.Infof("[INFO] Generate %q at %q\n", file.Proto.GetName(), gopkg)
+	pp.Namespace = strings.TrimPrefix(gopkg, pp.PackagePrefix)
 
 	ss := pp.convertTypes(file)
 	pp.Services = append(pp.Services, ss...)
@@ -245,7 +271,8 @@ func (pp *protocPlugin) convertTypes(file *protogen.File) (ss []*generator.Servi
 		mm := make(map[string]*generator.MethodInfo)
 		for _, m := range methods {
 			if _, ok := mm[m.Name]; ok {
-				println(fmt.Sprintf("combine service method %s in %s conflicts with %s in %s", m.Name, m.ServiceName, m.Name, mm[m.Name].ServiceName))
+				log.Warnf("[WARN] combine service method %s in %s conflicts with %s in %s\n",
+					m.Name, m.ServiceName, m.Name, mm[m.Name].ServiceName)
 				return
 			}
 			mm[m.Name] = m

--- a/tool/internal_pkg/pluginmode/protoc/util.go
+++ b/tool/internal_pkg/pluginmode/protoc/util.go
@@ -16,6 +16,7 @@ package protoc
 
 import (
 	"go/token"
+	"path/filepath"
 	"strings"
 	"unicode"
 )
@@ -34,4 +35,27 @@ func goSanitized(s string) string {
 		return "_" + s
 	}
 	return s
+}
+
+type pathElements struct {
+	module string // module name
+	prefix string // prefix of import path for generated codes
+}
+
+func (p *pathElements) getImportPath(pkg string) (path string, ok bool) {
+	parts := strings.Split(pkg, "/")
+	if len(parts) == 0 {
+		// malformed import path
+		return "", false
+	}
+
+	if strings.HasPrefix(pkg, p.prefix) {
+		return pkg, true
+	}
+	if strings.Contains(parts[0], ".") || (p.module != "" && strings.HasPrefix(pkg, p.module)) {
+		// already a complete import path, but outside the target path
+		return "", false
+	}
+	// incomplete import path
+	return filepath.Join(p.prefix, pkg), true
 }


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en: skip proto files with external import paths when generates code
zh: 生成代码的时候跳过指定了外部 import path 的 proto 文件

#### Which issue(s) this PR fixes:

closes #563 