### PR TITLE
fix(generic): marshalling list<byte> in generic and enabling forJSON reader option for MapThriftGeneric

### DIFF
--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -60,6 +60,16 @@ func MapThriftGeneric(p DescriptorProvider) (Generic, error) {
 	}, nil
 }
 
+func MapThriftGenericForJSON(p DescriptorProvider) (Generic, error) {
+	codec, err := newMapThriftCodecForJSON(p, thriftCodec)
+	if err != nil {
+		return nil, err
+	}
+	return &mapThriftGeneric{
+		codec: codec,
+	}, nil
+}
+
 // HTTPThriftGeneric http mapping Generic.
 // Base64 codec for binary field is disabled by default. You can change this option with SetBinaryWithBase64.
 // eg:

--- a/pkg/generic/generic_test.go
+++ b/pkg/generic/generic_test.go
@@ -61,6 +61,28 @@ func TestMapThriftGeneric(t *testing.T) {
 	test.Assert(t, method.Name == "Test")
 }
 
+func TestMapThriftGenericForJSON(t *testing.T) {
+	p, err := NewThriftFileProvider("./map_test/idl/mock.thrift")
+	test.Assert(t, err == nil)
+
+	// new
+	g, err := MapThriftGenericForJSON(p)
+	test.Assert(t, err == nil)
+	defer g.Close()
+
+	test.Assert(t, g.PayloadCodec().Name() == "MapThrift")
+
+	err = SetBinaryWithBase64(g, true)
+	test.Assert(t, strings.Contains(err.Error(), "Base64Binary is unavailable"))
+	test.Assert(t, g.Framed() == false)
+
+	test.Assert(t, g.PayloadCodecType() == serviceinfo.Thrift)
+
+	method, err := g.GetMethod(nil, "Test")
+	test.Assert(t, err == nil)
+	test.Assert(t, method.Name == "Test")
+}
+
 func TestHTTPThriftGeneric(t *testing.T) {
 	p, err := NewThriftFileProvider("./http_test/idl/binary_echo.thrift")
 	test.Assert(t, err == nil)

--- a/pkg/generic/thrift/struct.go
+++ b/pkg/generic/thrift/struct.go
@@ -65,10 +65,19 @@ func NewReadStruct(svc *descriptor.ServiceDescriptor, isClient bool) *ReadStruct
 	}
 }
 
+func NewReadStructForJSON(svc *descriptor.ServiceDescriptor, isClient bool) *ReadStruct {
+	return &ReadStruct{
+		svc:      svc,
+		isClient: isClient,
+		forJSON:  true,
+	}
+}
+
 // ReadStruct implement of MessageReaderWithMethod
 type ReadStruct struct {
 	svc      *descriptor.ServiceDescriptor
 	isClient bool
+	forJSON  bool
 }
 
 var _ MessageReader = (*ReadStruct)(nil)
@@ -83,5 +92,5 @@ func (m *ReadStruct) Read(ctx context.Context, method string, in thrift.TProtoco
 	if !m.isClient {
 		fDsc = fnDsc.Request
 	}
-	return skipStructReader(ctx, in, fDsc, &readerOption{throwException: true})
+	return skipStructReader(ctx, in, fDsc, &readerOption{throwException: true, forJSON: m.forJSON})
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
fix: 泛化调用支持list<byte>类型，map读泛化增加forJSON选项
