### PR TITLE
fix: unmarshal return non-nil response when buf is nil

### DIFF
--- a/pkg/remote/codec/protobuf/pberror.go
+++ b/pkg/remote/codec/protobuf/pberror.go
@@ -52,9 +52,6 @@ func (p *pbError) Marshal(out []byte) ([]byte, error) {
 }
 
 func (p *pbError) Unmarshal(in []byte) error {
-	if len(in) == 0 {
-		return nil
-	}
 	err := new(ErrorProto)
 	if err := proto.Unmarshal(in, err); err != nil {
 		return err

--- a/pkg/remote/codec/protobuf/protobuf_test.go
+++ b/pkg/remote/codec/protobuf/protobuf_test.go
@@ -209,9 +209,6 @@ func (p *MockReqArgs) Marshal(out []byte) ([]byte, error) {
 }
 
 func (p *MockReqArgs) Unmarshal(in []byte) error {
-	if len(in) == 0 {
-		return nil
-	}
 	msg := new(MockReq)
 	if err := proto.Unmarshal(in, msg); err != nil {
 		return err

--- a/tool/internal_pkg/tpl/service.go
+++ b/tool/internal_pkg/tpl/service.go
@@ -252,9 +252,6 @@ func (p *{{.ArgStructName}}) Marshal(out []byte) ([]byte, error) {
 }
 
 func (p *{{.ArgStructName}}) Unmarshal(in []byte) error {
-	if len(in) == 0 {
-		return nil
-	}
 	msg := new({{NotPtr $arg.Type}})
 	if err := proto.Unmarshal(in, msg); err != nil {
 	   return err
@@ -317,9 +314,6 @@ func (p *{{.ResStructName}}) Marshal(out []byte) ([]byte, error) {
 }
 
 func (p *{{.ResStructName}}) Unmarshal(in []byte) error {
-	if len(in) == 0 {
-		return nil
-	}
 	msg := new({{NotPtr .Resp.Type}})
 	if err := proto.Unmarshal(in, msg); err != nil {
 	   return err


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: buf为nil的时候Unmarshal返回非空response

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/cloudwego/kitex/issues/1085

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->