### PR TITLE
fix(lb): dont share balancer factory when it defined by user

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -245,11 +245,14 @@ func (kc *kClient) initLBCache() error {
 			NameFunc: func() string { return "no_resolver" },
 		}
 	}
+	// because we cannot ensure that user's custom loadbalancer is cacheable, we need to disable it here
+	cacheOpts := lbcache.Options{DiagnosisService: kc.opt.DebugService, Cacheable: false}
 	balancer := kc.opt.Balancer
 	if balancer == nil {
+		// default internal lb balancer is cacheable
+		cacheOpts.Cacheable = true
 		balancer = loadbalance.NewWeightedBalancer()
 	}
-	cacheOpts := lbcache.Options{DiagnosisService: kc.opt.DebugService}
 	if kc.opt.BalancerCacheOpt != nil {
 		cacheOpts = *kc.opt.BalancerCacheOpt
 	}

--- a/pkg/loadbalance/lbcache/cache.go
+++ b/pkg/loadbalance/lbcache/cache.go
@@ -54,6 +54,9 @@ type Options struct {
 
 	// DiagnosisService is used register info for diagnosis
 	DiagnosisService diagnosis.Service
+
+	// Cacheable is used to indicate that if the factory could be shared between multi clients
+	Cacheable bool
 }
 
 func (v *Options) check() {
@@ -91,29 +94,37 @@ func cacheKey(resolver, balancer string, opts Options) string {
 	return fmt.Sprintf("%s|%s|{%s %s}", resolver, balancer, opts.RefreshInterval, opts.ExpireInterval)
 }
 
+func newBalancerFactory(resolver discovery.Resolver, balancer loadbalance.Loadbalancer, opts Options) *BalancerFactory {
+	b := &BalancerFactory{
+		opts:     opts,
+		resolver: resolver,
+		balancer: balancer,
+	}
+	if rb, ok := balancer.(loadbalance.Rebalancer); ok {
+		hrb := newHookRebalancer(rb)
+		b.rebalancer = hrb
+		b.Hookable = hrb
+	} else {
+		b.Hookable = noopHookRebalancer{}
+	}
+	go b.watcher()
+	return b
+}
+
 // NewBalancerFactory get or create a balancer factory for balancer instance
 // cache key with resolver name, balancer name and options
 func NewBalancerFactory(resolver discovery.Resolver, balancer loadbalance.Loadbalancer, opts Options) *BalancerFactory {
 	opts.check()
+	if !opts.Cacheable {
+		return newBalancerFactory(resolver, balancer, opts)
+	}
 	uniqueKey := cacheKey(resolver.Name(), balancer.Name(), opts)
 	val, ok := balancerFactories.Load(uniqueKey)
 	if ok {
 		return val.(*BalancerFactory)
 	}
 	val, _, _ = balancerFactoriesSfg.Do(uniqueKey, func() (interface{}, error) {
-		b := &BalancerFactory{
-			opts:     opts,
-			resolver: resolver,
-			balancer: balancer,
-		}
-		if rb, ok := balancer.(loadbalance.Rebalancer); ok {
-			hrb := newHookRebalancer(rb)
-			b.rebalancer = hrb
-			b.Hookable = hrb
-		} else {
-			b.Hookable = noopHookRebalancer{}
-		}
-		go b.watcher()
+		b := newBalancerFactory(resolver, balancer, opts)
 		balancerFactories.Store(uniqueKey, b)
 		return b, nil
 	})

--- a/pkg/loadbalance/lbcache/cache_test.go
+++ b/pkg/loadbalance/lbcache/cache_test.go
@@ -61,7 +61,7 @@ func TestBuilder(t *testing.T) {
 		return picker
 	}).AnyTimes()
 	lb.EXPECT().Name().Return("Synthesized").AnyTimes()
-	NewBalancerFactory(r, lb, Options{})
+	NewBalancerFactory(r, lb, Options{Cacheable: true})
 	b, ok := balancerFactories.Load(cacheKey(t.Name(), "Synthesized", defaultOptions))
 	test.Assert(t, ok)
 	test.Assert(t, b != nil)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

fix(lb): 当 lb 来自用户自定义设置时候，不共享同一个 balancer factory

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: The premise of balancer factory sharing is that lb must be stateless. For example, consistent hash load balancer has its own state so cannot be shared. This fix will not use caching for all user-specified load balancers.
zh(optional): balancer factory 共享的前提是，lb 必须是无状态的。而比如一致性哈希负载均衡，是有其自身状态的，无法被共享。该修复会对所有用户手动指定的负载均衡都不使用缓存。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
