### PR TITLE
feat: support loop_service in custom template

### DIFF
--- a/tool/internal_pkg/generator/completor.go
+++ b/tool/internal_pkg/generator/completor.go
@@ -306,8 +306,11 @@ func (c *commonCompleter) addImport(w io.Writer, newMethods []*MethodInfo, fset 
 		if err != nil {
 			return err
 		}
-		if _, ok := existImports[strings.Trim(content, "\"")]; !ok {
-			astutil.AddImport(fset, handlerAST, strings.Trim(content, "\""))
+		imports := c.parseImports(content)
+		for idx := range imports {
+			if _, ok := existImports[strings.Trim(imports[idx][1], "\"")]; !ok {
+				astutil.AddImport(fset, handlerAST, strings.Trim(imports[idx][1], "\""))
+			}
 		}
 	}
 	printer.Fprint(w, fset, handlerAST)
@@ -331,4 +334,35 @@ func (c *commonCompleter) addImplementations(w io.Writer, newMethods []*MethodIn
 	_, err = w.Write([]byte(content))
 	c.pkg.Methods = tmp
 	return err
+}
+
+// imports[2] is alias, import
+func (c *commonCompleter) parseImports(content string) (imports [][2]string) {
+	if !strings.Contains(content, "\"") {
+		imports = append(imports, [2]string{"", content})
+		return imports
+	}
+	for i := 0; i < len(content); i++ {
+		if content[i] == ' ' {
+			continue
+		}
+		isAlias := content[i] != '"'
+
+		start := i
+		for ; i < len(content); i++ {
+			if content[i] == ' ' {
+				break
+			}
+		}
+		sub := content[start:i]
+		switch {
+		case isAlias:
+			imports = append(imports, [2]string{sub, ""})
+		case len(imports) > 0 && imports[len(imports)-1][1] == "":
+			imports[len(imports)-1][1] = sub
+		default:
+			imports = append(imports, [2]string{"", sub})
+		}
+	}
+	return imports
 }

--- a/tool/internal_pkg/generator/custom_template.go
+++ b/tool/internal_pkg/generator/custom_template.go
@@ -206,11 +206,6 @@ func renderFile(pkg *PackageInfo, outputPath string, tpl *Template) (fs []*File,
 		err = cg.commonGenerate(tpl)
 	}
 	if err == errNoNewMethod {
-		_serviceName := pkg.PkgName
-		if pkg.Base != nil {
-			_serviceName = pkg.Base.PkgName
-		}
-		log.Warnf("service %s does not need to update template: %s ", _serviceName, tpl.Path)
 		err = nil
 	}
 	return cg.fs, err


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
feat(tool): 自定义模板中支持 loop_service

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: In custom template, if the `combination-service` is set in the generation command and loop_service is set to true in the template, the corresponding template file will be rendered in a loop according to the service during generation.
zh(optional): 在自定义模板中，如果在生成命令中设置了 combine-service 和在模版中指定了 loop_service: true，则在生成时，对应的模版文件会按照 service 循环渲染

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
