### PR TITLE
optimize(metainfo): ignore whether protocol supports meta data to support the use of backward values in pure thrift protocol

### DIFF
--- a/pkg/transmeta/metainfo.go
+++ b/pkg/transmeta/metainfo.go
@@ -33,7 +33,7 @@ var (
 type metainfoClientHandler struct{}
 
 func (mi *metainfoClientHandler) WriteMeta(ctx context.Context, sendMsg remote.Message) (context.Context, error) {
-	if sendMsg.ProtocolInfo().TransProto.WithMeta() && metainfo.HasMetaInfo(ctx) {
+	if metainfo.HasMetaInfo(ctx) {
 		kvs := make(map[string]string)
 		metainfo.SaveMetaInfoToMap(ctx, kvs)
 		sendMsg.TransInfo().PutTransStrInfo(kvs)
@@ -53,22 +53,17 @@ func (mi *metainfoClientHandler) ReadMeta(ctx context.Context, recvMsg remote.Me
 type metainfoServerHandler struct{}
 
 func (mi *metainfoServerHandler) ReadMeta(ctx context.Context, recvMsg remote.Message) (context.Context, error) {
-	if recvMsg.ProtocolInfo().TransProto.WithMeta() {
-		if kvs := recvMsg.TransInfo().TransStrInfo(); len(kvs) > 0 {
-			ctx = metainfo.SetMetaInfoFromMap(ctx, kvs)
-		}
-		ctx = metainfo.WithBackwardValuesToSend(ctx)
+	if kvs := recvMsg.TransInfo().TransStrInfo(); len(kvs) > 0 {
+		ctx = metainfo.SetMetaInfoFromMap(ctx, kvs)
 	}
-
+	ctx = metainfo.WithBackwardValuesToSend(ctx)
 	ctx = metainfo.TransferForward(ctx)
 	return ctx, nil
 }
 
 func (mi *metainfoServerHandler) WriteMeta(ctx context.Context, sendMsg remote.Message) (context.Context, error) {
-	if sendMsg.ProtocolInfo().TransProto.WithMeta() {
-		if kvs := metainfo.AllBackwardValuesToSend(ctx); len(kvs) > 0 {
-			sendMsg.TransInfo().PutTransStrInfo(kvs)
-		}
+	if kvs := metainfo.AllBackwardValuesToSend(ctx); len(kvs) > 0 {
+		sendMsg.TransInfo().PutTransStrInfo(kvs)
 	}
 
 	return ctx, nil

--- a/pkg/transmeta/metainfo_test.go
+++ b/pkg/transmeta/metainfo_test.go
@@ -67,7 +67,9 @@ func TestClientWriteMetainfo(t *testing.T) {
 	test.Assert(t, err == nil)
 
 	kvs := msg.TransInfo().TransStrInfo()
-	test.Assert(t, len(kvs) == 0)
+	test.Assert(t, len(kvs) == 2, kvs)
+	test.Assert(t, kvs[metainfo.PrefixTransient+"tk"] == "tv")
+	test.Assert(t, kvs[metainfo.PrefixPersistent+"pk"] == "pv")
 
 	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeader, serviceinfo.Thrift))
 	_, err = MetainfoClientHandler.WriteMeta(ctx, msg)
@@ -96,8 +98,8 @@ func TestServerReadMetainfo(t *testing.T) {
 	tvs := metainfo.GetAllValues(ctx)
 	pvs := metainfo.GetAllPersistentValues(ctx)
 	test.Assert(t, err == nil)
-	test.Assert(t, len(tvs) == 0)
-	test.Assert(t, len(pvs) == 0)
+	test.Assert(t, len(tvs) == 1 && tvs["tk"] == "tv", tvs)
+	test.Assert(t, len(pvs) == 1 && pvs["pk"] == "pv")
 
 	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeader, serviceinfo.Thrift))
 	ctx, err = MetainfoServerHandler.ReadMeta(ctx0, msg)
@@ -129,7 +131,7 @@ func TestServerWriteMetainfo(t *testing.T) {
 	ctx, err := MetainfoServerHandler.WriteMeta(ctx, msg)
 	test.Assert(t, err == nil)
 	kvs := msg.TransInfo().TransStrInfo()
-	test.Assert(t, len(kvs) == 0)
+	test.Assert(t, len(kvs) == 1 && kvs["bk"] == "bv", kvs)
 
 	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.TTHeader, serviceinfo.Thrift))
 	_, err = MetainfoServerHandler.WriteMeta(ctx, msg)

--- a/transport/keys.go
+++ b/transport/keys.go
@@ -54,9 +54,3 @@ func (tp Protocol) String() string {
 	}
 	return Unknown
 }
-
-// WithMeta reports whether the protocol is capable of carrying meta
-// data besides the payload.
-func (tp Protocol) WithMeta() bool {
-	return tp != PurePayload && tp != Framed
-}


### PR DESCRIPTION
…port the use of backward values in pure thrift protocol

#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
optimize(metainfo): 忽略协议是否支持meta data以支持纯thrift协议下反向传递的使用

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
