### PR TITLE
optimize(ttheader): attach part of ttheader binary into error when readKVInfo failed, which is useful for troubleshooting

### DIFF
--- a/pkg/remote/codec/header_codec.go
+++ b/pkg/remote/codec/header_codec.go
@@ -196,7 +196,7 @@ func (t ttHeader) decode(ctx context.Context, message remote.Message, in remote.
 	}
 
 	if err := readKVInfo(hdIdx, headerInfo, message); err != nil {
-		return perrors.NewProtocolErrorWithMsg(fmt.Sprintf("ttHeader read kv info failed, %s", err.Error()))
+		return perrors.NewProtocolErrorWithMsg(fmt.Sprintf("ttHeader read kv info failed, %s, headerInfo=%#x", err.Error(), headerInfo))
 	}
 	fillBasicInfoOfTTHeader(message)
 


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
optimize(ttheader): 当 reakKVInfo 失败后附加部分 header 的 binary 信息到 error 中，用于问题排查

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
