### PR TITLE
fix: ignore SIGHUP when run with nohup

### DIFF
--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -155,7 +155,11 @@ func DefaultSysExitSignal() <-chan error {
 
 func SysExitSignal() chan os.Signal {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+	notifications := []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+	if !signal.Ignored(syscall.SIGHUP) {
+		notifications = append(notifications, syscall.SIGHUP)
+	}
+	signal.Notify(signals, notifications...)
 	return signals
 }
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: https://stackoverflow.com/questions/64479821/why-hangup-signal-is-caught-even-with-nohup
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/cloudwego/kitex/issues/1050

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->