### PR TITLE
refactor: add ForceSetTag method for RemoteInfo, it is used to overwrite Tag info in special scene

### DIFF
--- a/pkg/rpcinfo/remoteinfo/remoteInfo.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo.go
@@ -33,6 +33,7 @@ type RemoteInfo interface {
 	rpcinfo.EndpointInfo
 	SetServiceName(name string)
 	SetTag(key, value string) error
+	ForceSetTag(key, value string)
 
 	// SetTagLock freezes a key of the tags and refuses further modification on its value.
 	SetTagLock(key string)
@@ -162,6 +163,13 @@ func (ri *remoteInfo) SetTag(key, value string) error {
 	}
 	ri.tags[key] = value
 	return nil
+}
+
+// ForceSetTag is used to set Tag without tag lock.
+func (ri *remoteInfo) ForceSetTag(key, value string) {
+	ri.Lock()
+	defer ri.Unlock()
+	ri.tags[key] = value
 }
 
 // ImmutableView implements rpcinfo.MutableEndpointInfo.


### PR DESCRIPTION
#### What type of PR is this?
refactor

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
refactor: 给 RemoteInfo 添加 ForceSetTag 用于特殊场景覆盖 Tag 信息

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
none
