### PR TITLE
fix: keep client alive during call

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -81,6 +81,11 @@ type kcFinalizerClient struct {
 	*kClient
 }
 
+func (kf *kcFinalizerClient) Call(ctx context.Context, method string, request, response interface{}) error {
+	defer runtime.KeepAlive(kf)
+	return kf.kClient.Call(ctx, method, request, response)
+}
+
 // NewClient creates a kitex.Client with the given ServiceInfo, it is from generated code.
 func NewClient(svcInfo *serviceinfo.ServiceInfo, opts ...Option) (Client, error) {
 	if svcInfo == nil {


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
确保 client 在调用期间不被 GC

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: keep kitex client alive until call finished
zh(optional): 确保 client 在调用调用结束之前不被 GC

#### Which issue(s) this PR fixes:
none
