### PR TITLE
fix(remoteinfo): fix the race problem caused by non-deepcopy CopyFrom of remoteinfo

### DIFF
--- a/pkg/rpcinfo/remoteinfo/remoteInfo.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo.go
@@ -176,18 +176,18 @@ func (ri *remoteInfo) ForceSetTag(key, value string) {
 }
 
 // CopyFrom copies the input RemoteInfo.
-// Not deepcopy.
+// the `from` param may be modified, so must do deep copy to prevent race.
 func (ri *remoteInfo) CopyFrom(from RemoteInfo) {
-	if from == nil {
+	if from == nil || ri == from {
 		return
 	}
 	ri.Lock()
 	f := from.(*remoteInfo)
 	ri.serviceName = f.serviceName
 	ri.instance = f.instance
-	ri.tags = f.tags
 	ri.method = f.method
-	ri.tagLocks = f.tagLocks
+	ri.tags = f.copyTags()
+	ri.tagLocks = f.copyTagsLocks()
 	ri.Unlock()
 }
 
@@ -196,7 +196,29 @@ func (ri *remoteInfo) ImmutableView() rpcinfo.EndpointInfo {
 	return ri
 }
 
+func (ri *remoteInfo) copyTags() map[string]string {
+	ri.Lock()
+	defer ri.Unlock()
+	newTags := make(map[string]string, len(ri.tags))
+	for k, v := range ri.tags {
+		newTags[k] = v
+	}
+	return newTags
+}
+
+func (ri *remoteInfo) copyTagsLocks() map[string]struct{} {
+	ri.Lock()
+	defer ri.Unlock()
+	newTagLocks := make(map[string]struct{}, len(ri.tagLocks))
+	for k, v := range ri.tagLocks {
+		newTagLocks[k] = v
+	}
+	return newTagLocks
+}
+
 func (ri *remoteInfo) zero() {
+	ri.Lock()
+	defer ri.Unlock()
 	ri.serviceName = ""
 	ri.method = ""
 	ri.instance = nil

--- a/pkg/rpcinfo/remoteinfo/remoteInfo_test.go
+++ b/pkg/rpcinfo/remoteinfo/remoteInfo_test.go
@@ -196,9 +196,10 @@ func TestCopyFromRace(t *testing.T) {
 	ri2 := remoteinfo.NewRemoteInfo(&rpcinfo.EndpointBasicInfo{ServiceName: "service", Tags: map[string]string{key2: val2}}, "method1")
 	// do copyFrom ri2
 	ri1.CopyFrom(ri2)
-	v, ok = ri1.Tag(key1)
+	_, ok = ri1.Tag(key1)
 	test.Assert(t, !ok)
 	v, ok = ri1.Tag(key2)
+	test.Assert(t, ok)
 	test.Assert(t, v == val2)
 
 	// test the data race problem caused by tag modification


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
fix(remoteinfo): 修复 remoteinfo 中非深拷贝的 CopyFrom 引入的 race 问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: The race problem may happen when enable retry
zh(optional): 在开启重试时可能会触发

#### Which issue(s) this PR fixes:
#827
