### PR TITLE
fix(tool): fix panic when rebuilding service code in WindowsOS

### DIFF
--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -18,6 +18,7 @@ package generator
 import (
 	"fmt"
 	"go/token"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -350,7 +351,7 @@ func (g *generator) GenerateMainPackage(pkg *PackageInfo) (fs []*File, err error
 		fs = append(fs, f)
 	}
 
-	handlerFilePath := util.JoinPath(g.OutputPath, HandlerFileName)
+	handlerFilePath := filepath.Join(g.OutputPath, HandlerFileName)
 	if util.Exists(handlerFilePath) {
 		comp := newCompleter(
 			pkg.ServiceInfo.AllMethods(),

--- a/tool/internal_pkg/util/util.go
+++ b/tool/internal_pkg/util/util.go
@@ -257,6 +257,7 @@ func CombineOutputPath(outputPath, ns string) string {
 	return outputPath
 }
 
+// JoinPath joins dirs as golang import format, such as xx/xx/xx
 func JoinPath(elem ...string) string {
 	if runtime.GOOS == "windows" {
 		return strings.ReplaceAll(filepath.Join(elem...), "\\", "/")


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复在 Windows 环境时更新 Service 脚手架代码触发 panic 的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
#944 

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->