### PR TITLE
optimize: add Interval option when building QPSLimiter

### DIFF
--- a/pkg/limit/limit.go
+++ b/pkg/limit/limit.go
@@ -16,6 +16,8 @@
 
 package limit
 
+import "time"
+
 // Updater is used to update the limit dynamically.
 type Updater interface {
 	UpdateLimit(opt *Option) (updated bool)
@@ -25,7 +27,7 @@ type Updater interface {
 type Option struct {
 	MaxConnections int
 	MaxQPS         int
-
+	Interval       time.Duration
 	// UpdateControl receives a Updater which gives the limitation provider
 	// the ability to update limit dynamically.
 	UpdateControl func(u Updater)

--- a/server/server.go
+++ b/server/server.go
@@ -368,7 +368,7 @@ func (s *server) buildLimiterWithOpt() (handler remote.InboundHandler) {
 	if qpsLimit == nil {
 		if limits != nil && limits.MaxQPS > 0 && limits.Interval > 0 {
 			qpsLimit = limiter.NewQPSLimiter(limits.Interval, limits.MaxQPS)
-		} else if limits != nil && limits.MaxQPS == 0 {
+		} else if limits != nil && limits.MaxQPS > 0 {
 			interval := time.Millisecond * 100 // FIXME: should not care this implementation-specific parameter
 			qpsLimit = limiter.NewQPSLimiter(interval, limits.MaxQPS)
 		} else {

--- a/server/server.go
+++ b/server/server.go
@@ -366,7 +366,9 @@ func (s *server) buildLimiterWithOpt() (handler remote.InboundHandler) {
 		}
 	}
 	if qpsLimit == nil {
-		if limits != nil && limits.MaxQPS > 0 {
+		if limits != nil && limits.MaxQPS > 0 && limits.Interval > 0 {
+			qpsLimit = limiter.NewQPSLimiter(limits.Interval, limits.MaxQPS)
+		} else if limits != nil && limits.MaxQPS == 0 {
 			interval := time.Millisecond * 100 // FIXME: should not care this implementation-specific parameter
 			qpsLimit = limiter.NewQPSLimiter(interval, limits.MaxQPS)
 		} else {


### PR DESCRIPTION
#### What type of PR is this?
optimize
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
在构建QPSLimiter时添加间隔选项

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
目前在RPC服务端调用WithLimit对服务器QPS进行限制时，其基本逻辑是将一秒分为若干个Interval，通过:
QPS/((Second)/(Interval))  的方式得到每个Interval可用的限流token数量。
但是在目前的源码中，Interval被固定为100ms，这就导致当QPS被设置为0<qps<10时，RPC服务器将永远处于被限流状态，无法响应请求。通过添加Interval选项，可以让用户自行配置每秒应当被分为多少个Interval；当用户没用提供Interval选项时，再采用原来的默认100ms。
