### PR TITLE
fix(tool):fix kitex cmd remote repo pulling logic

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -251,7 +251,7 @@ func (a *Arguments) checkPath() {
 	a.OutputPath = curpath
 }
 
-func runGitCommand(a *Arguments, gitLink string) (string, string, error) {
+func RunGitCommand(a *Arguments, gitLink string) (string, string, error) {
 	u, err := user.Current()
 	if err != nil {
 		return "", "Failed to get home dir", err
@@ -283,7 +283,7 @@ func runGitCommand(a *Arguments, gitLink string) (string, string, error) {
 	}
 	gitPath := filepath.Join(cachePath, repoLink+branchSuffix)
 
-	_, err = os.Stat(gitPath)
+	_, err = os.Stat(filepath.Join(gitPath, ".git"))
 	if err != nil && !os.IsExist(err) {
 		err = os.MkdirAll(gitPath, os.ModePerm)
 		if err != nil {
@@ -339,7 +339,7 @@ func (a *Arguments) BuildCmd(out io.Writer) *exec.Cmd {
 
 	for i, inc := range a.Includes {
 		if strings.HasPrefix(inc, "git@") || strings.HasPrefix(inc, "http://") || strings.HasPrefix(inc, "https://") {
-			localGitPath, errMsg, gitErr := runGitCommand(a, inc)
+			localGitPath, errMsg, gitErr := RunGitCommand(a, inc)
 			if gitErr != nil {
 				if errMsg == "" {
 					errMsg = gitErr.Error()


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

修复 kitex cmd -I 参数拉取远程仓库逻辑

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: fix repo pulling logic when first time repo pulling is canceled
zh(optional): 修复了首次仓库拉取时中途取消后，再进行仓库拉取时的判断逻辑

#### Which issue(s) this PR fixes:
