### PR TITLE
feat(grpc): add kitex grpc metadata api to get header, tailer, and peer address metadata

### DIFF
--- a/client/stream.go
+++ b/client/stream.go
@@ -19,6 +19,8 @@ package client
 import (
 	"context"
 
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/remotecli"
@@ -78,6 +80,26 @@ func (kc *kClient) invokeStreamingEndpoint() (endpoint.Endpoint, error) {
 type stream struct {
 	stream streaming.Stream
 	kc     *kClient
+}
+
+func (s *stream) SetTrailer(metadata.MD) {
+	panic("this method should only be used in server side stream!")
+}
+
+func (s *stream) SetHeader(metadata.MD) error {
+	panic("this method should only be used in server side stream!")
+}
+
+func (s *stream) SendHeader(metadata.MD) error {
+	panic("this method should only be used in server side stream!")
+}
+
+func (s *stream) Header() (metadata.MD, error) {
+	return s.stream.Header()
+}
+
+func (s *stream) Trailer() metadata.MD {
+	return s.stream.Trailer()
 }
 
 func (s *stream) Context() context.Context {

--- a/pkg/remote/trans/nphttp2/client_handler.go
+++ b/pkg/remote/trans/nphttp2/client_handler.go
@@ -73,6 +73,7 @@ func (h *cliTransHandler) Read(ctx context.Context, conn net.Conn, msg remote.Me
 			return ctx, nil
 		}
 	}
+	receiveHeaderAndTrailer(ctx, conn)
 	return ctx, err
 }
 

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -31,6 +31,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/peer"
+
 	"github.com/cloudwego/netpoll"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -343,9 +345,17 @@ func (t *http2Client) createHeaderFields(ctx context.Context, callHdr *CallHdr) 
 	return headerFields
 }
 
