### PR TITLE
fix(connpool): CloseCallback and statistical reporting of connection pool are invalid when the connection pool is reset in `ForwardProxy`

### DIFF
--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -189,27 +189,4 @@ func (o *Options) initRemoteOpt() {
 			)
 		}
 	}
-	pool := o.RemoteOpt.ConnPool
-	o.CloseCallbacks = append(o.CloseCallbacks, pool.Close)
-
-	if df, ok := pool.(interface{ Dump() interface{} }); ok {
-		o.DebugService.RegisterProbeFunc(diagnosis.ConnPoolKey, df.Dump)
-	}
-	if r, ok := pool.(remote.ConnPoolReporter); ok && o.RemoteOpt.EnableConnPoolReporter {
-		r.EnableReporter()
-	}
-
-	if long, ok := pool.(remote.LongConnPool); ok {
-		o.Bus.Watch(discovery.ChangeEventName, func(ev *event.Event) {
-			ch, ok := ev.Extra.(*discovery.Change)
-			if !ok {
-				return
-			}
-			for _, inst := range ch.Removed {
-				if addr := inst.Address(); addr != nil {
-					long.Clean(addr.Network(), addr.String())
-				}
-			}
-		})
-	}
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
fix(connpool): 修复当连接池在 ForwardProxy 实现中被重置后，连接池的 CloseCallback、统计上报失效的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: The logic for setting the connection pool `CloseCallback` and statistics reporting is before `initProxy`. When the connection pool is replaced by `WithProxy`, the new connection pool cannot be set. So move this part of the logic after `initProxy`.
zh(optional): 设置连接池CloseCallback、统计上报的逻辑在 `initProxy` 之前，当通过 `WithProxy` 替换连接池后，新的连接池将无法设置。因此将这部分逻辑移到 `initProxy` 之后。


#### Which issue(s) this PR fixes:
