### PR TITLE
feat: use frugal as default codec when available

### DIFF
--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -39,11 +39,6 @@ const (
 	FastRead
 )
 
-// NewThriftCodec creates the thrift binary codec.
-func NewThriftCodec() remote.PayloadCodec {
-	return &thriftCodec{FastWrite | FastRead}
-}
-
 // NewThriftFrugalCodec creates the thrift binary codec powered by frugal.
 // Eg: xxxservice.NewServer(handler, server.WithPayloadCodec(thrift.NewThriftCodecWithConfig(thrift.FastWrite | thrift.FastRead)))
 func NewThriftCodecWithConfig(c CodecType) remote.PayloadCodec {

--- a/pkg/remote/codec/thrift/thrift_frugal_amd64.go
+++ b/pkg/remote/codec/thrift/thrift_frugal_amd64.go
@@ -37,6 +37,11 @@ const (
 	FrugalRead
 )
 
+// NewThriftCodec creates the thrift binary codec.
+func NewThriftCodec() remote.PayloadCodec {
+	return &thriftCodec{FrugalWrite | FrugalRead | FastWrite | FastRead}
+}
+
 // hyperMarshalEnabled indicates that if there are high priority message codec for current platform.
 func (c thriftCodec) hyperMarshalEnabled() bool {
 	return c.CodecType&FrugalWrite != 0

--- a/pkg/remote/codec/thrift/thrift_others.go
+++ b/pkg/remote/codec/thrift/thrift_others.go
@@ -23,6 +23,11 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote"
 )
 
+// NewThriftCodec creates the thrift binary codec.
+func NewThriftCodec() remote.PayloadCodec {
+	return &thriftCodec{FastWrite | FastRead}
+}
+
 // hyperMarshalEnabled indicates that if there are high priority message codec for current platform.
 func (c thriftCodec) hyperMarshalEnabled() bool {
 	return false


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
当 Frugal 可用的时候使用 Frugal 作为默认编解码

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: use Frugal as default codec when Frugal codec is available
zh(optional): 当 Frugal 可用的时候使用 Frugal 作为默认编解码

#### Which issue(s) this PR fixes:
none
