### PR TITLE
refactor: return error in onRead of defaultServerHandler and close conn in outer method

### DIFF
--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -110,27 +110,22 @@ func (t *svrTransHandler) Read(ctx context.Context, conn net.Conn, recvMsg remot
 }
 
 // OnRead implements the remote.ServerTransHandler interface.
-func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
+func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error) {
 	ri := rpcinfo.GetRPCInfo(ctx)
 	t.ext.SetReadTimeout(ctx, conn, ri.Config(), remote.Server)
-	var err error
-	var closeConn bool
 	var recvMsg remote.Message
 	var sendMsg remote.Message
 	defer func() {
 		panicErr := recover()
 		if panicErr != nil {
-			closeConn = true
 			if conn != nil {
 				ri := rpcinfo.GetRPCInfo(ctx)
 				rService, rAddr := getRemoteInfo(ri, conn)
+				conn.Close()
 				klog.CtxErrorf(ctx, "KITEX: panic happened, close conn, remoteAddress=%s, remoteService=%s, error=%v\nstack=%s", rAddr, rService, panicErr, string(debug.Stack()))
 			} else {
 				klog.CtxErrorf(ctx, "KITEX: panic happened, error=%v\nstack=%s", panicErr, string(debug.Stack()))
 			}
-		}
-		if closeConn && conn != nil {
-			conn.Close()
 		}
 		t.finishTracer(ctx, ri, err, panicErr)
 		t.finishProfiler(ctx)
@@ -145,20 +140,18 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 	recvMsg.SetPayloadCodec(t.opt.PayloadCodec)
 	ctx, err = t.Read(ctx, conn, recvMsg)
 	if err != nil {
-		closeConn = true
 		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
 		t.OnError(ctx, err, conn)
-		return nil
+		return err
 	}
 
 	var methodInfo serviceinfo.MethodInfo
 	if methodInfo, err = GetMethodInfo(ri, t.svcInfo); err != nil {
 		// it won't be err, because the method has been checked in decode, err check here just do defensive inspection
-		closeConn = true
 		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
 		// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded
 		t.OnError(ctx, err, conn)
-		return nil
+		return err
 	}
 	if methodInfo.OneWay() {
 		sendMsg = remote.NewMessage(nil, t.svcInfo, ri, remote.Reply, remote.Server)
@@ -171,15 +164,18 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 		// error cannot be wrapped to print here, so it must exec before NewTransError
 		t.OnError(ctx, err, conn)
 		err = remote.NewTransError(remote.InternalError, err)
-		closeConn = t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, false)
+		// connection should not be closed only when the error is return by the server handler
+		// otherwise, return the error and the connection will be closed outside.
+		if closeConn := t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, false); closeConn {
+			return err
+		}
 		return nil
 	}
 
 	remote.FillSendMsgFromRecvMsg(recvMsg, sendMsg)
 	if ctx, err = t.transPipe.Write(ctx, conn, sendMsg); err != nil {
-		closeConn = true
 		t.OnError(ctx, err, conn)
-		return nil
+		return err
 	}
 	return nil
 }

--- a/pkg/remote/trans/gonet/server_handler_test.go
+++ b/pkg/remote/trans/gonet/server_handler_test.go
@@ -173,6 +173,6 @@ func TestNoMethodInfo(t *testing.T) {
 	test.Assert(t, err == nil, err)
 
 	err = svrTransHdlr.OnRead(ctx, conn)
-	test.Assert(t, err == nil, err)
-	test.Assert(t, isClosed)
+	test.Assert(t, err != nil, err)
+	test.Assert(t, !isClosed)
 }

--- a/pkg/remote/trans/gonet/server_handler_test.go
+++ b/pkg/remote/trans/gonet/server_handler_test.go
@@ -36,11 +36,16 @@ func TestOnActive(t *testing.T) {
 			},
 		},
 	}
+	pl := remote.NewTransPipeline(svrTransHdlr)
+	svrTransHdlr.SetPipeline(pl)
+	if setter, ok := svrTransHdlr.(remote.InvokeHandleFuncSetter); ok {
+		setter.SetInvokeHandleFunc(func(ctx context.Context, req, resp interface{}) (err error) {
+			return nil
+		})
+	}
 
 	ctx := context.Background()
-	ctx, err := svrTransHdlr.OnActive(ctx, conn)
-	test.Assert(t, err == nil, err)
-	err = svrTransHdlr.OnRead(ctx, conn)
+	_, err := svrTransHdlr.OnActive(ctx, conn)
 	test.Assert(t, err == nil, err)
 }
 
@@ -141,9 +146,9 @@ func TestPanicAfterRead(t *testing.T) {
 	test.Assert(t, err == nil, err)
 
 	err = svrTransHdlr.OnRead(ctx, conn)
-	test.Assert(t, err == nil, err)
+	test.Assert(t, err != nil, err)
 	test.Assert(t, !isInvoked)
-	test.Assert(t, isClosed)
+	test.Assert(t, !isClosed)
 }
 
 // TestNoMethodInfo test server_handler without method info success

--- a/pkg/remote/trans/netpoll/server_handler_test.go
+++ b/pkg/remote/trans/netpoll/server_handler_test.go
@@ -268,8 +268,8 @@ func TestNoMethodInfo(t *testing.T) {
 	test.Assert(t, err == nil, err)
 
 	err = svrTransHdlr.OnRead(ctx, conn)
-	test.Assert(t, err == nil, err)
+	test.Assert(t, err != nil, err)
 	test.Assert(t, isReaderBufReleased)
 	test.Assert(t, isWriteBufFlushed)
-	test.Assert(t, isClosed)
+	test.Assert(t, !isClosed)
 }

--- a/pkg/remote/trans/netpoll/trans_server_test.go
+++ b/pkg/remote/trans/netpoll/trans_server_test.go
@@ -187,10 +187,15 @@ func TestConnOnActiveAndOnInactivePanic(t *testing.T) {
 // TestOnConnRead test trans_server onConnRead success
 func TestConnOnRead(t *testing.T) {
 	// 1. prepare mock data
+	var isClosed bool
 	conn := &MockNetpollConn{
 		Conn: mocks.Conn{
 			RemoteAddrFunc: func() (r net.Addr) {
 				return addr
+			},
+			CloseFunc: func() (e error) {
+				isClosed = true
+				return nil
 			},
 		},
 	}
@@ -205,4 +210,5 @@ func TestConnOnRead(t *testing.T) {
 	// 2. test
 	err := transSvr.onConnRead(context.Background(), conn)
 	test.Assert(t, err == nil, err)
+	test.Assert(t, isClosed)
 }


### PR DESCRIPTION
#### What type of PR is this?
refactor
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
zh: refactor: defaultServerHandler 的 onRead 返回错误，由外层方法关闭连接。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
