### PR TITLE
Revert "fix(gRPC): client send END_STREAM flag in unary call"

### DIFF
--- a/pkg/remote/trans/nphttp2/client_conn.go
+++ b/pkg/remote/trans/nphttp2/client_conn.go
@@ -33,14 +33,9 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
 
-type streamDesc struct {
-	isStreaming bool
-}
-
 type clientConn struct {
-	tr   grpc.ClientTransport
-	s    *grpc.Stream
-	desc *streamDesc
+	tr grpc.ClientTransport
+	s  *grpc.Stream
 }
 
 var _ GRPCConn = (*clientConn)(nil)
@@ -68,6 +63,7 @@ func newClientConn(ctx context.Context, tr grpc.ClientTransport, addr string) (*
 	} else {
 		svcName = fmt.Sprintf("%s.%s", ri.Invocation().PackageName(), ri.Invocation().ServiceName())
 	}
+
 	host := ri.To().ServiceName()
 	if rawURL, ok := ri.To().Tag(rpcinfo.HTTPURL); ok {
 		u, err := url.Parse(rawURL)
@@ -76,7 +72,7 @@ func newClientConn(ctx context.Context, tr grpc.ClientTransport, addr string) (*
 		}
 		host = u.Host
 	}
-	isStreaming := ri.Config().InteractionMode() == rpcinfo.Streaming
+
 	s, err := tr.NewStream(ctx, &grpc.CallHdr{
 		Host: host,
 		// grpc method format /package.Service/Method
@@ -87,9 +83,8 @@ func newClientConn(ctx context.Context, tr grpc.ClientTransport, addr string) (*
 		return nil, err
 	}
 	return &clientConn{
-		tr:   tr,
-		s:    s,
-		desc: &streamDesc{isStreaming: isStreaming},
+		tr: tr,
+		s:  s,
 	}, nil
 }
 
@@ -116,7 +111,11 @@ func (c *clientConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *clientConn) WriteFrame(hdr, data []byte) (n int, err error) {
-	grpcConnOpt := &grpc.Options{Last: !c.desc.isStreaming}
+	grpcConnOpt := &grpc.Options{}
+	// When there's no more data frame, add END_STREAM flag to this empty frame.
+	if hdr == nil && data == nil {
+		grpcConnOpt.Last = true
+	}
 	err = c.tr.Write(c.s, hdr, data, grpcConnOpt)
 	return len(hdr) + len(data), err
 }

--- a/pkg/remote/trans/nphttp2/client_conn_test.go
+++ b/pkg/remote/trans/nphttp2/client_conn_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
-	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
 
 func TestClientConn(t *testing.T) {
@@ -59,29 +58,4 @@ func TestClientConn(t *testing.T) {
 	n, err = clientConn.Write([]byte(""))
 	test.Assert(t, err != nil, err)
 	test.Assert(t, n == 0)
-}
-
-func TestClientConnStreamDesc(t *testing.T) {
-	connPool := newMockConnPool()
-
-	// streaming
-	ctx := newMockCtxWithRPCInfo()
-	ri := rpcinfo.GetRPCInfo(ctx)
-	test.Assert(t, ri != nil)
-	rpcinfo.AsMutableRPCConfig(ri.Config()).SetInteractionMode(rpcinfo.Streaming)
-	conn, err := connPool.Get(ctx, "tcp", mockAddr0, newMockConnOption())
-	test.Assert(t, err == nil, err)
-	defer conn.Close()
-	cn := conn.(*clientConn)
-	test.Assert(t, cn != nil)
-	test.Assert(t, cn.desc.isStreaming == true)
-
-	// pingpong
-	rpcinfo.AsMutableRPCConfig(ri.Config()).SetInteractionMode(rpcinfo.PingPong)
-	conn, err = connPool.Get(ctx, "tcp", mockAddr0, newMockConnOption())
-	test.Assert(t, err == nil, err)
-	defer conn.Close()
-	cn = conn.(*clientConn)
-	test.Assert(t, cn != nil)
-	test.Assert(t, cn.desc.isStreaming == false)
 }

--- a/pkg/remote/trans/nphttp2/server_conn.go
+++ b/pkg/remote/trans/nphttp2/server_conn.go
@@ -85,8 +85,12 @@ func (c *serverConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *serverConn) WriteFrame(hdr, data []byte) (n int, err error) {
-	// server sets the END_STREAM flag in trailer when writeStatus
-	err = c.tr.Write(c.s, hdr, data, &grpc.Options{})
+	grpcConnOpt := &grpc.Options{}
+	// When there's no more data frame, add END_STREAM flag to this empty frame.
+	if hdr == nil && data == nil {
+		grpcConnOpt.Last = true
+	}
+	err = c.tr.Write(c.s, hdr, data, grpcConnOpt)
 	return len(hdr) + len(data), err
 }
 


### PR DESCRIPTION
Reverts cloudwego/kitex#1066 because of potential issue in stability test