### PR TITLE
chore: change kitex meta file name from kitex.yaml to kitex_info.yaml

### DIFF
--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -36,7 +36,7 @@ const (
 
 	BuildFileName       = "build.sh"
 	BootstrapFileName   = "bootstrap.sh"
-	ToolVersionFileName = "kitex.yaml"
+	ToolVersionFileName = "kitex_info.yaml"
 	HandlerFileName     = "handler.go"
 	MainFileName        = "main.go"
 	ClientFileName      = "client.go"


### PR DESCRIPTION
#### What type of PR is this?
chore

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
把 kitex 生成代码元信息记录文件名称从 kitex.yaml 改为 kitex_info.yaml

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

#### Which issue(s) this PR fixes:
