### PR TITLE
fix: set message payload size when decode PurePayload

### DIFF
--- a/pkg/remote/codec/default_codec.go
+++ b/pkg/remote/codec/default_codec.go
@@ -176,8 +176,13 @@ func (c *defaultCodec) Decode(ctx context.Context, message remote.Message, in re
 	}
 
 	// 2. decode body
+	hasRead := in.ReadLen()
 	if err = c.decodePayload(ctx, message, in); err != nil {
 		return err
+	}
+	if message.PayloadLen() == 0 {
+		// if protocol is PurePayload, should set payload length after decoded
+		message.SetPayloadLen(in.ReadLen() - hasRead)
 	}
 	return nil
 }

--- a/pkg/remote/codec/protobuf/grpc.go
+++ b/pkg/remote/codec/protobuf/grpc.go
@@ -98,6 +98,7 @@ func (c *grpcCodec) Decode(ctx context.Context, message remote.Message, in remot
 	if err != nil {
 		return err
 	}
+	message.SetPayloadLen(dLen)
 	data := message.Data()
 	switch t := data.(type) {
 	case fastpb.Reader:


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (en: English/zh: Chinese):

en: set message payload size when decode PurePayload
zh: 在解码时针对 PurePayload 协议依然设置 Payload Size

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
