### PR TITLE
refactor: support specify Listener for server

### DIFF
--- a/internal/mocks/transhandlerserver.go
+++ b/internal/mocks/transhandlerserver.go
@@ -130,7 +130,7 @@ type MockTransServer struct {
 	transHdlr remote.ServerTransHandler
 
 	CreateListenerFunc  func(net.Addr) (net.Listener, error)
-	BootstrapServerFunc func() (err error)
+	BootstrapServerFunc func(net.Listener) (err error)
 	ShutdownFunc        func() (err error)
 	ConnCountFunc       func() utils.AtomicInt
 }
@@ -144,9 +144,9 @@ func (t *MockTransServer) CreateListener(addr net.Addr) (ln net.Listener, err er
 }
 
 // BootstrapServer .
-func (t *MockTransServer) BootstrapServer() (err error) {
+func (t *MockTransServer) BootstrapServer(ln net.Listener) (err error) {
 	if t.BootstrapServerFunc != nil {
-		return t.BootstrapServerFunc()
+		return t.BootstrapServerFunc(ln)
 	}
 	return
 }

--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -79,7 +79,7 @@ type ServerOption struct {
 
 	PayloadCodec PayloadCodec
 
-	// Listener is used for customized need to listen addr, the priority is higher than Address.
+	// Listener is used to specify the server listener, which comes with higher priority than Address below.
 	Listener net.Listener
 
 	// Address is the listener addr

--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -79,6 +79,10 @@ type ServerOption struct {
 
 	PayloadCodec PayloadCodec
 
+	// Listener is used for customized need to listen addr, the priority is higher than Address.
+	Listener net.Listener
+
+	// Address is the listener addr
 	Address net.Addr
 
 	ReusePort bool

--- a/pkg/remote/remotesvr/server.go
+++ b/pkg/remote/remotesvr/server.go
@@ -65,11 +65,15 @@ func (s *server) Start() chan error {
 	s.listener = ln
 	s.Unlock()
 
-	go func() { errCh <- s.transSvr.BootstrapServer() }()
+	go func() { errCh <- s.transSvr.BootstrapServer(ln) }()
 	return errCh
 }
 
 func (s *server) buildListener() (ln net.Listener, err error) {
+	if s.opt.Listener != nil {
+		klog.Infof("KITEX: server listen at addr=%s", s.opt.Listener.Addr().String())
+		return s.opt.Listener, nil
+	}
 	addr := s.opt.Address
 	if ln, err = s.transSvr.CreateListener(addr); err != nil {
 		klog.Errorf("KITEX: server listen failed, addr=%s error=%s", addr.String(), err)

--- a/pkg/remote/remotesvr/server_test.go
+++ b/pkg/remote/remotesvr/server_test.go
@@ -38,7 +38,7 @@ func TestServerStart(t *testing.T) {
 			ln, err = net.Listen("tcp", ":8888")
 			return ln, err
 		},
-		BootstrapServerFunc: func() (err error) {
+		BootstrapServerFunc: func(net.Listener) (err error) {
 			isBootstrapped = true
 			return nil
 		},

--- a/pkg/remote/trans/gonet/trans_server.go
+++ b/pkg/remote/trans/gonet/trans_server.go
@@ -63,16 +63,17 @@ var _ remote.TransServer = &transServer{}
 
 // CreateListener implements the remote.TransServer interface.
 // The network must be "tcp", "tcp4", "tcp6" or "unix".
-func (ts *transServer) CreateListener(addr net.Addr) (_ net.Listener, err error) {
-	ts.ln, err = ts.lncfg.Listen(context.Background(), addr.Network(), addr.String())
-	return ts.ln, err
+func (ts *transServer) CreateListener(addr net.Addr) (ln net.Listener, err error) {
+	ln, err = ts.lncfg.Listen(context.Background(), addr.Network(), addr.String())
+	return ln, err
 }
 
 // BootstrapServer implements the remote.TransServer interface.
-func (ts *transServer) BootstrapServer() (err error) {
-	if ts.ln == nil {
+func (ts *transServer) BootstrapServer(ln net.Listener) (err error) {
+	if ln == nil {
 		return errors.New("listener is nil in gonet transport server")
 	}
+	ts.ln = ln
 	for {
 		conn, err := ts.ln.Accept()
 		if err != nil {

--- a/pkg/remote/trans/netpoll/trans_server.go
+++ b/pkg/remote/trans/netpoll/trans_server.go
@@ -64,20 +64,21 @@ type transServer struct {
 var _ remote.TransServer = &transServer{}
 
 // CreateListener implements the remote.TransServer interface.
-func (ts *transServer) CreateListener(addr net.Addr) (_ net.Listener, err error) {
+func (ts *transServer) CreateListener(addr net.Addr) (net.Listener, error) {
 	if addr.Network() == "unix" {
 		syscall.Unlink(addr.String())
 	}
 	// The network must be "tcp", "tcp4", "tcp6" or "unix".
-	ts.ln, err = ts.lncfg.Listen(context.Background(), addr.Network(), addr.String())
-	return ts.ln, err
+	ln, err := ts.lncfg.Listen(context.Background(), addr.Network(), addr.String())
+	return ln, err
 }
 
 // BootstrapServer implements the remote.TransServer interface.
-func (ts *transServer) BootstrapServer() (err error) {
-	if ts.ln == nil {
+func (ts *transServer) BootstrapServer(ln net.Listener) (err error) {
+	if ln == nil {
 		return errors.New("listener is nil in netpoll transport server")
 	}
+	ts.ln = ln
 	opts := []netpoll.Option{
 		netpoll.WithIdleTimeout(ts.opt.MaxConnectionIdleTime),
 		netpoll.WithReadTimeout(ts.opt.ReadWriteTimeout),

--- a/pkg/remote/trans/netpoll/trans_server_test.go
+++ b/pkg/remote/trans/netpoll/trans_server_test.go
@@ -109,7 +109,7 @@ func TestBootStrap(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		err = transSvr.BootstrapServer()
+		err = transSvr.BootstrapServer(ln)
 		test.Assert(t, err == nil, err)
 		wg.Done()
 	}()

--- a/pkg/remote/trans/netpollmux/client_handler.go
+++ b/pkg/remote/trans/netpollmux/client_handler.go
@@ -45,7 +45,7 @@ func NewCliTransHandlerFactory() remote.ClientTransHandlerFactory {
 // NewTransHandler implements the remote.ClientTransHandlerFactory interface.
 func (f *cliTransHandlerFactory) NewTransHandler(opt *remote.ClientOption) (remote.ClientTransHandler, error) {
 	if _, ok := opt.ConnPool.(*MuxPool); !ok {
-		return nil, fmt.Errorf("ConnPool[%T] invalid, netpoll mux just suppot MuxPool", opt.ConnPool)
+		return nil, fmt.Errorf("ConnPool[%T] invalid, netpoll mux just support MuxPool", opt.ConnPool)
 	}
 	return newCliTransHandler(opt)
 }

--- a/pkg/remote/trans_server.go
+++ b/pkg/remote/trans_server.go
@@ -30,7 +30,7 @@ type TransServerFactory interface {
 // TransServer is the abstraction for remote server.
 type TransServer interface {
 	CreateListener(net.Addr) (net.Listener, error)
-	BootstrapServer() (err error)
+	BootstrapServer(net.Listener) (err error)
 	Shutdown() error
 	ConnCount() utils.AtomicInt
 }

--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -22,6 +22,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 
 	internal_server "github.com/cloudwego/kitex/internal/server"
 	"github.com/cloudwego/kitex/pkg/acl"
@@ -161,7 +162,18 @@ func WithExitSignal(f func() <-chan error) Option {
 	}}
 }
 
-// WithReusePort sets SO_REUSEPORT on listener.
+// WithListener sets the listener for server, which is used for customized need to listen addr,
+// the priority is higher than WithServiceAddr
+func WithListener(ln net.Listener) Option {
+	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithListener(%+v)", ln))
+
+		o.RemoteOpt.Listener = ln
+	}}
+}
+
+// WithReusePort sets SO_REUSEPORT on listener, it is only used with Option `WithServiceAddr`.
+// It cannot be effective for specifying Listener by `WithListener`.
 func WithReusePort(reuse bool) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithReusePort(%+v)", reuse))

--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -162,8 +162,7 @@ func WithExitSignal(f func() <-chan error) Option {
 	}}
 }
 
-// WithListener sets the listener for server, which is used for customized need to listen addr,
-// the priority is higher than WithServiceAddr
+// WithListener sets the listener for server, the priority is higher than WithServiceAddr
 func WithListener(ln net.Listener) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithListener(%+v)", ln))
@@ -173,7 +172,7 @@ func WithListener(ln net.Listener) Option {
 }
 
 // WithReusePort sets SO_REUSEPORT on listener, it is only used with Option `WithServiceAddr`.
-// It cannot be effective for specifying Listener by `WithListener`.
+// It won't take effect when listener is specified by WithListener.
 func WithReusePort(reuse bool) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithReusePort(%+v)", reuse))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -432,7 +432,7 @@ func TestInvokeHandlerExec(t *testing.T) {
 	exitCh := make(chan bool)
 	var ln net.Listener
 	transSvr := &mocks.MockTransServer{
-		BootstrapServerFunc: func() error {
+		BootstrapServerFunc: func(net.Listener) error {
 			{ // mock server call
 				ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation(svcInfo.ServiceName, callMethod), nil, rpcinfo.NewRPCStats())
 				ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
@@ -495,7 +495,7 @@ func TestInvokeHandlerPanic(t *testing.T) {
 	exitCh := make(chan bool)
 	var ln net.Listener
 	transSvr := &mocks.MockTransServer{
-		BootstrapServerFunc: func() error {
+		BootstrapServerFunc: func(net.Listener) error {
 			{
 				// mock server call
 				ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation(svcInfo.ServiceName, callMethod), nil, rpcinfo.NewRPCStats())


### PR DESCRIPTION
#### What type of PR is this?
refactor

#### What this PR does / why we need it (en: English/zh: Chinese):
en: feat: support specify Listener for server by option WithListener, the priority is higher than WithServiceAddr
zh: feat: 服务端支持通过 WithListener 配置 listener，其优先级高于 WithServiceAddr


#### Which issue(s) this PR fixes:
related https://github.com/cloudwego/kitex/pull/518/files
