### PR TITLE
feat: path support under windows

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -277,6 +277,7 @@ func (a *Arguments) BuildCmd(out io.Writer) *exec.Cmd {
 		if a.Use == "" {
 			cmd.Args = append(cmd.Args, "-r")
 		}
+		exe = strings.ReplaceAll(exe, ":", "\\:")
 		cmd.Args = append(cmd.Args,
 			"-o", generator.KitexGenPath,
 			"-g", gas,

--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -245,6 +245,7 @@ func (a *Arguments) checkPath() {
 	if a.Use != "" {
 		a.PackagePrefix = a.Use
 	}
+	a.PackagePrefix = strings.ReplaceAll(a.PackagePrefix, "\\", "/")
 	a.OutputPath = curpath
 }
 

--- a/tool/internal_pkg/generator/completor.go
+++ b/tool/internal_pkg/generator/completor.go
@@ -115,12 +115,14 @@ func (c *completer) addImport(w io.Writer, newMethods []*MethodInfo, fset *token
 	for _, m := range newMethods {
 		for _, arg := range m.Args {
 			for _, dep := range arg.Deps {
-				newImports[dep.PkgRefName+" "+dep.ImportPath] = true
+				s := strings.ReplaceAll(dep.PkgRefName+" "+dep.ImportPath, "\\", "/")
+				newImports[s] = true
 			}
 		}
 		if m.Resp != nil {
 			for _, dep := range m.Resp.Deps {
-				newImports[dep.PkgRefName+" "+dep.ImportPath] = true
+				s := strings.ReplaceAll(dep.PkgRefName+" "+dep.ImportPath, "\\", "/")
+				newImports[s] = true
 			}
 		}
 	}
@@ -138,6 +140,7 @@ func (c *completer) addImport(w io.Writer, newMethods []*MethodInfo, fset *token
 		delete(newImports, aliasPath)
 	}
 	for path := range newImports {
+		path = strings.ReplaceAll(path, "\\", "/")
 		s := strings.Split(path, " ")
 		switch len(s) {
 		case 1:

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -67,7 +67,8 @@ func SetKitexImportPath(path string) {
 
 // ImportPathTo returns an import path to the specified package under kitex.
 func ImportPathTo(pkg string) string {
-	return filepath.Join(kitexImportPath, pkg)
+	res := filepath.Join(kitexImportPath, pkg)
+	return strings.ReplaceAll(res, "\\", "/")
 }
 
 // AddGlobalMiddleware adds middleware for all generators

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -52,6 +52,7 @@ func (p *PackageInfo) AddImport(pkg, path string) {
 	if p.Imports == nil {
 		p.Imports = make(map[string]map[string]bool)
 	}
+	path = strings.ReplaceAll(path, "\\", "/")
 	if pkg != "" {
 		if p.ExternalKitexGen != "" && strings.Contains(path, KitexGenPath) {
 			parts := strings.Split(path, KitexGenPath)


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

实现在windows下的路径支持

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: When using the kitex command-line tool to generate files under the Windows platform, due to the differences in path parsing between different platforms, the package name path in the file will become an incorrect backslash. This pr will deal with this problem.
zh(optional): 在windows平台下利用kitex命令行工具生成文件时，由于不同平台间的路径解析差异，文件中的包名路径会变成错误的反斜杠，本pr将对这一问题进行了处理

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fix #469 