### PR TITLE
fix(codec): fix fastpb nil ptr when struct fields are all default values

### DIFF
--- a/pkg/remote/codec/protobuf/grpc.go
+++ b/pkg/remote/codec/protobuf/grpc.go
@@ -108,10 +108,18 @@ func (c *grpcCodec) Decode(ctx context.Context, message remote.Message, in remot
 	}
 	message.SetPayloadLen(dLen)
 	data := message.Data()
+	if t, ok := data.(fastpb.Reader); ok {
+		if len(d) == 0 {
+			// if all fields of a struct is default value, data will be nil
+			// In the implementation of fastpb, if data is nil, then fastpb will skip creating this struct, as a result user will get a nil pointer which is not expected.
+			// So, when data is nil, use default protobuf unmarshal method to decode the struct.
+			// todo: fix fastpb
+		} else {
+			_, err = fastpb.ReadMessage(d, fastpb.SkipTypeCheck, t)
+			return err
+		}
+	}
 	switch t := data.(type) {
-	case fastpb.Reader:
-		_, err = fastpb.ReadMessage(d, fastpb.SkipTypeCheck, t)
-		return err
 	case protobufV2MsgCodec:
 		return t.XXX_Unmarshal(d)
 	case proto.Message:


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复当结构体值为默认时使用 fastpb 解码导致空指针的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: Due to the implementation of fastpb, when a structure with default values ​​is encountered, the serialization step will be skipped and a null pointer will be returned directly. Let’s first use the protobuf native serialization method to deal with this special situation from the Kitex code level. This problem will be completely solved in fastpb later.

zh(optional): 由于 fastpb 的实现原因，当遇到默认值的结构体时，会跳过序列化的步骤，直接返回空指针。先从 Kitex 代码层面用 protobuf 原生序列化方式处理这种特殊情况兜底。后续再在 fastpb 中彻底解决这个问题。

#### Which issue(s) this PR fixes:
Fixes #789
