### PR TITLE
fix(generic): avoid dead-loop when marshal self-referenced struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bytedance/sonic v1.9.1
 	github.com/choleraehyq/pid v0.0.16
 	github.com/cloudwego/configmanager v0.2.0
-	github.com/cloudwego/dynamicgo v0.1.1
+	github.com/cloudwego/dynamicgo v0.1.2
 	github.com/cloudwego/fastpb v0.0.4
 	github.com/cloudwego/frugal v0.1.7
 	github.com/cloudwego/netpoll v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudwego/configmanager v0.2.0 h1:niVpVg+wQ+npNqnH3dup96SMbR02Pk+tNErubYCJqKo=
 github.com/cloudwego/configmanager v0.2.0/go.mod h1:FLIQTjxsZRGjnmDhTttWQTy6f6DghPTatfBVOs2gQLk=
 github.com/cloudwego/dynamicgo v0.1.0/go.mod h1:Mdsz0XGsIImi15vxhZaHZpspNChEmBMIiWkUfD6JDKg=
-github.com/cloudwego/dynamicgo v0.1.1 h1:11wE8lcObMfTTFhDNiTfQiSRk/8cJUuFsh/Nl9uLQe0=
-github.com/cloudwego/dynamicgo v0.1.1/go.mod h1:doLt+7OzJ4+4HiDD0Wj6StmTdXBviFH+6Z8xsjh1c9w=
+github.com/cloudwego/dynamicgo v0.1.2 h1:t5KMzo/UkT002n3EvGI0Y6+Me73NGDzFI/AQlT1LQME=
+github.com/cloudwego/dynamicgo v0.1.2/go.mod h1:AdPqyFN+0+fc3iVSSWojDCnOGPkzH+T0rI65017GCUA=
 github.com/cloudwego/fastpb v0.0.3/go.mod h1:/V13XFTq2TUkxj2qWReV8MwfPC4NnPcy6FsrojnsSG0=
 github.com/cloudwego/fastpb v0.0.4 h1:/ROVVfoFtpfc+1pkQLzGs+azjxUbSOsAqSY4tAAx4mg=
 github.com/cloudwego/fastpb v0.0.4/go.mod h1:/V13XFTq2TUkxj2qWReV8MwfPC4NnPcy6FsrojnsSG0=
@@ -74,6 +74,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=

--- a/pkg/generic/json_test/idl/self_ref.thrift
+++ b/pkg/generic/json_test/idl/self_ref.thrift
@@ -4,3 +4,7 @@ struct A {
     1: A self
     2: string extra
 }
+
+service Mock {
+    string Test(1:A req)
+}

--- a/pkg/generic/map_test/idl/self_ref.thrift
+++ b/pkg/generic/map_test/idl/self_ref.thrift
@@ -4,3 +4,7 @@ struct A {
     1: A self
     2: string extra
 }
+
+service Mock {
+    string Test(1:A req)
+}

