### PR TITLE
fix(grpc): no need to set context return by sendMsg/recvMsg to the context of stream

### DIFF
--- a/client/stream_test.go
+++ b/client/stream_test.go
@@ -102,13 +102,24 @@ func TestStreaming(t *testing.T) {
 		kc:     kc,
 	}
 
-	// recv nil msg
-	err = stream.RecvMsg(nil)
-	test.Assert(t, err == nil, err)
+	for i := 0; i < 10; i++ {
+		ch := make(chan struct{})
+		// recv nil msg
+		go func() {
+			err := stream.RecvMsg(nil)
+			test.Assert(t, err == nil, err)
+			ch <- struct{}{}
+		}()
 
-	// send nil msg
-	err = stream.SendMsg(nil)
-	test.Assert(t, err == nil, err)
+		// send nil msg
+		go func() {
+			err := stream.SendMsg(nil)
+			test.Assert(t, err == nil, err)
+			ch <- struct{}{}
+		}()
+		<-ch
+		<-ch
+	}
 
 	// close
 	err = stream.Close()

--- a/pkg/remote/trans/nphttp2/stream.go
+++ b/pkg/remote/trans/nphttp2/stream.go
@@ -98,8 +98,7 @@ func (s *stream) RecvMsg(m interface{}) error {
 	msg.SetProtocolInfo(remote.NewProtocolInfo(ri.Config().TransportProtocol(), s.svcInfo.PayloadCodec))
 	defer msg.Recycle()
 
-	ctx, err := s.handler.Read(s.ctx, s.conn, msg)
-	s.ctx = ctx
+	_, err := s.handler.Read(s.ctx, s.conn, msg)
 	return err
 }
 
@@ -110,8 +109,7 @@ func (s *stream) SendMsg(m interface{}) error {
 	msg.SetProtocolInfo(remote.NewProtocolInfo(ri.Config().TransportProtocol(), s.svcInfo.PayloadCodec))
 	defer msg.Recycle()
 
-	ctx, err := s.handler.Write(s.ctx, s.conn, msg)
-	s.ctx = ctx
+	_, err := s.handler.Write(s.ctx, s.conn, msg)
 	return err
 }
 


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
zh: fix(grpc): stream 的 sendMsg/recvMsg 返回的 ctx 无需赋值给 stream 的 ctx

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
