### PR TITLE
fix: close pre-configured connpool in the client option when forward proxy configure the connpool

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -185,6 +185,10 @@ func (kc *kClient) initProxy() error {
 		// update fields in the client option for further use.
 		kc.opt.Resolver = cfg.Resolver
 		kc.opt.Balancer = cfg.Balancer
+		// close predefined pool when proxy init new pool.
+		if cfg.Pool != kc.opt.RemoteOpt.ConnPool && kc.opt.RemoteOpt.ConnPool != nil {
+			kc.opt.RemoteOpt.ConnPool.Close()
+		}
 		kc.opt.RemoteOpt.ConnPool = cfg.Pool
 		kc.opt.Targets = cfg.FixedTargets
 	}


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
zh: 当 forward proxy 配置了连接池时，关闭 client option 内已有的连接池。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
