### PR TITLE
optimize(MetaHandler): remove error logic for adding default metaHandler in #503

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -46,7 +46,6 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo/remoteinfo"
 	"github.com/cloudwego/kitex/pkg/rpctimeout"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
-	"github.com/cloudwego/kitex/pkg/transmeta"
 	"github.com/cloudwego/kitex/pkg/utils"
 	"github.com/cloudwego/kitex/pkg/warmup"
 	"github.com/cloudwego/kitex/transport"
@@ -390,21 +389,14 @@ func (kc *kClient) initDebugService() {
 
 func (kc *kClient) richRemoteOption() {
 	kc.opt.RemoteOpt.SvcInfo = kc.svcInfo
-	// add default meta handler
-	if len(kc.opt.MetaHandlers) == 0 {
-		if kc.opt.Configs.TransportProtocol()&transport.GRPC == transport.GRPC {
-			kc.opt.MetaHandlers = append(kc.opt.MetaHandlers, transmeta.ClientHTTP2Handler)
-		}
-		if kc.opt.Configs.TransportProtocol()&transport.TTHeader == transport.TTHeader {
-			kc.opt.MetaHandlers = append(kc.opt.MetaHandlers, transmeta.ClientTTHeaderHandler)
-		}
-	}
 	// for client trans info handler
-	// TODO in stream situations, meta is only assembled when the stream creates
-	// metaHandler needs to be called separately.
-	// (newClientStreamer: call WriteMeta before remotecli.NewClient)
-	transInfoHdlr := bound.NewTransMetaHandler(kc.opt.MetaHandlers)
-	kc.opt.RemoteOpt.PrependBoundHandler(transInfoHdlr)
+	if len(kc.opt.MetaHandlers) > 0 {
+		// TODO in stream situations, meta is only assembled when the stream creates
+		// metaHandler needs to be called separately.
+		// (newClientStreamer: call WriteMeta before remotecli.NewClient)
+		transInfoHdlr := bound.NewTransMetaHandler(kc.opt.MetaHandlers)
+		kc.opt.RemoteOpt.PrependBoundHandler(transInfoHdlr)
+	}
 }
 
 func (kc *kClient) buildInvokeChain() error {


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
optimize(MetaHandler): 移除 #503 添加default metahandler的错误逻辑

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: Because client/server will add MetainfoClientHandler or MetainfoServerHandler by default, the code of this PR cannot actually take effect, and it is more complicated to be compatible with the metainfo handler, so default metaHandlers are no longer added.
zh(optional): 因为client/server都会默认添加MetainfoClientHandler/MetainfoServerHandler，因此这个PR的代码实际上无法生效，而去兼容这个handler又较为复杂，因此不再添加默认metaHandler。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
