### PR TITLE
fix: rpcinfo panic on http2 server

### DIFF
--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -98,7 +98,7 @@ type ServerOption struct {
 
 	ReadWriteTimeout time.Duration
 
-	InitOrResetRPCInfoFunc func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context)
+	InitOrResetRPCInfoFunc func(rpcinfo.RPCInfo, net.Addr) rpcinfo.RPCInfo
 
 	TracerCtl *internal_stats.Controller
 

--- a/pkg/remote/trans/gonet/trans_server.go
+++ b/pkg/remote/trans/gonet/trans_server.go
@@ -81,7 +81,8 @@ func (ts *transServer) BootstrapServer(ln net.Listener) (err error) {
 			os.Exit(1)
 		}
 		go func() {
-			ri, ctx := ts.opt.InitOrResetRPCInfoFunc(context.Background(), conn.RemoteAddr())
+			ri := ts.opt.InitOrResetRPCInfoFunc(nil, conn.RemoteAddr())
+			ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
 			defer func() {
 				transRecover(ctx, conn, "OnRead")
 				// recycle rpcinfo

--- a/pkg/remote/trans/gonet/trans_server_test.go
+++ b/pkg/remote/trans/gonet/trans_server_test.go
@@ -17,7 +17,6 @@
 package gonet
 
 import (
-	"context"
 	"net"
 	"os"
 	"testing"
@@ -43,17 +42,16 @@ var (
 
 func TestMain(m *testing.M) {
 	svrOpt = &remote.ServerOption{
-		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			fromInfo := rpcinfo.EmptyEndpointInfo()
 			rpcCfg := rpcinfo.NewRPCConfig()
 			mCfg := rpcinfo.AsMutableRPCConfig(rpcCfg)
 			mCfg.SetReadWriteTimeout(rwTimeout)
 			ink := rpcinfo.NewInvocation("", method)
 			rpcStat := rpcinfo.NewRPCStats()
-			ri := rpcinfo.NewRPCInfo(fromInfo, nil, ink, rpcCfg, rpcStat)
-			rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(addr)
-			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
-			return ri, ctx
+			nri := rpcinfo.NewRPCInfo(fromInfo, nil, ink, rpcCfg, rpcStat)
+			rpcinfo.AsMutableEndpointInfo(nri.From()).SetAddress(addr)
+			return nri
 		},
 		Codec: &MockCodec{
 			EncodeFunc: nil,

--- a/pkg/remote/trans/netpoll/trans_server_test.go
+++ b/pkg/remote/trans/netpoll/trans_server_test.go
@@ -46,17 +46,16 @@ var (
 
 func TestMain(m *testing.M) {
 	svrOpt = &remote.ServerOption{
-		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
+		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			fromInfo := rpcinfo.EmptyEndpointInfo()
 			rpcCfg := rpcinfo.NewRPCConfig()
 			mCfg := rpcinfo.AsMutableRPCConfig(rpcCfg)
 			mCfg.SetReadWriteTimeout(rwTimeout)
 			ink := rpcinfo.NewInvocation("", method)
 			rpcStat := rpcinfo.NewRPCStats()
-			ri := rpcinfo.NewRPCInfo(fromInfo, nil, ink, rpcCfg, rpcStat)
-			rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(addr)
-			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
-			return ri, ctx
+			nri := rpcinfo.NewRPCInfo(fromInfo, nil, ink, rpcCfg, rpcStat)
+			rpcinfo.AsMutableEndpointInfo(nri.From()).SetAddress(addr)
+			return nri
 		},
 		Codec: &MockCodec{
 			EncodeFunc: nil,

--- a/pkg/remote/trans/netpollmux/mux_conn.go
+++ b/pkg/remote/trans/netpollmux/mux_conn.go
@@ -145,7 +145,7 @@ func newMuxSvrConn(connection netpoll.Connection, pool *sync.Pool) *muxSvrConn {
 
 type muxSvrConn struct {
 	muxConn
-	pool *sync.Pool // ctx with rpcInfo
+	pool *sync.Pool // pool of rpcInfo
 }
 
 func newMuxConn(connection netpoll.Connection) muxConn {

--- a/pkg/remote/trans/nphttp2/mocks_test.go
+++ b/pkg/remote/trans/nphttp2/mocks_test.go
@@ -304,8 +304,8 @@ func newMockServerOption() *remote.ServerOption {
 		AcceptFailedDelayTime: 0,
 		MaxConnectionIdleTime: 0,
 		ReadWriteTimeout:      0,
-		InitOrResetRPCInfoFunc: func(ctx context.Context, addr net.Addr) (rpcinfo.RPCInfo, context.Context) {
-			return newMockRPCInfo(), context.Background()
+		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
+			return newMockRPCInfo()
 		},
 		TracerCtl: &stats.Controller{},
 		GRPCCfg: &grpc.ServerConfig{

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -100,7 +100,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 			rCtx := rpcinfo.NewCtxWithRPCInfo(s.Context(), ri)
 			defer func() {
 				// reset rpcinfo
-				ri, _ = t.opt.InitOrResetRPCInfoFunc(rCtx, conn.RemoteAddr())
+				ri = t.opt.InitOrResetRPCInfoFunc(ri, conn.RemoteAddr())
 				svrTrans.pool.Put(ri)
 			}()
 
@@ -218,7 +218,7 @@ func (t *svrTransHandler) OnActive(ctx context.Context, conn net.Conn) (context.
 	pool := &sync.Pool{
 		New: func() interface{} {
 			// init rpcinfo
-			ri, _ := t.opt.InitOrResetRPCInfoFunc(ctx, conn.RemoteAddr())
+			ri := t.opt.InitOrResetRPCInfoFunc(nil, conn.RemoteAddr())
 			return ri
 		},
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -121,14 +121,10 @@ func newErrorHandleMW(errHandle func(error) error) endpoint.Middleware {
 	}
 }
 
-func (s *server) initOrResetRPCInfoFunc() func(context.Context, net.Addr) (rpcinfo.RPCInfo, context.Context) {
-	return func(ctx context.Context, rAddr net.Addr) (rpcinfo.RPCInfo, context.Context) {
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		var ri rpcinfo.RPCInfo
+func (s *server) initOrResetRPCInfoFunc() func(rpcinfo.RPCInfo, net.Addr) rpcinfo.RPCInfo {
+	return func(ri rpcinfo.RPCInfo, rAddr net.Addr) rpcinfo.RPCInfo {
 		// Reset rpcinfo if it exists in ctx.
-		if ri = rpcinfo.GetRPCInfo(ctx); ri != nil {
+		if ri != nil {
 			fi := rpcinfo.AsMutableEndpointInfo(ri.From())
 			fi.Reset()
 			fi.SetAddress(rAddr)
@@ -142,7 +138,7 @@ func (s *server) initOrResetRPCInfoFunc() func(context.Context, net.Addr) (rpcin
 			if s.opt.StatsLevel != nil {
 				rpcStats.SetLevel(*s.opt.StatsLevel)
 			}
-			return ri, ctx
+			return ri
 		}
 		rpcStats := rpcinfo.AsMutableRPCStats(rpcinfo.NewRPCStats())
 		if s.opt.StatsLevel != nil {
@@ -158,8 +154,7 @@ func (s *server) initOrResetRPCInfoFunc() func(context.Context, net.Addr) (rpcin
 			rpcStats.ImmutableView(),
 		)
 		rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(rAddr)
-		ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
-		return ri, ctx
+		return ri
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -116,10 +116,9 @@ func TestInitOrResetRPCInfo(t *testing.T) {
 	conn.RemoteAddrFunc = func() (r net.Addr) {
 		return remoteAddr
 	}
-	ctx := context.Background()
 	rpcInfoInitFunc := svr.initOrResetRPCInfoFunc()
-	ri, ctx := rpcInfoInitFunc(ctx, conn.RemoteAddr())
-	test.Assert(t, rpcinfo.GetRPCInfo(ctx) != nil)
+	ri := rpcInfoInitFunc(nil, conn.RemoteAddr())
+	test.Assert(t, ri != nil)
 	test.Assert(t, ri.From().Address().String() == remoteAddr.String())
 	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
 
@@ -157,8 +156,6 @@ func TestInitOrResetRPCInfo(t *testing.T) {
 	rpcStats.SetLevel(stats.LevelDetailed)
 
 	// check setting
-	test.Assert(t, rpcinfo.GetRPCInfo(ctx) == ri)
-
 	test.Assert(t, ri.From().ServiceName() == "mock service")
 	test.Assert(t, ri.From().Method() == "mock method")
 	value, exist := ri.From().Tag("key")
@@ -189,8 +186,7 @@ func TestInitOrResetRPCInfo(t *testing.T) {
 	test.Assert(t, ri.Stats().Level() == stats.LevelDetailed)
 
 	// test reset
-	ri, ctx = rpcInfoInitFunc(ctx, conn.RemoteAddr())
-	test.Assert(t, rpcinfo.GetRPCInfo(ctx) == ri)
+	ri = rpcInfoInitFunc(ri, conn.RemoteAddr())
 	test.Assert(t, ri.From().Address().String() == remoteAddr.String())
 	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
 


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: fix the panic problem caused by rpcinfo multiplexing under http2
zh: 修复http2下rpcinfo复用导致的panic问题

#### Which issue(s) this PR fixes:

