### PR TITLE
optimize(lb): WRR reduces memory usage to minimum positive period

### DIFF
--- a/pkg/loadbalance/weighted_balancer_test.go
+++ b/pkg/loadbalance/weighted_balancer_test.go
@@ -275,6 +275,42 @@ func BenchmarkGetPicker(b *testing.B) {
 	}
 }
 
+func BenchmarkWeightedPicker_Next(b *testing.B) {
+	ctx := context.Background()
+
+	makeNInstances := func(n, base int, seq []int) (res []discovery.Instance) {
+		for i := 0; i < n; i++ {
+			weight := seq[i%len(seq)] * base
+			res = append(res, discovery.NewInstance("tcp", fmt.Sprintf("addr[%d]-weight[%d]", i, weight), weight, nil))
+		}
+		return
+	}
+
+	for _, tc := range balancerTestcases {
+		b.Run(tc.Name, func(b *testing.B) {
+			balancer := tc.factory()
+
+			n := 10
+			for i := 0; i < 4; i++ {
+				b.Run(fmt.Sprintf("%dins", n), func(b *testing.B) {
+					inss := makeNInstances(n, 1000, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+					e := discovery.Result{
+						Cacheable: true,
+						CacheKey:  "test",
+						Instances: inss,
+					}
+					picker := balancer.GetPicker(e)
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						picker.Next(ctx, nil)
+					}
+				})
+				n *= 10
+			}
+		})
+	}
+}
+
 func genInstList() []discovery.Instance {
 	n := 1000
 	insList := make([]discovery.Instance, 0, n)

--- a/pkg/loadbalance/weighted_round_robin.go
+++ b/pkg/loadbalance/weighted_round_robin.go
@@ -159,9 +159,7 @@ func (rp *RoundRobinPicker) Next(ctx context.Context, request interface{}) (ins 
 
 func gcdInt(a, b int) int {
 	for b != 0 {
-		r := a % b
-		a = b
-		b = r
+		a, b = b, a%b
 	}
 	return a
 }

--- a/pkg/loadbalance/weighted_round_robin_test.go
+++ b/pkg/loadbalance/weighted_round_robin_test.go
@@ -80,6 +80,10 @@ func TestWeightedRoundRobinPicker(t *testing.T) {
 	test.Assert(t, accessMap["addr1"] == round/6, accessMap)
 	test.Assert(t, accessMap["addr2"] == round/6*2, accessMap)
 	test.Assert(t, accessMap["addr3"] == round/6*3, accessMap)
+
+	wrrp := picker.(*WeightedRoundRobinPicker)
+	test.Assert(t, wrrp.vcapacity == 6)
+	test.Assert(t, len(wrrp.vnodes) == 6)
 }
 
 func TestWeightedRoundRobinPickerLargeInstances(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

WRR reduces memory usage to minimum positive period via GCD ([gh-1014](https://github.com/cloudwego/kitex/issues/1014))

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

加权轮询负载均衡算法使用GCD来将内存使用量减少到所有节点加权轮询一次的最小正周期

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: it's reduces the memory usage
zh(optional): 减少了内存开销

UT Result
```Console
go test github.com/cloudwego/kitex/pkg/loadbalance
ok      github.com/cloudwego/kitex/pkg/loadbalance      2.871s
```

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1014 

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->