### PR TITLE
fix: revise the order of lock to avoid data race in retry container Init

### DIFF
--- a/pkg/retry/retryer.go
+++ b/pkg/retry/retryer.go
@@ -96,7 +96,7 @@ type Container struct {
 	retryerMap  sync.Map // <method: retryer>
 	cbContainer *cbContainer
 	msg         string
-	sync.Mutex
+	sync.RWMutex
 
 	// shouldResultRetry is only used with FailureRetry
 	shouldResultRetry *ShouldResultRetry
@@ -110,12 +110,13 @@ type cbContainer struct {
 
 // InitWithPolicies to init Retryer with methodPolicies
 // Notice, InitWithPolicies is export func, the lock should be added inside
-func (rc *Container) InitWithPolicies(methodPolicies map[string]Policy) (inited bool, err error) {
+func (rc *Container) InitWithPolicies(methodPolicies map[string]Policy) error {
 	if methodPolicies == nil {
-		return
+		return nil
 	}
 	rc.Lock()
 	defer rc.Unlock()
+	var inited bool
 	for m := range methodPolicies {
 		if methodPolicies[m].Enable {
 			inited = true
@@ -123,12 +124,14 @@ func (rc *Container) InitWithPolicies(methodPolicies map[string]Policy) (inited 
 				// NotifyPolicyChange may happen before
 				continue
 			}
-			if err = rc.initRetryer(m, methodPolicies[m]); err != nil {
-				return false, err
+			if err := rc.initRetryer(m, methodPolicies[m]); err != nil {
+				rc.msg = err.Error()
+				return err
 			}
 		}
 	}
-	return
+	rc.hasCodeCfg = inited
+	return nil
 }
 
 // NotifyPolicyChange to receive policy when it changes
@@ -161,9 +164,7 @@ func (rc *Container) Init(mp map[string]Policy, rr *ShouldResultRetry) (err erro
 	// NotifyPolicyChange func may execute before Init func.
 	// Because retry Container is built before Client init, NotifyPolicyChange can be triggered first
 	rc.updateRetryer(rr)
-	rc.hasCodeCfg, err = rc.InitWithPolicies(mp)
-	if err != nil {
-		rc.msg = err.Error()
+	if err = rc.InitWithPolicies(mp); err != nil {
 		return fmt.Errorf("NewRetryer in Init failed, err=%w", err)
 	}
 	return nil
@@ -251,6 +252,7 @@ func (rc *Container) getRetryer(ri rpcinfo.RPCInfo) Retryer {
 
 // Dump is used to show current retry policy
 func (rc *Container) Dump() interface{} {
+	rc.RLock()
 	dm := make(map[string]interface{})
 	dm["has_code_cfg"] = rc.hasCodeCfg
 	rc.retryerMap.Range(func(key, value interface{}) bool {
@@ -262,6 +264,7 @@ func (rc *Container) Dump() interface{} {
 	if rc.msg != "" {
 		dm["msg"] = rc.msg
 	}
+	rc.RUnlock()
 	return dm
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
zh: 调整 lock 以避免 retry container 的并发读写问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
