### PR TITLE
optimize(connpool): set maxIdleGlobal to no limit if not set

### DIFF
--- a/client/option_test.go
+++ b/client/option_test.go
@@ -650,7 +650,7 @@ func TestWithLongConnectionOption(t *testing.T) {
 	opts := client.NewOptions(options)
 	test.Assert(t, opts.PoolCfg.MaxIdleTimeout == 30*time.Second) // defaultMaxIdleTimeout
 	test.Assert(t, opts.PoolCfg.MaxIdlePerAddress == 1)           // default
-	test.Assert(t, opts.PoolCfg.MaxIdleGlobal == 1)               // default
+	test.Assert(t, opts.PoolCfg.MaxIdleGlobal == 1<<20)           // default
 }
 
 func TestWithWarmingUpOption(t *testing.T) {

--- a/pkg/connpool/config.go
+++ b/pkg/connpool/config.go
@@ -30,6 +30,7 @@ const (
 	defaultMaxIdleTimeout = 30 * time.Second
 	minMaxIdleTimeout     = 2 * time.Second
 	maxMinIdlePerAddress  = 5
+	defaultMaxIdleGlobal  = 1 << 20 // no limit
 )
 
 // CheckPoolConfig to check invalid param.
@@ -58,9 +59,8 @@ func CheckPoolConfig(config IdleConfig) *IdleConfig {
 
 	// globalIdle
 	if config.MaxIdleGlobal <= 0 {
-		config.MaxIdleGlobal = 1
-	}
-	if config.MaxIdleGlobal < config.MaxIdlePerAddress {
+		config.MaxIdleGlobal = defaultMaxIdleGlobal
+	} else if config.MaxIdleGlobal < config.MaxIdlePerAddress {
 		config.MaxIdleGlobal = config.MaxIdlePerAddress
 	}
 	return &config

--- a/pkg/connpool/config_test.go
+++ b/pkg/connpool/config_test.go
@@ -33,7 +33,7 @@ func TestCheckPoolConfig(t *testing.T) {
 	cfg = CheckPoolConfig(IdleConfig{MinIdlePerAddress: -1})
 	test.Assert(t, cfg.MinIdlePerAddress == 0)
 	test.Assert(t, cfg.MaxIdlePerAddress == 1)
-	test.Assert(t, cfg.MaxIdleGlobal == 1)
+	test.Assert(t, cfg.MaxIdleGlobal == defaultMaxIdleGlobal)
 	cfg = CheckPoolConfig(IdleConfig{MinIdlePerAddress: 1})
 	test.Assert(t, cfg.MinIdlePerAddress == 1)
 	cfg = CheckPoolConfig(IdleConfig{MinIdlePerAddress: maxMinIdlePerAddress + 1})


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
zh: optimize(connpool): 如果没有单独配置 maxIdleGlobal，则不做限制。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->