### PR TITLE
fix: skip frugal on go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bytedance/gopkg v0.0.0-20230531144706-a12972768317
 	github.com/bytedance/mockey v1.2.0
 	github.com/bytedance/sonic v1.9.1
-	github.com/choleraehyq/pid v0.0.16
+	github.com/choleraehyq/pid v0.0.17
 	github.com/cloudwego/configmanager v0.2.0
 	github.com/cloudwego/dynamicgo v0.1.1
 	github.com/cloudwego/fastpb v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,9 @@ github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/choleraehyq/pid v0.0.13/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/choleraehyq/pid v0.0.15/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
-github.com/choleraehyq/pid v0.0.16 h1:1/714sMH9IBlE/aK6xM0acTagGKSzpiR0bDt7l0cG7o=
 github.com/choleraehyq/pid v0.0.16/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
+github.com/choleraehyq/pid v0.0.17 h1:BLBfHTllp2nRRbZ/cOFHKlx9oWJuMwKmp7GqB5d58Hk=
+github.com/choleraehyq/pid v0.0.17/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/pkg/remote/codec/thrift/thrift_frugal_amd64.go
+++ b/pkg/remote/codec/thrift/thrift_frugal_amd64.go
@@ -1,5 +1,5 @@
-//go:build amd64 && !windows && go1.16
-// +build amd64,!windows,go1.16
+//go:build amd64 && !windows && go1.16 && !go1.21
+// +build amd64,!windows,go1.16,!go1.21
 
 /*
  * Copyright 2021 CloudWeGo Authors

--- a/pkg/remote/codec/thrift/thrift_frugal_amd64_test.go
+++ b/pkg/remote/codec/thrift/thrift_frugal_amd64_test.go
@@ -1,5 +1,5 @@
-//go:build amd64 && !windows && go1.16
-// +build amd64,!windows,go1.16
+//go:build amd64 && !windows && go1.16 && !go1.21
+// +build amd64,!windows,go1.16,!go1.21
 
 /*
  * Copyright 2021 CloudWeGo Authors

--- a/pkg/remote/codec/thrift/thrift_others.go
+++ b/pkg/remote/codec/thrift/thrift_others.go
@@ -1,5 +1,5 @@
-//go:build !amd64 || windows || !go1.16
-// +build !amd64 windows !go1.16
+//go:build !amd64 || windows || !go1.16 || go1.21
+// +build !amd64 windows !go1.16 go1.21
 
 /*
  * Copyright 2021 CloudWeGo Authors


### PR DESCRIPTION
#### What type of PR is this?
fix: A bug fix

#### Check the PR title.
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [X] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: With go1.21rc2 released, we noticed that go replaced `runtime.gcWriteBarrier` with new APIs of different behavior. This is a quick fix to bypass frugal when compiling with go1.21; we'll update it once frugal is adapted to go1.21
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:


#### (optional) The PR that updates user documentation:
