### PR TITLE
fix: reset all fields of netpoll byte buffer when recycle it

### DIFF
--- a/pkg/remote/trans/netpoll/bytebuf.go
+++ b/pkg/remote/trans/netpoll/bytebuf.go
@@ -255,8 +255,10 @@ func (b *netpollByteBuffer) Release(e error) (err error) {
 }
 
 func (b *netpollByteBuffer) zero() {
-	b.status = 0
 	b.writer = nil
 	b.reader = nil
+	b.ioReader = nil
+	b.ioWriter = nil
+	b.status = 0
 	b.readSize = 0
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: 在回收netpoll byte buffer时重置其所有字段

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->