### PR TITLE
feat: add entrance middleware option

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -227,6 +227,7 @@ func (kc *kClient) initLBCache() error {
 }
 
 func (kc *kClient) initMiddlewares(ctx context.Context) {
+	kc.mws = append(kc.mws, richMWsWithBuilder(ctx, kc.opt.EntranceMWBs)...)
 	builderMWs := richMWsWithBuilder(ctx, kc.opt.MWBs)
 	// integrate xds if enabled
 	if kc.opt.XDSEnabled && kc.opt.XDSRouterMiddleware != nil && kc.opt.Proxy == nil {

--- a/client/option.go
+++ b/client/option.go
@@ -104,6 +104,17 @@ func WithMiddlewareBuilder(mwb endpoint.MiddlewareBuilder) Option {
 	}}
 }
 
+// WithEntranceMW adds middleware for client to handle request before all another middlewares.
+func WithEntranceMW(mw endpoint.Middleware) Option {
+	emwb := func(ctx context.Context) endpoint.Middleware {
+		return mw
+	}
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		di.Push(fmt.Sprintf("WithEntranceMW(%+v)", utils.GetFuncName(mw)))
+		o.EntranceMWBs = append(o.EntranceMWBs, emwb)
+	}}
+}
+
 // WithInstanceMW adds middleware for client to handle request after service discovery and loadbalance process.
 func WithInstanceMW(mw endpoint.Middleware) Option {
 	imwb := func(ctx context.Context) endpoint.Middleware {

--- a/client/option_test.go
+++ b/client/option_test.go
@@ -327,6 +327,11 @@ func TestWithInstanceMW(t *testing.T) {
 	test.Assert(t, len(opts.IMWBs) == 1, len(opts.IMWBs))
 }
 
+func TestWithEntranceMW(t *testing.T) {
+	opts := client.NewOptions([]client.Option{WithEntranceMW(md)})
+	test.Assert(t, len(opts.EntranceMWBs) == 1, len(opts.EntranceMWBs))
+}
+
 func TestWithHTTPResolver(t *testing.T) {
 	opts := client.NewOptions([]client.Option{WithHTTPResolver(httpResolver)})
 	test.DeepEqual(t, opts.HTTPResolver, httpResolver)

--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -78,8 +78,9 @@ type Options struct {
 
 	ACLRules []acl.RejectFunc
 
-	MWBs  []endpoint.MiddlewareBuilder
-	IMWBs []endpoint.MiddlewareBuilder
+	EntranceMWBs []endpoint.MiddlewareBuilder
+	MWBs         []endpoint.MiddlewareBuilder
+	IMWBs        []endpoint.MiddlewareBuilder
 
 	Bus          event.Bus
 	Events       event.Queue


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

添加入口中间件 Option

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: add entrance middleware option to let user set a middleware at the entrance of Kitex middleware chain that executing before all anther middlewares.
zh(optional): 让用户可以在 Kitex 中间件执行流程的最外层添加一个中间件，该中间件将会在熔断，服务超时以及其他所有中间件逻辑之前执行。

#### Which issue(s) this PR fixes:

