### PR TITLE
feat(rpctimeout): fine grained rpc timeout error code

### DIFF
--- a/pkg/kerrors/kerrors.go
+++ b/pkg/kerrors/kerrors.go
@@ -26,18 +26,20 @@ import (
 
 // Basic error types
 var (
-	ErrInternalException = &basicError{"internal exception"}
-	ErrServiceDiscovery  = &basicError{"service discovery error"}
-	ErrGetConnection     = &basicError{"get connection error"}
-	ErrLoadbalance       = &basicError{"loadbalance error"}
-	ErrNoMoreInstance    = &basicError{"no more instances to retry"}
-	ErrRPCTimeout        = &basicError{"rpc timeout"}
-	ErrACL               = &basicError{"request forbidden"}
-	ErrCircuitBreak      = &basicError{"forbidden by circuitbreaker"}
-	ErrRemoteOrNetwork   = &basicError{"remote or network error"}
-	ErrOverlimit         = &basicError{"request over limit"}
-	ErrPanic             = &basicError{"panic"}
-	ErrBiz               = &basicError{"biz error"}
+	ErrInternalException  = &basicError{"internal exception"}
+	ErrServiceDiscovery   = &basicError{"service discovery error"}
+	ErrGetConnection      = &basicError{"get connection error"}
+	ErrLoadbalance        = &basicError{"loadbalance error"}
+	ErrNoMoreInstance     = &basicError{"no more instances to retry"}
+	ErrRPCTimeout         = &basicError{"rpc timeout"}
+	ErrCanceledByBusiness = &basicError{"canceled by business"}
+	ErrTimeoutByBusiness  = &basicError{"timeout by business"}
+	ErrACL                = &basicError{"request forbidden"}
+	ErrCircuitBreak       = &basicError{"forbidden by circuitbreaker"}
+	ErrRemoteOrNetwork    = &basicError{"remote or network error"}
+	ErrOverlimit          = &basicError{"request over limit"}
+	ErrPanic              = &basicError{"panic"}
+	ErrBiz                = &basicError{"biz error"}
 
 	ErrRetry = &basicError{"retry error"}
 	// ErrRPCFinish happens when retry enabled and there is one call has finished

--- a/pkg/rpctimeout/rpctimeout.go
+++ b/pkg/rpctimeout/rpctimeout.go
@@ -15,12 +15,11 @@
  */
 
 // Package rpctimeout implements logic for timeout controlling.
-// Deprecated: the timeout function is a built-in function of clients. This
-// package is no longger needed.
 package rpctimeout
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cloudwego/kitex/pkg/endpoint"
@@ -30,12 +29,12 @@ type timeoutAdjustKeyType int
 
 // TimeoutAdjustKey is used to adjust the timeout of RPC timeout middleware.
 // Deprecated: this value is kept for historical reason and compatibility.
-// It should not be used any more.
+// It should not be used anymore.
 const TimeoutAdjustKey timeoutAdjustKeyType = 1
 
 // MiddlewareBuilder builds timeout middleware.
 // Deprecated: this method is kept for historical reason and compatibility.
-// It should not be used any more.
+// It should not be used anymore.
 func MiddlewareBuilder(moreTimeout time.Duration) endpoint.MiddlewareBuilder {
 	return func(mwCtx context.Context) endpoint.Middleware {
 		if p, ok := mwCtx.Value(TimeoutAdjustKey).(*time.Duration); ok {
@@ -43,4 +42,33 @@ func MiddlewareBuilder(moreTimeout time.Duration) endpoint.MiddlewareBuilder {
 		}
 		return endpoint.DummyMiddleware
 	}
+}
+
+// Controls whether `rpcTimeoutMW` should separate ErrRPCTimeout into different errors according to causes.
+// Since atomic.Bool is available only since go1.19, use int32 instead.
+var globalNeedFineGrainedErrCode int32 = 0
+
+// EnableGlobalNeedFineGrainedErrCode can be used to set global flag, which applies to all clients.
+func EnableGlobalNeedFineGrainedErrCode() {
+	atomic.StoreInt32(&globalNeedFineGrainedErrCode, 1)
+}
+
+// DisableGlobalNeedFineGrainedErrCode can be used to revert the flag, which is useful in tests.
+func DisableGlobalNeedFineGrainedErrCode() {
+	atomic.StoreInt32(&globalNeedFineGrainedErrCode, 0)
+}
+
+// LoadGlobalNeedFineGrainedErrCode is used to load the flag, and return a bool value.
+func LoadGlobalNeedFineGrainedErrCode() bool {
+	return atomic.LoadInt32(&globalNeedFineGrainedErrCode) == 1
+}
+
+// defaultBusinessTimeoutThreshold is used to determine whether a timeout is set by kitex or business.
+// If actual DDL + threshold <  Kitex's expected DDL, it's more likely to be set by business code.
+var defaultBusinessTimeoutThreshold = time.Millisecond * 50
+
+// LoadBusinessTimeoutThreshold is used the load the threshold, and keeps compatibility if in the future
+// there's need for business code to modify the value.
+func LoadBusinessTimeoutThreshold() time.Duration {
+	return defaultBusinessTimeoutThreshold
 }


### PR DESCRIPTION
#### What type of PR is this?
feat: A new feature

#### Check the PR title.
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
feat(rpctimeout): 支持细粒度的超时错误码

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: kerrors.ErrRPCTimeout can be caused by:
- RPCTimeout set by client/call option
- Timeout set in context by business code
- context cancel() called by business code.

In some scenarios, business logic needs to distinguish the detailed reason, so this PR separates it into 3 error codes: ErrRPCTimeout, ErrTimeoutByBusiness, ErrCanceledByBusiness.

Additionally, since there may be some latency in go's timer, ErrTimeoutByBusiness is set only when actual DDL + threshold (defaults to 50ms) < kitex's DDL.

For backward compatibility, a global flag to control this feature is added and defaults to false.

zh(optional): 

#### Which issue(s) this PR fixes:
-