### PR TITLE
fix(tool): fix import missing when having different alias for the same path

### DIFF
--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -373,7 +373,7 @@ func (g *generator) updatePackageInfo(pkg *PackageInfo) {
 }
 
 func (g *generator) setImports(name string, pkg *PackageInfo) {
-	pkg.Imports = make(map[string]string)
+	pkg.Imports = make(map[string]map[string]bool)
 	switch name {
 	case ClientFileName:
 		pkg.AddImports("client")

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -41,7 +41,7 @@ type PackageInfo struct {
 	NoFastAPI        bool
 	Version          string
 	RealServiceName  string
-	Imports          map[string]string // import path => alias
+	Imports          map[string]map[string]bool // import path => alias
 	ExternalKitexGen string
 	Features         []feature
 }
@@ -54,9 +54,12 @@ func (p *PackageInfo) AddImport(pkg, path string) {
 			path = filepath.Join(p.ExternalKitexGen, parts[len(parts)-1])
 		}
 		if path == pkg {
-			p.Imports[path] = ""
+			p.Imports[path] = nil
 		} else {
-			p.Imports[path] = pkg
+			if p.Imports[path] == nil {
+				p.Imports[path] = make(map[string]bool)
+			}
+			p.Imports[path][pkg] = true
 		}
 	}
 }

--- a/tool/internal_pkg/tpl/client.go.tmpl
+++ b/tool/internal_pkg/tpl/client.go.tmpl
@@ -2,8 +2,14 @@
 
 package {{ToLower .ServiceName}}
 import (
-	{{- range $path, $alias := .Imports}}
-	{{$alias}} "{{$path}}"
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
 	{{- end}}
 )
 // Client is designed to provide IDL-compatible methods with call-option parameter for kitex framework.

--- a/tool/internal_pkg/tpl/handler.go.tmpl
+++ b/tool/internal_pkg/tpl/handler.go.tmpl
@@ -1,8 +1,14 @@
 package main
 
 import (
-	{{- range $path, $alias := .Imports}}
-	{{$alias }}"{{$path}}"
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
 	{{- end}}
 )
 

--- a/tool/internal_pkg/tpl/invoker.go.tmpl
+++ b/tool/internal_pkg/tpl/invoker.go.tmpl
@@ -3,8 +3,14 @@
 package {{ToLower .ServiceName}}
 
 import (
-	{{- range $path, $alias := .Imports}}
-	{{$alias }}"{{$path}}"
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
 	{{- end}}
 )
 

--- a/tool/internal_pkg/tpl/main.go.tmpl
+++ b/tool/internal_pkg/tpl/main.go.tmpl
@@ -1,8 +1,14 @@
 package main
 
 import (
-	{{- range $path, $alias := .Imports}}
-	{{$alias }}"{{$path}}"
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
 	{{- end}}
 )
 

--- a/tool/internal_pkg/tpl/server.go.tmpl
+++ b/tool/internal_pkg/tpl/server.go.tmpl
@@ -2,9 +2,15 @@
 package {{ToLower .ServiceName}}
 
 import (
-    {{- range $path, $alias := .Imports}}
-    {{$alias }}"{{$path}}"
-    {{- end}}
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
+	{{- end}}
 )
 
 // NewServer creates a server.Server with the given handler and options.

--- a/tool/internal_pkg/tpl/service.go.tmpl
+++ b/tool/internal_pkg/tpl/service.go.tmpl
@@ -3,8 +3,14 @@
 package {{ToLower .ServiceName}}
 
 import (
-	{{- range $path, $alias := .Imports}}
-	{{$alias }}"{{$path}}"
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
 	{{- end}}
 )
 


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] The PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of PR title is from user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复当一个 import 拥有不同的别名时 import 会丢失的问题。


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: In the old version generator, 'imports' is a map that uses import path as key and import alias as value. In this case, if there are different aliases for the same import path, the first alias will be replaced, and the import will be missing.
zh(optional): 在旧版本的实现中，imports 是一个以 import path 为 key，import 别名为 value 的 map，这就导致如果生成代码里用到了同一个 import 的不同别名，就会出现别名被覆盖，从来导致 import 丢失的问题。

#### Which issue(s) this PR fixes:
none
