### PR TITLE
optimize(ttheader): add type check for headerFlags of TTheader

### DIFF
--- a/pkg/remote/codec/header_codec.go
+++ b/pkg/remote/codec/header_codec.go
@@ -390,14 +390,18 @@ func readACLToken(idx *int, buf []byte, info map[string]string) error {
 func getFlags(message remote.Message) HeaderFlags {
 	var headerFlags HeaderFlags
 	if message.Tags() != nil && message.Tags()[HeaderFlagsKey] != nil {
-		headerFlags = message.Tags()[HeaderFlagsKey].(HeaderFlags)
+		if hfs, ok := message.Tags()[HeaderFlagsKey].(HeaderFlags); ok {
+			headerFlags = hfs
+		} else {
+			klog.Warnf("KITEX: the type of headerFlags is invalid, %T", message.Tags()[HeaderFlagsKey])
+		}
 	}
 	return headerFlags
 }
 
 func setFlags(flags uint16, message remote.Message) {
 	if message.MessageType() == remote.Call {
-		message.Tags()[HeaderFlagsKey] = flags
+		message.Tags()[HeaderFlagsKey] = HeaderFlags(flags)
 	}
 }
 

--- a/pkg/remote/codec/header_codec_test.go
+++ b/pkg/remote/codec/header_codec_test.go
@@ -259,7 +259,7 @@ func BenchmarkTTHeaderWithTransInfoParallel(b *testing.B) {
 			test.DeepEqual(b, strKVInfoRecv, strKVInfo)
 			flag := recvMsg.Tags()[HeaderFlagsKey]
 			test.Assert(b, flag != nil)
-			test.Assert(b, flag == uint16(HeaderFlagSupportOutOfOrder))
+			test.Assert(b, flag == HeaderFlagSupportOutOfOrder)
 		}
 	})
 }

--- a/pkg/remote/codec/header_codec_test.go
+++ b/pkg/remote/codec/header_codec_test.go
@@ -88,7 +88,7 @@ func TestTTHeaderCodecWithTransInfo(t *testing.T) {
 	test.DeepEqual(t, strKVInfoRecv, strKVInfo)
 	flag := recvMsg.Tags()[HeaderFlagsKey]
 	test.Assert(t, flag != nil)
-	test.Assert(t, flag == uint16(HeaderFlagSupportOutOfOrder))
+	test.Assert(t, flag == HeaderFlagSupportOutOfOrder)
 }
 
 func TestTTHeaderCodecWithTransInfoWithGDPRToken(t *testing.T) {
@@ -121,7 +121,7 @@ func TestTTHeaderCodecWithTransInfoWithGDPRToken(t *testing.T) {
 	test.DeepEqual(t, strKVInfoRecv, strKVInfo)
 	flag := recvMsg.Tags()[HeaderFlagsKey]
 	test.Assert(t, flag != nil)
-	test.Assert(t, flag == uint16(HeaderFlagSupportOutOfOrder))
+	test.Assert(t, flag == HeaderFlagSupportOutOfOrder)
 }
 
 func TestTTHeaderCodecWithTransInfoFromMetaInfoGDPRToken(t *testing.T) {
@@ -155,7 +155,7 @@ func TestTTHeaderCodecWithTransInfoFromMetaInfoGDPRToken(t *testing.T) {
 	test.DeepEqual(t, strKVInfoRecv, map[string]string{transmeta.GDPRToken: "test token"})
 	flag := recvMsg.Tags()[HeaderFlagsKey]
 	test.Assert(t, flag != nil)
-	test.Assert(t, flag == uint16(HeaderFlagSupportOutOfOrder))
+	test.Assert(t, flag == HeaderFlagSupportOutOfOrder)
 }
 
 func TestFillBasicInfoOfTTHeader(t *testing.T) {

--- a/pkg/remote/codec/header_codec_test.go
+++ b/pkg/remote/codec/header_codec_test.go
@@ -482,3 +482,23 @@ func (t ttHeader) encode2(ctx context.Context, message remote.Message, payloadBu
 	}
 	return err
 }
+
+func TestHeaderFlags(t *testing.T) {
+	// case 1: correct HeaderFlags
+	msg := initClientSendMsg(transport.TTHeader)
+	msg.Tags()[HeaderFlagsKey] = HeaderFlagSASL | HeaderFlagSupportOutOfOrder
+	hfs := getFlags(msg)
+	test.Assert(t, hfs == HeaderFlagSASL|HeaderFlagSupportOutOfOrder)
+
+	// case 2: invalid type for HeaderFlagsKey
+	msg = initClientSendMsg(transport.TTHeader)
+	msg.Tags()[HeaderFlagsKey] = 1
+	hfs = getFlags(msg)
+	test.Assert(t, hfs == 0)
+
+	// case 3: setFlags then get Flags
+	msg = initClientSendMsg(transport.TTHeader)
+	setFlags(uint16(HeaderFlagSupportOutOfOrder), msg)
+	hfs = getFlags(msg)
+	test.Assert(t, hfs == HeaderFlagSupportOutOfOrder, hfs)
+}


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
optimize(ttheader): ttheader 的 headerFlags 处理增加类型检查

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->