--- a/pkg/generic/mapthrift_codec_test.go
+++ b/pkg/generic/mapthrift_codec_test.go
@@ -18,6 +18,7 @@ package generic
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/mocks"
@@ -56,6 +57,42 @@ func TestMapThriftCodec(t *testing.T) {
 	in := remote.NewReaderBuffer(buf)
 	err = mtc.Unmarshal(ctx, recvMsg, in)
 	test.Assert(t, err == nil)
+}
+
+func TestMapThriftCodecSelfRef(t *testing.T) {
+	p, err := NewThriftFileProvider("./map_test/idl/self_ref.thrift")
+	test.Assert(t, err == nil)
+	mtc, err := newMapThriftCodec(p, thriftCodec)
+	test.Assert(t, err == nil)
+	defer mtc.Close()
+	test.Assert(t, mtc.Name() == "MapThrift")
+
+	method, err := mtc.getMethod(nil, "Test")
+	test.Assert(t, err == nil)
+	test.Assert(t, method.Name == "Test")
+
+	ctx := context.Background()
+	sendMsg := initNilMapSendMsg(transport.TTHeader)
+
+	// Marshal side
+	out := remote.NewWriterBuffer(0)
+	err = mtc.Marshal(ctx, sendMsg, out)
+	test.Assert(t, err == nil)
+
+	// UnMarshal side
+	recvMsg := initMapRecvMsg()
+	buf, err := out.Bytes()
+	test.Assert(t, err == nil)
+	recvMsg.SetPayloadLen(len(buf))
+	in := remote.NewReaderBuffer(buf)
+	err = mtc.Unmarshal(ctx, recvMsg, in)
+	test.Assert(t, err == nil)
+	exp := map[string]interface{}{
+		"self":  map[string]interface{}{},
+		"extra": "",
+	}
+	act := recvMsg.Data().(*Args).Request
+	test.Assert(t, reflect.DeepEqual(exp, act))
 }
 
 func TestMapThriftCodecForJSON(t *testing.T) {
@@ -126,6 +163,23 @@ func initMapSendMsg(tp transport.Protocol) remote.Message {
 				"strMap": map[string]interface{}{
 					"Test1": "Test2",
 				},
+			},
+		},
+		Method: "Test",
+	}
+	svcInfo := mocks.ServiceInfo()
+	ink := rpcinfo.NewInvocation("", "Test")
+	ri := rpcinfo.NewRPCInfo(nil, nil, ink, nil, rpcinfo.NewRPCStats())
+	msg := remote.NewMessage(req, svcInfo, ri, remote.Call, remote.Client)
+	msg.SetProtocolInfo(remote.NewProtocolInfo(tp, svcInfo.PayloadCodec))
+	return msg
+}
+
+func initNilMapSendMsg(tp transport.Protocol) remote.Message {
+	req := &Args{
+		Request: &descriptor.HTTPRequest{
+			Body: map[string]interface{}{
+				"self": nil,
 			},
 		},
 		Method: "Test",

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -721,14 +721,13 @@ func writeStruct(ctx context.Context, val interface{}, out thrift.TProtocol, t *
 				if err != nil {
 					return err
 				}
-				
 			}
 			elem, err = field.ValueMapping.Request(ctx, elem, field)
 			if err != nil {
 				return err
 			}
 		}
-		
+
 		if elem == nil {
 			if !field.Optional {
 				if err := out.WriteFieldBegin(field.Name, field.Type.Type.ToThriftTType(), int16(field.ID)); err != nil {
@@ -753,7 +752,7 @@ func writeStruct(ctx context.Context, val interface{}, out thrift.TProtocol, t *
 				return fmt.Errorf("writer of field[%s] error %w", name, err)
 			}
 		}
-		
+
 		if err := out.WriteFieldEnd(); err != nil {
 			return err
 		}
@@ -786,7 +785,7 @@ func writeHTTPRequest(ctx context.Context, val interface{}, out thrift.TProtocol
 			}
 			continue
 		}
-		
+
 		if field.ValueMapping != nil {
 			if v == nil {
 				v, err = getEmptyValue(field.Type, opt)
@@ -806,7 +805,7 @@ func writeHTTPRequest(ctx context.Context, val interface{}, out thrift.TProtocol
 				}
 				if err := writeEmptyValue(out, field.Type, opt); err != nil {
 					return fmt.Errorf("field (%d/%s) error: %w", field.ID, name, err)
-				} 
+				}
 				// goto WriteFieldEnd()
 			} else {
 				continue

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -576,8 +576,8 @@ func writeStringMap(ctx context.Context, val interface{}, out thrift.TProtocol, 
 	}
 
 	var (
-		keyWriter         writer
-		elemWriter        writer
+		keyWriter  writer
+		elemWriter writer
 	)
 	for key, elem := range m {
 		_key, err := buildinTypeFromString(key, t.Key)

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -683,13 +683,6 @@ func writeStruct(ctx context.Context, val interface{}, out thrift.TProtocol, t *
 			continue
 		}
 
-		if field.ValueMapping != nil {
-			elem, err = field.ValueMapping.Request(ctx, elem, field)
-			if err != nil {
-				return err
-			}
-		}
-
 		// empty fields
 		if elem == nil || !ok {
 			if !field.Optional {

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -804,7 +804,6 @@ func writeHTTPRequest(ctx context.Context, val interface{}, out thrift.TProtocol
 				if err := out.WriteFieldBegin(field.Name, field.Type.Type.ToThriftTType(), int16(field.ID)); err != nil {
 					return err
 				}
-				
 				if err := writeEmptyValue(out, field.Type, opt); err != nil {
 					return fmt.Errorf("field (%d/%s) error: %w", field.ID, name, err)
 				} 
@@ -813,6 +812,9 @@ func writeHTTPRequest(ctx context.Context, val interface{}, out thrift.TProtocol
 				continue
 			}
 		} else {
+			if err := out.WriteFieldBegin(field.Name, field.Type.Type.ToThriftTType(), int16(field.ID)); err != nil {
+				return err
+			}
 			writer, err := nextWriter(v, field.Type, opt)
 			if err != nil {
 				return fmt.Errorf("nextWriter of field[%s] error %w", name, err)

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -534,9 +534,9 @@ func writeInterfaceMap(ctx context.Context, val interface{}, out thrift.TProtoco
 		return out.WriteMapEnd()
 	}
 	var (
-		keyWriter         writer
-		elemWriter        writer
-		err               error
+		keyWriter  writer
+		elemWriter writer
+		err        error
 	)
 	for key, elem := range m {
 		if keyWriter == nil {

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -27,13 +27,12 @@ import (
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/jhump/protoreflect/desc/protoparse"
-	"github.com/tidwall/gjson"
-
 	"github.com/cloudwego/kitex/internal/mocks"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/generic/descriptor"
 	"github.com/cloudwego/kitex/pkg/generic/proto"
+	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/tidwall/gjson"
 )
 
 func Test_writeVoid(t *testing.T) {

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -26,11 +26,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/cloudwego/kitex/internal/mocks"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/generic/descriptor"
 	"github.com/cloudwego/kitex/pkg/generic/proto"
+
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jhump/protoreflect/desc/protoparse"
 	"github.com/tidwall/gjson"
 )

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -26,14 +26,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/tidwall/gjson"
+
 	"github.com/cloudwego/kitex/internal/mocks"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/generic/descriptor"
 	"github.com/cloudwego/kitex/pkg/generic/proto"
-
-	"github.com/apache/thrift/lib/go/thrift"
-	"github.com/jhump/protoreflect/desc/protoparse"
-	"github.com/tidwall/gjson"
 )
 
 func Test_writeVoid(t *testing.T) {

--- a/pkg/generic/thriftidl_provider_test.go
+++ b/pkg/generic/thriftidl_provider_test.go
@@ -209,11 +209,11 @@ func TestFallback(t *testing.T) {
 	defer p.Close()
 	pd, ok := p.(GetProviderOption)
 	test.Assert(t, ok)
-	test.Assert(t, !pd.Option().DynamicGoEnabled)
+	test.Assert(t, pd.Option().DynamicGoEnabled)
 	tree := <-p.Provide()
 	test.Assert(t, tree != nil)
 	test.Assert(t, tree.Functions["BinaryEcho"].Request.Struct.FieldsByName["req"].Type.Struct.FieldsByID[int32(1)].Alias == "STR")
-	test.Assert(t, tree.DynamicGoDsc == nil)
+	test.Assert(t, tree.DynamicGoDsc != nil)
 }
 
 func TestDisableGoTagForDynamicGo(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
（泛化调用）避免自引用类型的空结构体序列化时候的死循环

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:  only write `FieldStop` for empty struct, which is allowed for Thrift specification and consistent with thriftgo's codegen
zh(optional): 根据 thrift 规范和 thriftgo 生成代码行为，对于空结构体仅写入`FieldStop` 值 
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->