### PR TITLE
optimize: add DeepCopy() & Equals() to circuitbreaker.CBConfig and retry.Policy

### DIFF
--- a/pkg/circuitbreak/cbsuite.go
+++ b/pkg/circuitbreak/cbsuite.go
@@ -46,10 +46,33 @@ func GetDefaultCBConfig() CBConfig {
 }
 
 // CBConfig is policy config of CircuitBreaker.
+// DON'T FORGET to update DeepCopy() and Equals() if you add new fields.
 type CBConfig struct {
 	Enable    bool    `json:"enable"`
 	ErrRate   float64 `json:"err_rate"`
 	MinSample int64   `json:"min_sample"`
+}
+
+// DeepCopy returns a full copy of CBConfig.
+func (c *CBConfig) DeepCopy() *CBConfig {
+	if c == nil {
+		return nil
+	}
+	return &CBConfig{
+		Enable:    c.Enable,
+		ErrRate:   c.ErrRate,
+		MinSample: c.MinSample,
+	}
+}
+
+func (c *CBConfig) Equals(other *CBConfig) bool {
+	if c == nil && other == nil {
+		return true
+	}
+	if c == nil || other == nil {
+		return false
+	}
+	return c.Enable == other.Enable && c.ErrRate == other.ErrRate && c.MinSample == other.MinSample
 }
 
 // GenServiceCBKeyFunc to generate circuit breaker key through rpcinfo.

--- a/pkg/circuitbreak/cbsuite_test.go
+++ b/pkg/circuitbreak/cbsuite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -429,4 +430,196 @@ func (m mockInst) Weight() int {
 
 func (m mockInst) Tag(key string) (value string, exist bool) {
 	return
+}
+
+func TestCBConfig_DeepCopy(t *testing.T) {
+	type fields struct {
+		c *CBConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *CBConfig
+	}{
+		{
+			name: "test_nil_copy",
+			fields: fields{
+				c: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "test_all_copy",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			want: &CBConfig{
+				Enable:    true,
+				ErrRate:   0.1,
+				MinSample: 10,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fields.c.DeepCopy(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeepCopy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCBConfig_Equals(t *testing.T) {
+	type fields struct {
+		c *CBConfig
+	}
+	type args struct {
+		other *CBConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "test_nil_equal",
+			fields: fields{
+				c: nil,
+			},
+			args: args{
+				other: nil,
+			},
+			want: true,
+		},
+		{
+			name: "test_nil_not_equal",
+			fields: fields{
+				c: nil,
+			},
+			args: args{
+				other: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test_other_nil_not_equal",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			args: args{
+				other: nil,
+			},
+			want: false,
+		},
+		{
+			name: "test_all_equal",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			args: args{
+				other: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test_all_not_equal",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			args: args{
+				other: &CBConfig{
+					Enable:    false,
+					ErrRate:   0.2,
+					MinSample: 20,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test_enable_equal",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			args: args{
+				other: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.2,
+					MinSample: 20,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test_err_rate_equal",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			args: args{
+				other: &CBConfig{
+					Enable:    false,
+					ErrRate:   0.1,
+					MinSample: 20,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test_min_sample_equal",
+			fields: fields{
+				c: &CBConfig{
+					Enable:    true,
+					ErrRate:   0.1,
+					MinSample: 10,
+				},
+			},
+			args: args{
+				other: &CBConfig{
+					Enable:    false,
+					ErrRate:   0.2,
+					MinSample: 10,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fields.c.Equals(tt.args.other); got != tt.want {
+				t.Errorf("Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION

#### What type of PR is this?
optimize: add DeepCopy() & Equals() to circuitbreaker.CBCofnig and retry.Policy


#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
给 circuitbreaker.CBCofnig and retry.Policy 增加 DeepCopy 和 Equals 方法

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: when implementing a config provider/translator, it will be more convienient to call the DeepCopy & Equals method
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
