### PR TITLE
fix[generic]: numeric constant parsing fails when used as generic default value

### DIFF
--- a/pkg/generic/thrift/parse.go
+++ b/pkg/generic/thrift/parse.go
@@ -472,6 +472,12 @@ func onInt(tree *parser.Thrift, name string, t *parser.Type, v *parser.ConstValu
 			return 0, err
 		}
 		switch rv := val.(type) {
+		case byte:
+			return int64(rv), nil
+		case int16:
+			return int64(rv), nil
+		case int32:
+			return int64(rv), nil
 		case int64:
 			return rv, nil
 		}

--- a/pkg/generic/thrift/parse_test.go
+++ b/pkg/generic/thrift/parse_test.go
@@ -343,12 +343,17 @@ namespace * demo
 
 include "base.thrift"
 
+const byte DefaultB = 1
+const i16 DefaultC = 2
+const i32 DefaultD = 3
+const i64 DefaultE = 4
+
 struct Request {
 	1: optional bool a = true,
-    2: optional byte b = 1,
-    3: optional i16 c = 2,
-	4: optional i32 d = 3,
-	5: optional i64 e = 4,
+	2: optional byte b = DefaultB,
+	3: optional i16 c = DefaultC,
+	4: optional i32 d = DefaultD,
+	5: optional i64 e = DefaultE,
 	6: optional double f = 5.1,
 	7: optional string g = "123",
 	8: optional binary h = "456",
@@ -386,7 +391,7 @@ func TestDefaultValue(t *testing.T) {
 	demo.Includes[0].Reference = base
 
 	dp, err := Parse(demo, DefaultParseMode())
-	test.Assert(t, err == nil)
+	test.Assert(t, err == nil, err)
 
 	fun, err := dp.LookupFunctionByMethod("req2res")
 	test.Assert(t, err == nil)


### PR DESCRIPTION

#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复：数值型常量作为泛化默认值时无法被正确解析


#### Which issue(s) this PR fixes:

