### PR TITLE
fix: generic escape double in tag

### DIFF
--- a/pkg/generic/descriptor/field_mapping.go
+++ b/pkg/generic/descriptor/field_mapping.go
@@ -18,8 +18,11 @@ package descriptor
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 )
+
+var escape = regexp.MustCompile(`\\.`)
 
 // FiledMapping mapping handle for filed descriptor
 type FiledMapping interface {
@@ -39,6 +42,12 @@ type goTag struct {
 
 // NewGoTag go.tag annotation creator
 var NewGoTag NewFieldMapping = func(value string) FiledMapping {
+	value = escape.ReplaceAllStringFunc(value, func(m string) string {
+		if m[1] == '"' {
+			return m[1:]
+		}
+		return m
+	})
 	return &goTag{reflect.StructTag(value)}
 }
 

--- a/pkg/generic/descriptor/field_mapping_test.go
+++ b/pkg/generic/descriptor/field_mapping_test.go
@@ -30,4 +30,6 @@ func Test_goTag_Handle(t *testing.T) {
 	test.Assert(t, f.Alias == "a", f.Alias)
 	NewGoTag(`db:"b" json:"a,string"`).Handle(f)
 	test.Assert(t, f.Alias == "a", f.Alias)
+	NewGoTag(`json:\"a\"`).Handle(f)
+	test.Assert(t, f.Alias == "a", f.Alias)
 }

--- a/pkg/remote/trans/netpollmux/client_handler.go
+++ b/pkg/remote/trans/netpollmux/client_handler.go
@@ -45,7 +45,7 @@ func NewCliTransHandlerFactory() remote.ClientTransHandlerFactory {
 // NewTransHandler implements the remote.ClientTransHandlerFactory interface.
 func (f *cliTransHandlerFactory) NewTransHandler(opt *remote.ClientOption) (remote.ClientTransHandler, error) {
 	if _, ok := opt.ConnPool.(*MuxPool); !ok {
-		return nil, fmt.Errorf("ConnPool[%T] invalid, netpoll mux just suppot MuxPool", opt.ConnPool)
+		return nil, fmt.Errorf("ConnPool[%T] invalid, netpoll mux just support MuxPool", opt.ConnPool)
 	}
 	return newCliTransHandler(opt)
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Support the tag format of the escape double quotes in single quotes to be compatible with the logic of the old version.
zh: 泛化调用支持单引号中双引号带转义符的tag格式以兼容旧版本逻辑

#### Which issue(s) this PR fixes:
https://github.com/cloudwego/thriftgo/blob/e1caf7dbdce956686dd32d3b9c8d4334662c1b76/generator/golang/util.go#L238
