### PR TITLE
fix(util): fix not able to get GOPATH correctly

### DIFF
--- a/tool/internal_pkg/util/util.go
+++ b/tool/internal_pkg/util/util.go
@@ -58,8 +58,8 @@ func FormatCode(code []byte) ([]byte, error) {
 func GetGOPATH() string {
 	goPath := os.Getenv("GOPATH")
 	// If there are many path in GOPATH, pick up the first one.
-	if GoPaths := strings.Split(goPath, ":"); len(GoPaths) >= 1 {
-		return GoPaths[0]
+	if GoPaths := strings.Split(goPath, ":"); len(GoPaths) >= 1 && strings.TrimSpace(GoPaths[0]) != "" {
+		return strings.TrimSpace(GoPaths[0])
 	}
 	// GOPATH not set through environment variables, try to get one by executing "go env GOPATH"
 	output, err := exec.Command("go", "env", "GOPATH").Output()

--- a/tool/internal_pkg/util/util_test.go
+++ b/tool/internal_pkg/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"os"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
@@ -31,4 +32,16 @@ func TestCombineOutputPath(t *testing.T) {
 	path3 := "kitex_path/{namespaceUnderscore}/code"
 	output3 := CombineOutputPath(path3, ns)
 	test.Assert(t, output3 == "kitex_path/aaa_bbb_ccc/code")
+}
+
+func TestGetGOPATH(t *testing.T) {
+	orig := os.Getenv("GOPATH")
+	defer func() {
+		os.Setenv("GOPATH", orig)
+	}()
+
+	os.Setenv("GOPATH", "/usr/bin/go:/usr/local/bin/go")
+	test.Assert(t, GetGOPATH() == "/usr/bin/go")
+	os.Setenv("GOPATH", "")
+	test.Assert(t, GetGOPATH() != "")
 }


### PR DESCRIPTION
FIX
when GOPATH is empty or not set in env, it will return empty instead of keep trying to find GOPATH from "go env"

tested under go1.20.4
