### PR TITLE
refactor: add ForceSetTag method for RemoteInfo, which is used to reset Tag in special scenario

### DIFF
--- a/pkg/rpcinfo/remoteinfo/remoteInfo.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo.go
@@ -33,6 +33,7 @@ type RemoteInfo interface {
 	rpcinfo.EndpointInfo
 	SetServiceName(name string)
 	SetTag(key, value string) error
+	ForceSetTag(key, value string)
 
 	// SetTagLock freezes a key of the tags and refuses further modification on its value.
 	SetTagLock(key string)
@@ -162,6 +163,13 @@ func (ri *remoteInfo) SetTag(key, value string) error {
 	}
 	ri.tags[key] = value
 	return nil
+}
+
+// ForceSetTag is used to set Tag without tag lock.
+func (ri *remoteInfo) ForceSetTag(key, value string) {
+	ri.Lock()
+	defer ri.Unlock()
+	ri.tags[key] = value
 }
 
 // ImmutableView implements rpcinfo.MutableEndpointInfo.

--- a/pkg/rpcinfo/remoteinfo/remoteInfo_test.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo_test.go
@@ -112,21 +112,21 @@ func TestSetTag(t *testing.T) {
 
 	// lock key cannot be reset
 	ri.SetTag(lockKey, "aa")
-	val, exist = ri.Tag(lockKey)
+	val, _ = ri.Tag(lockKey)
 	test.Assert(t, val == "a")
 
 	// lock key still can be reset with ForceSetTag
 	ri.ForceSetTag(lockKey, "aa")
-	val, exist = ri.Tag(lockKey)
+	val, _ = ri.Tag(lockKey)
 	test.Assert(t, val == "aa")
 
 	// unlock key can be reset
 	ri.SetTag(unlockKey, "bb")
-	val, exist = ri.Tag(unlockKey)
+	val, _ = ri.Tag(unlockKey)
 	test.Assert(t, val == "bb")
 
 	// unlock key can be reset
 	ri.ForceSetTag(unlockKey, "bb")
-	val, exist = ri.Tag(unlockKey)
+	val, _ = ri.Tag(unlockKey)
 	test.Assert(t, val == "bb")
 }

--- a/pkg/rpcinfo/remoteinfo/remoteInfo_test.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo_test.go
@@ -92,3 +92,41 @@ func TestAsRemoteInfo(t *testing.T) {
 		test.Assert(t, na2.String() == "aaa")
 	}
 }
+
+func TestSetTag(t *testing.T) {
+	lockKey := "lock"
+	unlockKey := "unlock"
+	bi := &rpcinfo.EndpointBasicInfo{
+		ServiceName: "service",
+		Tags:        map[string]string{lockKey: "a", unlockKey: "b"},
+	}
+	ri := remoteinfo.NewRemoteInfo(bi, "method1")
+
+	ri.SetTagLock(lockKey)
+	val, exist := ri.Tag(lockKey)
+	test.Assert(t, val == "a")
+	test.Assert(t, exist)
+	val, exist = ri.Tag(unlockKey)
+	test.Assert(t, val == "b")
+	test.Assert(t, exist)
+
+	// lock key cannot be reset
+	ri.SetTag(lockKey, "aa")
+	val, exist = ri.Tag(lockKey)
+	test.Assert(t, val == "a")
+
+	// lock key still can be reset with ForceSetTag
+	ri.ForceSetTag(lockKey, "aa")
+	val, exist = ri.Tag(lockKey)
+	test.Assert(t, val == "aa")
+
+	// unlock key can be reset
+	ri.SetTag(unlockKey, "bb")
+	val, exist = ri.Tag(unlockKey)
+	test.Assert(t, val == "bb")
+
+	// unlock key can be reset
+	ri.ForceSetTag(unlockKey, "bb")
+	val, exist = ri.Tag(unlockKey)
+	test.Assert(t, val == "bb")
+}


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
refator: 给 RemoteInfo 添加 ForceSetTag 用于特殊场景覆盖 Tag 信息

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
none
