### PR TITLE
feat(tool): support frugal precompile (pretouch) when new client or server

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -102,6 +102,8 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"Copy each IDL file to the output path.")
 	f.StringVar(&a.ExtensionFile, "template-extension", a.ExtensionFile,
 		"Specify a file for template extension.")
+	f.BoolVar(&a.FrugalPretouch, "frugal-pretouch", false,
+		"Use frugal to compile arguments and results when new clients and servers.")
 
 	a.Version = version
 	a.ThriftOptions = append(a.ThriftOptions,

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -52,6 +52,7 @@ var (
 		"client":  ImportPathTo("client"),
 		"server":  ImportPathTo("server"),
 		"callopt": ImportPathTo("client/callopt"),
+		"frugal":  "github.com/cloudwego/frugal",
 	}
 )
 
@@ -110,6 +111,7 @@ type Config struct {
 	CopyIDL         bool
 	ThriftPlugins   util.StringSlice
 	Features        []feature
+	FrugalPretouch  bool
 
 	ExtensionFile string
 	tmplExt       *TemplateExtension
@@ -404,6 +406,7 @@ func (g *generator) updatePackageInfo(pkg *PackageInfo) {
 	pkg.RealServiceName = g.ServiceName
 	pkg.Features = g.Features
 	pkg.ExternalKitexGen = g.Use
+	pkg.FrugalPretouch = g.FrugalPretouch
 	if pkg.Dependencies == nil {
 		pkg.Dependencies = make(map[string]string)
 	}
@@ -480,6 +483,13 @@ func (g *generator) setImports(name string, pkg *PackageInfo) {
 				for _, dep := range e.Deps {
 					pkg.AddImport(dep.PkgRefName, dep.ImportPath)
 				}
+			}
+		}
+		if pkg.FrugalPretouch {
+			pkg.AddImports("sync")
+			if len(pkg.AllMethods()) > 0 {
+				pkg.AddImports("frugal")
+				pkg.AddImports("reflect")
 			}
 		}
 	case MainFileName:

--- a/tool/internal_pkg/generator/generator_test.go
+++ b/tool/internal_pkg/generator/generator_test.go
@@ -46,6 +46,7 @@ func TestConfig_Pack(t *testing.T) {
 		CopyIDL         bool
 		ThriftPlugins   util.StringSlice
 		Features        []feature
+		FrugalPretouch  bool
 	}
 	tests := []struct {
 		name    string
@@ -56,7 +57,7 @@ func TestConfig_Pack(t *testing.T) {
 		{
 			name:    "some",
 			fields:  fields{Features: []feature{feature(999)}},
-			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "Features=999", "ExtensionFile="},
+			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "Features=999", "FrugalPretouch=false", "ExtensionFile="},
 		},
 	}
 	for _, tt := range tests {
@@ -81,6 +82,7 @@ func TestConfig_Pack(t *testing.T) {
 				CopyIDL:         tt.fields.CopyIDL,
 				ThriftPlugins:   tt.fields.ThriftPlugins,
 				Features:        tt.fields.Features,
+				FrugalPretouch:  tt.fields.FrugalPretouch,
 			}
 			if gotRes := c.Pack(); !reflect.DeepEqual(gotRes, tt.wantRes) {
 				t.Errorf("Config.Pack() = \n%v\nwant\n%v", gotRes, tt.wantRes)
@@ -109,6 +111,7 @@ func TestConfig_Unpack(t *testing.T) {
 		CombineService  bool
 		CopyIDL         bool
 		Features        []feature
+		FrugalPretouch  bool
 	}
 	type args struct {
 		args []string
@@ -148,6 +151,7 @@ func TestConfig_Unpack(t *testing.T) {
 				CombineService:  tt.fields.CombineService,
 				CopyIDL:         tt.fields.CopyIDL,
 				Features:        tt.fields.Features,
+				FrugalPretouch:  tt.fields.FrugalPretouch,
 			}
 			if err := c.Unpack(tt.args.args); (err != nil) != tt.wantErr {
 				t.Errorf("Config.Unpack() error = %v, wantErr %v", err, tt.wantErr)

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -44,6 +44,7 @@ type PackageInfo struct {
 	Imports          map[string]map[string]bool // import path => alias
 	ExternalKitexGen string
 	Features         []feature
+	FrugalPretouch   bool
 }
 
 // AddImport .

--- a/tool/internal_pkg/tpl/client.go
+++ b/tool/internal_pkg/tpl/client.go
@@ -70,6 +70,9 @@ func NewClient(destService string, opts ...client.Option) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	{{- if .FrugalPretouch}}
+	pretouch()
+	{{- end}}{{/* if .FrugalPretouch */}}
 	return &k{{.ServiceName}}Client{
 		kClient: newServiceClient(kc),
 	}, nil

--- a/tool/internal_pkg/tpl/invoker.go
+++ b/tool/internal_pkg/tpl/invoker.go
@@ -44,6 +44,9 @@ func NewInvoker(handler {{call .ServiceTypeName}}, opts ...server.Option) server
 	if err := s.Init(); err != nil {
 		panic(err)
 	}
+	{{- if .FrugalPretouch}}
+	pretouch()
+	{{- end}}{{/* if .FrugalPretouch */}}
     return s
 }
 {{template "@invoker.go-EOF" .}}

--- a/tool/internal_pkg/tpl/server.go
+++ b/tool/internal_pkg/tpl/server.go
@@ -40,6 +40,9 @@ func NewServer(handler {{call .ServiceTypeName}}, opts ...server.Option) server.
     if err := svr.RegisterService(serviceInfo(), handler); err != nil {
             panic(err)
     }
+	{{- if .FrugalPretouch}}
+	pretouch()
+	{{- end}}{{/* if .FrugalPretouch */}}
     return svr
 }
 {{template "@server.go-EOF" .}}


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
支持在创建 client 或者 server 的时候进行 frugal “预编译” (pretouch)

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: To reduce time cost of first RPC call when using frugal, compile service arguments and results when new client or server.
zh(optional): 为了减少使用 frugal 时初次 RPC 调用的时间开销，在创建 client 或者 server 的时候就进行 arguments 和 result 的编译。

#### Which issue(s) this PR fixes:
none
