### PR TITLE
feat(retry): add configuration to support disable timeout retry when do failure retry, which is for the non-idempotent request

### DIFF
--- a/pkg/retry/failure_retryer.go
+++ b/pkg/retry/failure_retryer.go
@@ -219,7 +219,7 @@ func (r *failureRetryer) isRetryErr(err error, ri rpcinfo.RPCInfo) bool {
 	// But CircuitBreak has been checked in ShouldRetry, it doesn't need to filter ServiceCircuitBreak.
 	// If there are some other specified errors that cannot be retried, it should be filtered here.
 
-	if kerrors.IsTimeoutError(err) {
+	if r.policy.IsRetryForTimeout() && kerrors.IsTimeoutError(err) {
 		return true
 	}
 	if r.policy.IsErrorRetryNonNil() && r.policy.ShouldResultRetry.ErrorRetry(err, ri) {

--- a/pkg/retry/policy.go
+++ b/pkg/retry/policy.go
@@ -90,17 +90,17 @@ type FailurePolicy struct {
 	ShouldResultRetry *ShouldResultRetry `json:"-"`
 }
 
-// IsRespRetryNonNil is used to judge if RespRetry is nil
+// IsRespRetryNonNil is used to check if RespRetry is nil
 func (p FailurePolicy) IsRespRetryNonNil() bool {
 	return p.ShouldResultRetry != nil && p.ShouldResultRetry.RespRetry != nil
 }
 
-// IsErrorRetryNonNil is used to judge if ErrorRetry is nil
+// IsErrorRetryNonNil is used to check if ErrorRetry is nil
 func (p FailurePolicy) IsErrorRetryNonNil() bool {
 	return p.ShouldResultRetry != nil && p.ShouldResultRetry.ErrorRetry != nil
 }
 
-// IsRetryForTimeout is used to judge if timeout error need to retry
+// IsRetryForTimeout is used to check if timeout error need to retry
 func (p FailurePolicy) IsRetryForTimeout() bool {
 	return p.ShouldResultRetry == nil || !p.ShouldResultRetry.NotRetryForTimeout
 }
@@ -165,7 +165,7 @@ const (
 type ShouldResultRetry struct {
 	ErrorRetry func(err error, ri rpcinfo.RPCInfo) bool
 	RespRetry  func(resp interface{}, ri rpcinfo.RPCInfo) bool
-	// the requests that are not idempotent cannot do timeout retry
+	// disable the default timeout retry in specific scenarios (e.g. the requests are not non-idempotent)
 	NotRetryForTimeout bool
 }
 

--- a/pkg/retry/policy.go
+++ b/pkg/retry/policy.go
@@ -92,18 +92,17 @@ type FailurePolicy struct {
 
 // IsRespRetryNonNil is used to judge if RespRetry is nil
 func (p FailurePolicy) IsRespRetryNonNil() bool {
-	if p.ShouldResultRetry != nil && p.ShouldResultRetry.RespRetry != nil {
-		return true
-	}
-	return false
+	return p.ShouldResultRetry != nil && p.ShouldResultRetry.RespRetry != nil
 }
 
 // IsErrorRetryNonNil is used to judge if ErrorRetry is nil
 func (p FailurePolicy) IsErrorRetryNonNil() bool {
-	if p.ShouldResultRetry != nil && p.ShouldResultRetry.ErrorRetry != nil {
-		return true
-	}
-	return false
+	return p.ShouldResultRetry != nil && p.ShouldResultRetry.ErrorRetry != nil
+}
+
+// IsRetryForTimeout is used to judge if timeout error need to retry
+func (p FailurePolicy) IsRetryForTimeout() bool {
+	return p.ShouldResultRetry == nil || !p.ShouldResultRetry.NotRetryForTimeout
 }
 
 // BackupPolicy for backup request
@@ -166,6 +165,8 @@ const (
 type ShouldResultRetry struct {
 	ErrorRetry func(err error, ri rpcinfo.RPCInfo) bool
 	RespRetry  func(resp interface{}, ri rpcinfo.RPCInfo) bool
+	// the requests that are not idempotent cannot do timeout retry
+	NotRetryForTimeout bool
 }
 
 // Equals to check if policy is equal

--- a/pkg/retry/policy_test.go
+++ b/pkg/retry/policy_test.go
@@ -406,6 +406,31 @@ func TestPolicyNotEqual(t *testing.T) {
 	test.Assert(t, !p.Equals(policy))
 }
 
+func TestPolicyNotRetryForTimeout(t *testing.T) {
+	// create failurePolicy
+	fp := &FailurePolicy{StopPolicy: StopPolicy{
+		MaxRetryTimes:    1,
+		MaxDurationMS:    2,
+		DisableChainStop: false,
+		DDLStop:          false,
+		CBPolicy: CBPolicy{
+			ErrorRate: defaultCBErrRate,
+		},
+	}}
+	// case 1: ShouldResultRetry is nil, retry for timeout
+	test.Assert(t, fp.IsRetryForTimeout())
+
+	// case 2: ShouldResultRetry is not nil, NotRetryForTimeout is false, retry for timeout
+	fp.ShouldResultRetry = &ShouldResultRetry{
+		ErrorRetry: nil,
+		RespRetry:  nil,
+	}
+
+	// case 3: ShouldResultRetry is not nil, NotRetryForTimeout is true, not retry for timeout
+	fp.ShouldResultRetry.NotRetryForTimeout = true
+	test.Assert(t, !fp.IsRetryForTimeout())
+}
+
 func genRPCInfo() rpcinfo.RPCInfo {
 	to := remoteinfo.NewRemoteInfo(&rpcinfo.EndpointBasicInfo{Method: method}, method).ImmutableView()
 	ri := rpcinfo.NewRPCInfo(to, to, rpcinfo.NewInvocation("", method), rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
feat(retry): 增加配置，支持异常重试场景下不对超时做重试，用于请求非幂等的场景

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: 
zh(optional): 

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
