### PR TITLE
fix(code_gen): failed to generate code with slim template

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/file_tpl.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/file_tpl.go
@@ -69,7 +69,6 @@ var (
 
 const body = `
 {{define "body"}}
-
 {{- range .Scope.StructLikes}}
 {{template "StructLikeCodec" .}}
 {{- end}}

--- a/tool/internal_pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/patcher.go
@@ -111,12 +111,18 @@ func (p *patcher) buildTemplates() (err error) {
 	tpl := template.New("kitex").Funcs(m)
 	allTemplates := basicTemplates
 	if p.utils.Template() == "slim" {
-		allTemplates = append(allTemplates, slim.StructLike,
+		allTemplates = append(allTemplates,
+			// fix issue: #986
+			structLikeCodec,
+			processor,
+
+			slim.StructLike,
 			templates.StructLikeDefault,
 			templates.FieldGetOrSet,
 			templates.FieldIsSet)
 	} else {
-		allTemplates = append(allTemplates, structLikeCodec,
+		allTemplates = append(allTemplates,
+			structLikeCodec,
 			structLikeFastRead,
 			structLikeFastReadField,
 			structLikeDeepCopy,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

修复 slim template 下生成代码失败的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
The bug was imported by the deepcopyapi feature, in which the author moved `GenerateFastApi` flag from outside of `StructLikeCodec` template to inside. However, after this was done, `StructLikeCodec` template is not going to be defined in slim mode.
To solve this problem, I just added another flag, `GenerateCodec`, which indicates whether the codec part should be generated (i.e. `StructLikeCodec` template), and the value of this flag will be set to false if the generator was working in slim mode. It is a trivial and naive solution to this bug, but I see it necessary and appropriate because it decoupled the flag that controls codec generation and the flag that controls fast api generation.

zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #986

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->