### PR TITLE
Lock by s#Lock when assign value to s.svcInfo in server#RegisterService

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -165,10 +165,13 @@ func (s *server) buildInvokeChain() {
 
 // RegisterService should not be called by users directly.
 func (s *server) RegisterService(svcInfo *serviceinfo.ServiceInfo, handler interface{}) error {
+	s.Lock()
 	if s.svcInfo != nil {
+		s.Unlock()
 		panic(fmt.Sprintf("Service[%s] is already defined", s.svcInfo.ServiceName))
 	}
 	s.svcInfo = svcInfo
+	s.Unlock()
 	s.handler = handler
 	diagnosis.RegisterProbeFunc(s.opt.DebugService, diagnosis.ServiceInfoKey, diagnosis.WrapAsProbeFunc(s.svcInfo))
 	return nil


### PR DESCRIPTION
避免多个goroutine并发调用 `server#RegisterService`导致`server`数据不一致。