### PR TITLE
fix: generic-map writeInt8 fails on byte

### DIFF
--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -309,7 +309,14 @@ func writeBool(ctx context.Context, val interface{}, out thrift.TProtocol, t *de
 }
 
 func writeInt8(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error {
-	return out.WriteByte(val.(int8))
+	switch val := val.(type) {
+	case int8:
+		return out.WriteByte(val)
+	case uint8:
+		return out.WriteByte(int8(val))
+	default:
+		return fmt.Errorf("unsupported type: %T", val)
+	}
 }
 
 func writeJSONNumber(ctx context.Context, val interface{}, out thrift.TProtocol, t *descriptor.TypeDescriptor, opt *writerOption) error {

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -126,11 +126,13 @@ func Test_writeInt8(t *testing.T) {
 		t   *descriptor.TypeDescriptor
 		opt *writerOption
 	}
-	mockTTransport := &mocks.MockThriftTTransport{
-		WriteByteFunc: func(val int8) error {
-			test.Assert(t, val == 1)
-			return nil
-		},
+	mockTTransport := func(v int8) *mocks.MockThriftTTransport {
+		return &mocks.MockThriftTTransport{
+			WriteByteFunc: func(val int8) error {
+				test.Assert(t, val == v)
+				return nil
+			},
+		}
 	}
 	tests := []struct {
 		name    string
@@ -142,13 +144,37 @@ func Test_writeInt8(t *testing.T) {
 			"writeInt8",
 			args{
 				val: int8(1),
-				out: mockTTransport,
+				out: mockTTransport(1),
 				t: &descriptor.TypeDescriptor{
 					Type:   descriptor.I08,
 					Struct: &descriptor.StructDescriptor{},
 				},
 			},
 			false,
+		},
+		{
+			name: "writeInt8 byte",
+			args: args{
+				val: byte(128),
+				out: mockTTransport(-128), // overflow
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "writeInt8 error",
+			args: args{
+				val: int16(2),
+				out: mockTTransport(2),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?
fix: A bug fix

#### Check the PR title.
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [X] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复 map 泛化调用在 byte 类型字段 panic 的问题


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: apache thrift always use int8 (in Golang struct fields) for byte (in IDL), so kitex always treat the field as int8 when writing. But it happens that biz code set byte-typed values for the field in generic-map call requests, which will cause panic.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:


#### (optional) The PR that updates user documentation:
