### PR TITLE
fix: zero first byte of grpc data frame, which could be random data from mcache

### DIFF
--- a/pkg/remote/codec/protobuf/grpc_test.go
+++ b/pkg/remote/codec/protobuf/grpc_test.go
@@ -1,0 +1,70 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protobuf
+
+import (
+	"testing"
+
+	"github.com/bytedance/gopkg/lang/mcache"
+)
+
+func Test_mallocWithFirstByteZeroed(t *testing.T) {
+	type args struct {
+		size int
+		data []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want byte
+	}{
+		{
+			name: "test_with_no_data",
+			args: args{
+				size: 4,
+				data: nil,
+			},
+			want: 0,
+		},
+		{
+			name: "test_with_zeroed_data",
+			args: args{
+				size: 8,
+				data: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+			},
+			want: 0,
+		},
+		{
+			name: "test_with_non_zeroed_data",
+			args: args{
+				size: 16,
+				data: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.data != nil {
+				buf := mcache.Malloc(tt.args.size)
+				copy(buf, tt.args.data)
+				mcache.Free(buf)
+			}
+			if got := mallocWithFirstByteZeroed(tt.args.size); got[0] != tt.want {
+				t.Errorf("mallocWithFirstByteZeroed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复：将 GRPC Data Frame 的首字节清零（compressed flag=0）；从mcache取得的buf里可能有任意数据

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: grpc data frame requires the first byte to be `compressed flag`, which should be 0/1, but kitex is using a buffer allocated by the mcache pkg which may contain random data.
zh(optional): 

#### Which issue(s) this PR fixes:
