### PR TITLE
feat(lb): interleaved weighted round-robin load balancer

### DIFF
--- a/pkg/loadbalance/interleaved_weighted_round_robin.go
+++ b/pkg/loadbalance/interleaved_weighted_round_robin.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package loadbalance
 
 import (

--- a/pkg/loadbalance/interleaved_weighted_round_robin.go
+++ b/pkg/loadbalance/interleaved_weighted_round_robin.go
@@ -1,0 +1,99 @@
+package loadbalance
+
+import (
+	"context"
+	"sync"
+
+	"github.com/bytedance/gopkg/lang/fastrand"
+
+	"github.com/cloudwego/kitex/pkg/discovery"
+)
+
+type iwrrNode struct {
+	discovery.Instance
+	remainder int
+
+	next *iwrrNode
+}
+
+type iwrrQueue struct {
+	head *iwrrNode
+	tail *iwrrNode
+}
+
+type InterleavedWeightedRoundRobinPicker struct {
+	current *iwrrQueue
+	next    *iwrrQueue
+
+	lock sync.Mutex
+}
+
+func newInterleavedWeightedRoundRobinPicker(instances []discovery.Instance) Picker {
+	iwrrp := new(InterleavedWeightedRoundRobinPicker)
+	iwrrp.current = newIwrrQueue()
+	iwrrp.next = newIwrrQueue()
+
+	size := uint64(len(instances))
+	offset := fastrand.Uint64n(size)
+	for idx := uint64(0); idx < size; idx++ {
+		ins := instances[(idx+offset)%size]
+
+		iwrrp.current.enqueue(&iwrrNode{
+			Instance:  ins,
+			remainder: ins.Weight(),
+		})
+	}
+
+	return iwrrp
+}
+
+func (ip *InterleavedWeightedRoundRobinPicker) Next(ctx context.Context, request interface{}) discovery.Instance {
+	ip.lock.Lock()
+	defer ip.lock.Unlock()
+
+	if ip.current.empty() {
+		ip.current, ip.next = ip.next, ip.current
+	}
+
+	node := ip.current.dequeue()
+	node.remainder--
+
+	if node.remainder > 0 {
+		ip.current.enqueue(node)
+	} else {
+		node.remainder = node.Instance.Weight()
+		ip.next.enqueue(node)
+	}
+
+	return node.Instance
+}
+
+func newIwrrQueue() *iwrrQueue {
+	return &iwrrQueue{}
+}
+
+func (q *iwrrQueue) enqueue(node *iwrrNode) {
+	node.next = nil
+	tail := q.tail
+	q.tail = node
+	if tail == nil {
+		q.head = node
+	} else {
+		tail.next = node
+	}
+}
+
+func (q *iwrrQueue) dequeue() *iwrrNode {
+	head := q.head
+	next := head.next
+	head.next = nil
+	q.head = next
+	if next == nil {
+		q.tail = nil
+	}
+	return head
+}
+
+func (q *iwrrQueue) empty() bool {
+	return q.head == nil
+}

--- a/pkg/loadbalance/weighted_balancer_test.go
+++ b/pkg/loadbalance/weighted_balancer_test.go
@@ -36,6 +36,7 @@ type balancerTestcase struct {
 var balancerTestcases = []*balancerTestcase{
 	{Name: "weight_round_robin", factory: NewWeightedRoundRobinBalancer},
 	{Name: "weight_random", factory: NewWeightedRandomBalancer},
+	{Name: "interleaved_weighted_round_robin", factory: NewInterleavedWeightedRoundRobinBalancer},
 }
 
 func TestWeightedBalancer_GetPicker(t *testing.T) {


### PR DESCRIPTION
An O(1) time and O(n) memory weighted load balancing implementation

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
交错式加权轮询负载均衡算法，时间复杂度O(1)，空间复杂度O(n)，相比于VNSWRR的O(sigma(W))更省空间且可控

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
https://en.wikipedia.org/wiki/Weighted_round_robin#Interleaved_WRR

与Linux O(1)调度器思路相同，维护两个队列，分别是当前队列和下一次队列。队列中的每个元素都维护remainder表示在当前队列中剩余可选中次数，初始时remainder与权重相同，每次被选中后都会减少remainder（使用GCD来缩短周期）。当remainder为0时表示当前周期内不可调度，将其放到下一次队列中。当当前队列为空时表示当前周期所有元素都被按权重选择过了，此时对换当前队列和下一次队列开始新一轮周期。由于始终复用链表节点，因此该负载均衡算法实现在初始化后可以保证是零分配的。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->