+func (t *http2Client) setPeer(ctx context.Context) {
+	peer, ok := peer.GetPeerFromContext(ctx)
+	if ok {
+		peer.Addr = t.remoteAddr
+	}
+}
+
 // NewStream creates a stream and registers it into the transport as "active"
 // streams.
 func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Stream, err error) {
+	t.setPeer(ctx)
 	s := t.newStream(ctx, callHdr)
 	cleanup := func(err error) {
 		if s.swapState(streamDone) == streamDone {

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -31,8 +31,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/peer"
-
 	"github.com/cloudwego/netpoll"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
@@ -43,6 +41,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/grpcframe"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/syscall"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/peer"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 

--- a/pkg/remote/trans/nphttp2/meta_api.go
+++ b/pkg/remote/trans/nphttp2/meta_api.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nphttp2
+
+import (
+	"context"
+	"net"
+
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+	"github.com/cloudwego/kitex/pkg/streaming"
+)
+
+// SetHeader sets the header metadata to be sent from the server to the client.
+// The context provided must be the context passed to the server's handler.
+//
+// Streaming RPCs should prefer the SetHeader method of the ServerStream.
+//
+// When called multiple times, all the provided metadata will be merged.  All
+// the metadata will be sent out when one of the following happens:
+//
+//   - grpc.SendHeader is called, or for streaming handlers, stream.SendHeader.
+//   - The first response message is sent.  For unary handlers, this occurs when
+//     the handler returns; for streaming handlers, this can happen when stream's
+//     SendMsg method is called.
+//   - An RPC status is sent out (error or success).  This occurs when the handler
+//     returns.
+//
+// SetHeader will fail if called after any of the events above.
+//
+// The error returned is compatible with the status package.  However, the
+// status code will often not match the RPC status as seen by the client
+// application, and therefore, should not be relied upon for this purpose.
+func SetHeader(ctx context.Context, md metadata.MD) error {
+	if md.Len() == 0 {
+		return nil
+	}
+	stream := serverTransportStreamFromContext(ctx)
+	if stream == nil {
+		return status.Errorf(codes.Internal, "grpc: failed to fetch the stream from the context %v", ctx)
+	}
+	return stream.SetHeader(md)
+}
+
+// SendHeader sends header metadata. It may be called at most once, and may not
+// be called after any event that causes headers to be sent (see SetHeader for
+// a complete list).  The provided md and headers set by SetHeader() will be
+// sent.
+//
+// The error returned is compatible with the status package.  However, the
+// status code will often not match the RPC status as seen by the client
+// application, and therefore, should not be relied upon for this purpose.
+func SendHeader(ctx context.Context, md metadata.MD) error {
+	stream := serverTransportStreamFromContext(ctx)
+	if stream == nil {
+		return status.Errorf(codes.Internal, "grpc: failed to fetch the stream from the context %v", ctx)
+	}
+	if err := stream.SendHeader(md); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetTrailer sets the trailer metadata that will be sent when an RPC returns.
+// When called more than once, all the provided metadata will be merged.
+//
+// The error returned is compatible with the status package.  However, the
+// status code will often not match the RPC status as seen by the client
+// application, and therefore, should not be relied upon for this purpose.
+func SetTrailer(ctx context.Context, md metadata.MD) error {
+	if md.Len() == 0 {
+		return nil
+	}
+	stream := serverTransportStreamFromContext(ctx)
+	if stream == nil {
+		return status.Errorf(codes.Internal, "grpc: failed to fetch the stream from the context %v", ctx)
+	}
+	stream.SetTrailer(md)
+	return nil
+}
+
+type streamKey struct{}
+
+func serverTransportStreamFromContext(ctx context.Context) streaming.Stream {
+	s, _ := ctx.Value(streamKey{}).(streaming.Stream)
+	return s
+}
+
+type (
+	headerKey  struct{}
+	trailerKey struct{}
+)
+
+// GRPCHeader is used for unary call client to get header from response.
+func GRPCHeader(ctx context.Context, md *metadata.MD) context.Context {
+	return context.WithValue(ctx, headerKey{}, md)
+}
+
+// GRPCTrailer is used for unary call client to get taiiler from response.
+func GRPCTrailer(ctx context.Context, md *metadata.MD) context.Context {
+	return context.WithValue(ctx, trailerKey{}, md)
+}
+
+func receiveHeaderAndTrailer(ctx context.Context, conn net.Conn) {
+	header := ctx.Value(headerKey{})
+	if header != nil {
+		headerMd := header.(*metadata.MD)
+		*headerMd, _ = conn.(*clientConn).Header()
+	}
+	tailer := ctx.Value(trailerKey{})
+	if tailer != nil {
+		tailerMd := tailer.(*metadata.MD)
+		*tailerMd = conn.(*clientConn).Trailer()
+	}
+}

--- a/pkg/remote/trans/nphttp2/peer/peer.go
+++ b/pkg/remote/trans/nphttp2/peer/peer.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package peer
+
+import (
+	"context"
+	"net"
+)
+
+type peerKey struct{}
+
+// Peer contains the information of the peer for an RPC, such as the address
+// and authentication information.
+type Peer struct {
+	// Addr is the peer address.
+	Addr net.Addr
+}
+
+// GRPCPeer is used for client to get remote service address
+func GRPCPeer(ctx context.Context, p *Peer) context.Context {
+	return context.WithValue(ctx, peerKey{}, p)
+}
+
+func GetPeerFromContext(ctx context.Context) (peer *Peer, ok bool) {
+	p := ctx.Value(peerKey{})
+	if p != nil {
+		return p.(*Peer), true
+	}
+	return nil, false
+}

--- a/pkg/remote/trans/nphttp2/peer/peer_test.go
+++ b/pkg/remote/trans/nphttp2/peer/peer_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package peer
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cloudwego/kitex/internal/test"
+)
+
+func TestPeer(t *testing.T) {
+	p := Peer{}
+	ctx := GRPCPeer(context.Background(), &p)
+	peer, ok := GetPeerFromContext(ctx)
+	test.Assert(t, ok)
+	test.Assert(t, peer == &p)
+}

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -162,6 +162,9 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 			st := NewStream(rCtx, t.svcInfo, newServerConn(tr, s), t)
 			streamArg := &streaming.Args{Stream: st}
 
+			// bind stream into ctx, in order to let user set header and trailer by provided api in meta_api.go
+			rCtx = context.WithValue(rCtx, streamKey{}, st)
+
 			// check grpc method
 			targetMethod := t.svcInfo.MethodInfo(methodName)
 			if targetMethod == nil {

--- a/pkg/remote/trans/nphttp2/stream.go
+++ b/pkg/remote/trans/nphttp2/stream.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"net"
 
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
@@ -51,6 +53,42 @@ func NewStream(ctx context.Context, svcInfo *serviceinfo.ServiceInfo, conn net.C
 
 func (s *stream) Context() context.Context {
 	return s.ctx
+}
+
+// Trailer is used for client side stream
+func (s *stream) Trailer() metadata.MD {
+	sc, ok := s.conn.(*clientConn)
+	if !ok {
+		panic("this method should only be used in client side stream!")
+	}
+	return sc.s.Trailer()
+}
+
+// Header is used for client side stream
+func (s *stream) Header() (metadata.MD, error) {
+	sc, ok := s.conn.(*clientConn)
+	if !ok {
+		panic("this method should only be used in client side stream!")
+	}
+	return sc.s.Header()
+}
+
+// SendHeader is used for server side stream
+func (s *stream) SendHeader(md metadata.MD) error {
+	sc := s.conn.(*serverConn)
+	return sc.s.SendHeader(md)
+}
+
+// SetHeader is used for server side stream
+func (s *stream) SetHeader(md metadata.MD) error {
+	sc := s.conn.(*serverConn)
+	return sc.s.SetHeader(md)
+}
+
+// SetTrailer is used for server side stream
+func (s *stream) SetTrailer(md metadata.MD) {
+	sc := s.conn.(*serverConn)
+	sc.s.SetTrailer(md)
 }
 
 func (s *stream) RecvMsg(m interface{}) error {

--- a/pkg/streaming/streaming.go
+++ b/pkg/streaming/streaming.go
@@ -20,10 +20,30 @@ package streaming
 import (
 	"context"
 	"io"
+
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
 )
 
 // Stream both client and server stream
 type Stream interface {
+	// SetHeader sets the header metadata. It may be called multiple times.
+	// When call multiple times, all the provided metadata will be merged.
+	// All the metadata will be sent out when one of the following happens:
+	//  - ServerStream.SendHeader() is called;
+	//  - The first response is sent out;
+	//  - An RPC status is sent out (error or success).
+	SetHeader(metadata.MD) error
+	// SendHeader sends the header metadata.
+	// The provided md and headers set by SetHeader() will be sent.
+	// It fails if called multiple times.
+	SendHeader(metadata.MD) error
+	// SetTrailer sets the trailer metadata which will be sent with the RPC status.
+	// When called more than once, all the provided metadata will be merged.
+	SetTrailer(metadata.MD)
+	// Header is used for client side stream to receive header from server.
+	Header() (metadata.MD, error)
+	// Trailer is used for client side stream to receive trailer from server.
+	Trailer() metadata.MD
 	// Context the stream context.Context
 	Context() context.Context
 	// RecvMsg recvive message from peer


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

为 kitex grpc 添加了元信息传递相关 api，包括 header，tailer，以及 peer 远端地址的获取接口。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: add kitex grpc metadata api to get header, tailer, and peer address metadata.
zh(optional): 为 kitex grpc 添加了元信息传递相关 api，包括 header，tailer，以及 peer 远端地址的获取接口。


#### Which issue(s) this PR fixes:

