### PR TITLE
feat: add clientSuite for xds

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/stats"
 	"github.com/cloudwego/kitex/pkg/utils"
 	"github.com/cloudwego/kitex/pkg/warmup"
+	"github.com/cloudwego/kitex/pkg/xds"
 	"github.com/cloudwego/kitex/transport"
 )
 
@@ -484,13 +485,14 @@ func WithWarmingUp(wuo *warmup.ClientOption) Option {
 	}}
 }
 
-// WithXDSSuite is used to set the xds suite for the client with the input xdsRouteMiddleware and xdsResolver
-func WithXDSSuite(rm endpoint.Middleware, r discovery.Resolver) Option {
+// WithXDSSuite is used to set the xds suite for the client.
+func WithXDSSuite(suite *xds.ClientSuite) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
-		di.Push("WithXDSSuite")
-
-		o.XDSEnabled = true
-		o.XDSRouterMiddleware = rm
-		o.Resolver = r
+		if xds.CheckClientSuite(suite) {
+			di.Push("WithXDSSuite")
+			o.XDSEnabled = true
+			o.XDSRouterMiddleware = suite.RouterMiddleware
+			o.Resolver = suite.Resolver
+		}
 	}}
 }

--- a/client/option.go
+++ b/client/option.go
@@ -486,7 +486,7 @@ func WithWarmingUp(wuo *warmup.ClientOption) Option {
 }
 
 // WithXDSSuite is used to set the xds suite for the client.
-func WithXDSSuite(suite *xds.ClientSuite) Option {
+func WithXDSSuite(suite xds.ClientSuite) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		if xds.CheckClientSuite(suite) {
 			di.Push("WithXDSSuite")

--- a/client/option_test.go
+++ b/client/option_test.go
@@ -599,7 +599,7 @@ func TestWithConnMetric(t *testing.T) {
 
 func TestWithXDSSuite(t *testing.T) {
 	// failed
-	s := &xds.ClientSuite{}
+	s := xds.ClientSuite{}
 	options := []client.Option{
 		WithXDSSuite(s),
 	}
@@ -609,7 +609,7 @@ func TestWithXDSSuite(t *testing.T) {
 	test.Assert(t, opt.Resolver == nil)
 
 	// succeed
-	s = &xds.ClientSuite{
+	s = xds.ClientSuite{
 		RouterMiddleware: endpoint.DummyMiddleware,
 		Resolver:         discovery.SynthesizedResolver{},
 	}

--- a/client/option_test.go
+++ b/client/option_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+
 	"github.com/cloudwego/kitex/internal/client"
 	"github.com/cloudwego/kitex/internal/mocks"
 	mock_remote "github.com/cloudwego/kitex/internal/mocks/remote"
@@ -44,8 +46,8 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/rpcinfo/remoteinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
+	"github.com/cloudwego/kitex/pkg/xds"
 	"github.com/cloudwego/kitex/transport"
-	"github.com/golang/mock/gomock"
 )
 
 func TestRetryOptionDebugInfo(t *testing.T) {
@@ -593,4 +595,29 @@ func TestWithConnMetric(t *testing.T) {
 	}
 	opt := client.NewOptions(options)
 	test.Assert(t, opt.RemoteOpt.EnableConnPoolReporter == true)
+}
+
+func TestWithXDSSuite(t *testing.T) {
+	// failed
+	s := &xds.ClientSuite{}
+	options := []client.Option{
+		WithXDSSuite(s),
+	}
+	opt := client.NewOptions(options)
+	test.Assert(t, opt.XDSEnabled == false)
+	test.Assert(t, opt.XDSRouterMiddleware == nil)
+	test.Assert(t, opt.Resolver == nil)
+
+	// succeed
+	s = &xds.ClientSuite{
+		RouterMiddleware: endpoint.DummyMiddleware,
+		Resolver:         discovery.SynthesizedResolver{},
+	}
+	options = []client.Option{
+		WithXDSSuite(s),
+	}
+	opt = client.NewOptions(options)
+	test.Assert(t, opt.XDSEnabled == true)
+	test.Assert(t, opt.XDSRouterMiddleware != nil)
+	test.Assert(t, opt.Resolver != nil)
 }

--- a/pkg/xds/xds.go
+++ b/pkg/xds/xds.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xds
+
+import (
+	"github.com/cloudwego/kitex/pkg/discovery"
+	"github.com/cloudwego/kitex/pkg/endpoint"
+)
+
+// ClientSuite includes all extensions used by the xDS-enabled client.
+type ClientSuite struct {
+	RouterMiddleware endpoint.Middleware
+	Resolver         discovery.Resolver
+}
+
+// CheckClientSuite checks if the client suite is valid.
+// RouteMiddleware and Resolver should not be nil.
+func CheckClientSuite(cs *ClientSuite) bool {
+	return cs.RouterMiddleware != nil && cs.Resolver != nil
+}

--- a/pkg/xds/xds.go
+++ b/pkg/xds/xds.go
@@ -29,6 +29,6 @@ type ClientSuite struct {
 
 // CheckClientSuite checks if the client suite is valid.
 // RouteMiddleware and Resolver should not be nil.
-func CheckClientSuite(cs *ClientSuite) bool {
+func CheckClientSuite(cs ClientSuite) bool {
 	return cs.RouterMiddleware != nil && cs.Resolver != nil
 }


### PR DESCRIPTION
#### What type of PR is this?
feat

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: provide clientSuite for xds, which will be used in `client.WithXDSSuite` option and avoid the modification of interface if adding new features.
zh: 添加 xds 客户端配置，用于 `client.WithXDSSuite` 接口，避免之后功能增加时的接口变更。

#### Which issue(s) this PR fixes:
