### PR TITLE
optimize: add nil check for MethodInfo which get from ServiceInfo in client.Call to ignore panic

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -448,7 +448,9 @@ func (kc *kClient) invokeHandleEndpoint() (endpoint.Endpoint, error) {
 		defer cli.Recycle()
 		config := ri.Config()
 		m := kc.svcInfo.MethodInfo(methodName)
-		if m.OneWay() {
+		if m == nil {
+			return fmt.Errorf("method info is nil, methodName=%s, serviceInfo=%+v", methodName, kc.svcInfo)
+		} else if m.OneWay() {
 			sendMsg = remote.NewMessage(req, kc.svcInfo, ri, remote.Oneway, remote.Client)
 		} else {
 			sendMsg = remote.NewMessage(req, kc.svcInfo, ri, remote.Call, remote.Client)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -936,6 +936,16 @@ func TestPanicInMiddleware(t *testing.T) {
 	test.Assert(t, reportPanic, err)
 }
 
+func TestMethodInfoIsNil(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	cli := newMockClient(t, ctrl)
+	req, res := new(MockTStruct), new(MockTStruct)
+	err := cli.Call(context.Background(), "notExist", req, res)
+	test.Assert(t, err != nil)
+	test.Assert(t, strings.Contains(err.Error(), "method info is nil"))
+}
+
 func mb(byteSize uint64) float32 {
 	return float32(byteSize) / float32(1024*1024)
 }


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
optimize: 在 client.Call 对 MethodInfo 增加 nil 检查，避免 panic

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:  Normally, there will be no panic, but there are abnormal situations. Adding nil-check is convenient for troubleshooting
zh(optional): 正常不会出现 panic，但存在异常情况，增加 nil 检查便于问题排查

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->