### PR TITLE
fix: revert golang 1.16 api for compatibility with lower go version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,16 +15,28 @@ test: Adding missing tests or correcting existing tests
 chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
 -->
 
-#### What this PR does / why we need it (en: English/zh: Chinese):
+#### Check the PR title.
 <!--
-The description will be attached in Release Notes, 
-so please describe it from user-oriented.
+The description of title will be attached in Release Notes, 
+so please describe it from user-oriented, what this PR does / why we need it.
+Please check your PR title with below requirements:
+-->
+- [ ] The PR title match the format: \<type\>(optional scope): \<description\>
+- [ ] The description of PR title is from user-oriented and clear enough for others to understand.
+
+
+#### (Optional) Translate the PR title into Chinese.
+
+
+#### (Optional) More detail description for this PR(en: English/zh: Chinese).
+<!--
+Provide more detail info for review. If it is a perf type PR, perf data is suggested to give.
 -->
 en: 
-zh:
+zh(optional): 
 
 #### Which issue(s) this PR fixes:
 <!--
-*Automatically closes linked issue when PR is merged.
+Automatically closes linked issue when PR is merged.
 Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   unit-benchmark-test:
     strategy:
       matrix:
-        go: [ 1.17, 1.18, 1.19 ]
+        go: [ 1.15, 1.17, 1.18, 1.19 ]
         os: [ X64, ARM64 ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,7 +34,7 @@ jobs:
   scenario-test:
     strategy:
       matrix:
-        go: [ 1.17, 1.18 ]
+        go: [ 1.15, 1.18 ]
     runs-on: [ self-hosted, X64 ]
     steps:
       - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudwego/kitex
 
-go 1.16
+go 1.13
 
 require (
 	github.com/apache/thrift v0.13.0

--- a/pkg/generic/httppbthrift_codec.go
+++ b/pkg/generic/httppbthrift_codec.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -168,7 +169,7 @@ func FromHTTPPbRequest(req *http.Request) (*HTTPRequest, error) {
 		// body == nil if from Get request
 		return customReq, nil
 	}
-	if customReq.RawBody, err = io.ReadAll(b); err != nil {
+	if customReq.RawBody, err = ioutil.ReadAll(b); err != nil {
 		return nil, err
 	}
 	if len(customReq.RawBody) == 0 {

--- a/pkg/generic/httpthrift_codec.go
+++ b/pkg/generic/httpthrift_codec.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"sync/atomic"
 
@@ -154,7 +155,7 @@ func FromHTTPRequest(req *http.Request) (*HTTPRequest, error) {
 		// body == nil if from Get request
 		return customReq, nil
 	}
-	if customReq.RawBody, err = io.ReadAll(b); err != nil {
+	if customReq.RawBody, err = ioutil.ReadAll(b); err != nil {
 		return nil, err
 	}
 	if len(customReq.RawBody) == 0 {

--- a/pkg/remote/codec/default_codec.go
+++ b/pkg/remote/codec/default_codec.go
@@ -176,8 +176,13 @@ func (c *defaultCodec) Decode(ctx context.Context, message remote.Message, in re
 	}
 
 	// 2. decode body
+	hasRead := in.ReadLen()
 	if err = c.decodePayload(ctx, message, in); err != nil {
 		return err
+	}
+	if message.PayloadLen() == 0 {
+		// if protocol is PurePayload, should set payload length after decoded
+		message.SetPayloadLen(in.ReadLen() - hasRead)
 	}
 	return nil
 }

--- a/pkg/remote/codec/protobuf/grpc.go
+++ b/pkg/remote/codec/protobuf/grpc.go
@@ -98,6 +98,7 @@ func (c *grpcCodec) Decode(ctx context.Context, message remote.Message, in remot
 	if err != nil {
 		return err
 	}
+	message.SetPayloadLen(dLen)
 	data := message.Data()
 	switch t := data.(type) {
 	case fastpb.Reader:

--- a/pkg/remote/trans/detection/server_handler.go
+++ b/pkg/remote/trans/detection/server_handler.go
@@ -112,8 +112,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 
 func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 	// t.http2 should use the ctx returned by OnActive in r.ctx
-	r := ctx.Value(handlerKey{}).(*handlerWrapper)
-	if r.ctx != nil {
+	if r, ok := ctx.Value(handlerKey{}).(*handlerWrapper); ok && r.ctx != nil {
 		ctx = r.ctx
 	}
 	t.which(ctx).OnInactive(ctx, conn)

--- a/pkg/remote/trans/netpoll/http_client_handler.go
+++ b/pkg/remote/trans/netpoll/http_client_handler.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"path"
@@ -279,7 +279,7 @@ func getBodyBufReader(buf remote.ByteBuffer) (remote.ByteBuffer, error) {
 	if hr.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("http response not OK, StatusCode: %d", hr.StatusCode)
 	}
-	b, err := io.ReadAll(hr.Body)
+	b, err := ioutil.ReadAll(hr.Body)
 	hr.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("read http response body error:%w", err)

--- a/pkg/utils/yaml.go
+++ b/pkg/utils/yaml.go
@@ -17,7 +17,7 @@
 package utils
 
 import (
-	"io"
+	"io/ioutil"
 	"os"
 	"time"
 
@@ -45,7 +45,7 @@ func ReadYamlConfigFile(yamlFile string) (*YamlConfig, error) {
 	}
 	defer fd.Close()
 
-	b, err := io.ReadAll(fd)
+	b, err := ioutil.ReadAll(fd)
 	if err != nil {
 		return nil, err
 	}

--- a/tool/internal_pkg/pluginmode/protoc/protoc.go
+++ b/tool/internal_pkg/pluginmode/protoc/protoc.go
@@ -17,7 +17,7 @@ package protoc
 import (
 	"errors"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +44,7 @@ func Run() int {
 
 func run(opts protogen.Options) error {
 	// unmarshal request from stdin
-	in, err := io.ReadAll(os.Stdin)
+	in, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/tool/internal_pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/patcher.go
@@ -16,7 +16,7 @@ package thriftgo
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -205,7 +205,7 @@ func (p *patcher) patch(req *plugin.Request) (patches []*plugin.Generated, err e
 		})
 
 		if p.copyIDL {
-			content, err := os.ReadFile(ast.Filename)
+			content, err := ioutil.ReadFile(ast.Filename)
 			if err != nil {
 				return nil, fmt.Errorf("read %q: %w", ast.Filename, err)
 			}

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -17,7 +17,7 @@ package thriftgo
 import (
 	"errors"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/cloudwego/thriftgo/plugin"
@@ -34,7 +34,7 @@ const TheUseOptionMessage = "kitex_gen is not generated due to the -use option"
 // Run is an entry of the plugin mode of kitex for thriftgo.
 // It reads a plugin request from the standard input and writes out a response.
 func Run() int {
-	data, err := io.ReadAll(os.Stdin)
+	data, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		println("Failed to get input:", err.Error())
 		return 1

--- a/tool/internal_pkg/util/util.go
+++ b/tool/internal_pkg/util/util.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"go/build"
 	"go/format"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -110,7 +111,7 @@ func NotPtr(s string) string {
 func SearchGoMod(cwd string) (moduleName, path string, found bool) {
 	for {
 		path = filepath.Join(cwd, "go.mod")
-		data, err := os.ReadFile(path)
+		data, err := ioutil.ReadFile(path)
 		if err == nil {
 			re := regexp.MustCompile(`^\s*module\s+(\S+)\s*`)
 			for _, line := range strings.Split(string(data), "\n") {

--- a/version.go
+++ b/version.go
@@ -19,5 +19,5 @@ package kitex
 // Name and Version info of this framework, used for statistics and debug
 const (
 	Name    = "Kitex"
-	Version = "v0.4.0"
+	Version = "v0.4.1"
 )


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] The PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of PR title is from user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
fix: 为保证与 go 低版本的兼容性 revert golang 1.16 api

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
none

#### Which issue(s) this PR fixes:
none
