### PR TITLE
feat(retry): support retry percentage limit

### DIFF
--- a/pkg/retry/failure_retryer.go
+++ b/pkg/retry/failure_retryer.go
@@ -84,7 +84,7 @@ func (r *failureRetryer) AllowRetry(ctx context.Context) (string, bool) {
 }
 
 // Do implement the Retryer interface.
-func (r *failureRetryer) Do(ctx context.Context, rpcCall RPCCallFunc, firstRI rpcinfo.RPCInfo, req interface{}) (recycleRI bool, err error) {
+func (r *failureRetryer) Do(ctx context.Context, rpcCall RPCCallFunc, firstRI rpcinfo.RPCInfo, req interface{}, container *Container) (recycleRI bool, err error) {
 	r.RLock()
 	var maxDuration time.Duration
 	if r.policy.StopPolicy.MaxDurationMS > 0 {
@@ -127,10 +127,14 @@ func (r *failureRetryer) Do(ctx context.Context, rpcCall RPCCallFunc, firstRI rp
 			}
 		}
 		callTimes++
+		if container.enablePercentageLimit {
+			// record stat before call since requests may be slow, making the limiter more accurate
+			recordRetryStat(cbKey, r.cbContainer.cbPanel, callTimes)
+		}
 		cRI, resp, err = rpcCall(ctx, r)
 		callCosts.WriteString(strconv.FormatInt(time.Since(callStart).Microseconds(), 10))
 
-		if r.cbContainer.cbStat {
+		if !container.enablePercentageLimit && r.cbContainer.cbStat {
 			circuitbreak.RecordStat(ctx, req, nil, err, cbKey, r.cbContainer.cbCtl, r.cbContainer.cbPanel)
 		}
 		if err == nil {

--- a/pkg/retry/percentage_limit.go
+++ b/pkg/retry/percentage_limit.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package retry
+
+import (
+	"github.com/bytedance/gopkg/cloud/circuitbreaker"
+)
+
+// treat retry as 'error' for limiting the percentage of retry requests.
+// callTimes == 1 means it's the first request, not a retry.
+func recordRetryStat(cbKey string, panel circuitbreaker.Panel, callTimes int32) {
+	if callTimes > 1 {
+		panel.Fail(cbKey)
+	} else {
+		panel.Succeed(cbKey)
+	}
+}

--- a/pkg/retry/retryer_test.go
+++ b/pkg/retry/retryer_test.go
@@ -822,3 +822,68 @@ func (r *mockResult) SetResult(ret mockResp) {
 	defer r.Unlock()
 	r.result = ret
 }
+
+func TestNewRetryContainerWithOptions(t *testing.T) {
+	t.Run("no_option", func(t *testing.T) {
+		rc := NewRetryContainer()
+		test.Assertf(t, rc.cbContainer.cbSuite != nil, "cb_suite nil")
+		test.Assertf(t, rc.cbContainer.cbStat == true, "cb_stat not true")
+	})
+
+	t.Run("percentage_limit", func(t *testing.T) {
+		rc := NewRetryContainer(WithContainerEnablePercentageLimit())
+		test.Assertf(t, rc.enablePercentageLimit == true, "percentage_limit not true")
+	})
+
+	t.Run("percentage_limit&&cbOptions", func(t *testing.T) {
+		cbSuite := newCBSuite()
+		rc := NewRetryContainer(
+			WithContainerEnablePercentageLimit(),
+			WithContainerCBSuite(cbSuite),
+			WithContainerCBControl(cbSuite.ServiceControl()),
+			WithContainerCBPanel(cbSuite.ServicePanel()),
+		)
+		test.Assertf(t, rc.enablePercentageLimit == true, "percentage_limit not true")
+		test.Assertf(t, rc.cbContainer.cbSuite != cbSuite, "cbSuite not ignored")
+		test.Assertf(t, rc.cbContainer.cbCtl != cbSuite.ServiceControl(), "cbCtl not ignored")
+		test.Assertf(t, rc.cbContainer.cbPanel != cbSuite.ServicePanel(), "cbPanel not ignored")
+	})
+
+	t.Run("cb_stat", func(t *testing.T) {
+		rc := NewRetryContainer(WithContainerCBStat())
+		test.Assertf(t, rc.cbContainer.cbStat == true, "cb_stat not true")
+	})
+
+	t.Run("cb_suite", func(t *testing.T) {
+		cbs := newCBSuite()
+		rc := NewRetryContainer(WithContainerCBSuite(cbs))
+		test.Assert(t, rc.cbContainer.cbSuite == cbs, "cbSuite expected %p, got %p", cbs, rc.cbContainer.cbSuite)
+	})
+
+	t.Run("cb_control&cb_panel", func(t *testing.T) {
+		cbs := newCBSuite()
+		rc := NewRetryContainer(
+			WithContainerCBControl(cbs.ServiceControl()),
+			WithContainerCBPanel(cbs.ServicePanel()))
+		test.Assert(t, rc.cbContainer.cbCtl == cbs.ServiceControl(), "cbControl not match")
+		test.Assert(t, rc.cbContainer.cbPanel == cbs.ServicePanel(), "cbPanel not match")
+	})
+}
+
+func TestNewRetryContainerWithCBStat(t *testing.T) {
+	cbs := newCBSuite()
+	rc := NewRetryContainerWithCBStat(cbs.ServiceControl(), cbs.ServicePanel())
+	test.Assert(t, rc.cbContainer.cbCtl == cbs.ServiceControl(), "cbControl not match")
+	test.Assert(t, rc.cbContainer.cbPanel == cbs.ServicePanel(), "cbPanel not match")
+	test.Assertf(t, rc.cbContainer.cbStat == true, "cb_stat not true")
+	rc.Close()
+}
+
+func TestNewRetryContainerWithCB(t *testing.T) {
+	cbs := newCBSuite()
+	rc := NewRetryContainerWithCB(cbs.ServiceControl(), cbs.ServicePanel())
+	test.Assert(t, rc.cbContainer.cbCtl == cbs.ServiceControl(), "cbControl not match")
+	test.Assert(t, rc.cbContainer.cbPanel == cbs.ServicePanel(), "cbPanel not match")
+	test.Assertf(t, rc.cbContainer.cbStat == false, "cb_stat not false")
+	rc.Close()
+}

--- a/pkg/retry/util.go
+++ b/pkg/retry/util.go
@@ -55,6 +55,8 @@ const (
 	OpDone
 )
 
+var tagValueFirstTry = "0"
+
 // DDLStopFunc is the definition of ddlStop func
 type DDLStopFunc func(ctx context.Context, policy StopPolicy) (bool, string)
 
@@ -83,7 +85,7 @@ func chainStop(ctx context.Context, policy StopPolicy) (bool, string) {
 	if policy.DisableChainStop {
 		return false, ""
 	}
-	if _, exist := metainfo.GetPersistentValue(ctx, TransitKey); !exist {
+	if !IsRemoteRetryRequest(ctx) {
 		return false, ""
 	}
 	return true, "chain stop retry"
@@ -169,4 +171,19 @@ func recordRetryInfo(firstRI, lastRI rpcinfo.RPCInfo, callTimes int32, lastCosts
 			firstRe.SetTag(rpcinfo.RetryLastCostTag, lastCosts)
 		}
 	}
+}
+
+// IsLocalRetryRequest checks whether it's a retry request by checking the RetryTag set in rpcinfo
+// It's supposed to be used in client middlewares
+func IsLocalRetryRequest(ctx context.Context) bool {
+	ri := rpcinfo.GetRPCInfo(ctx)
+	retryCountStr := ri.To().DefaultTag(rpcinfo.RetryTag, tagValueFirstTry)
+	return retryCountStr != tagValueFirstTry
+}
+
+// IsRemoteRetryRequest checks whether it's a retry request by checking the TransitKey in metainfo
+// It's supposed to be used in server side (handler/middleware)
+func IsRemoteRetryRequest(ctx context.Context) bool {
+	_, isRetry := metainfo.GetPersistentValue(ctx, TransitKey)
+	return isRetry
 }

--- a/pkg/retry/util_test.go
+++ b/pkg/retry/util_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package retry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/gopkg/cloud/metainfo"
+
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+)
+
+func mockRPCInfo(retryTag string) rpcinfo.RPCInfo {
+	var tags map[string]string
+	if retryTag != "" {
+		tags = map[string]string{
+			rpcinfo.RetryTag: retryTag,
+		}
+	}
+	to := rpcinfo.NewEndpointInfo("service", "method", nil, tags)
+	return rpcinfo.NewRPCInfo(nil, to, nil, nil, nil)
+}
+
+func mockContext(retryTag string) context.Context {
+	return rpcinfo.NewCtxWithRPCInfo(context.TODO(), mockRPCInfo(retryTag))
+}
+
+func TestIsLocalRetryRequest(t *testing.T) {
+	t.Run("no-retry-tag", func(t *testing.T) {
+		test.Assertf(t, !IsLocalRetryRequest(mockContext("")), "no-retry-tag")
+	})
+	t.Run("retry-tag=0", func(t *testing.T) {
+		test.Assertf(t, !IsLocalRetryRequest(mockContext("0")), "retry-tag=0")
+	})
+	t.Run("retry-tag=1", func(t *testing.T) {
+		test.Assertf(t, IsLocalRetryRequest(mockContext("1")), "retry-tag=1")
+	})
+}
+
+func TestIsRemoteRetryRequest(t *testing.T) {
+	t.Run("no-retry", func(t *testing.T) {
+		test.Assertf(t, !IsRemoteRetryRequest(context.Background()), "should be not retry")
+	})
+	t.Run("retry", func(t *testing.T) {
+		ctx := metainfo.WithPersistentValue(context.Background(), TransitKey, "2")
+		test.Assertf(t, IsRemoteRetryRequest(ctx), "should be retry")
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat: A new feature


#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: to limit the percentage of retry requests among all requests. It's useful especially in backup request, because a request taking longer than backup threshold will trigger a backup retry request. But if it takes shorter than the rpc timeout threshold, it will be finally succesful and not be treated as failed, which may cause lots of retry requests in case of temporary bad network conditions, imposing high pressure for the server or even cause avalanche.
zh(optional): 限制重试请求的占比。尤其在备用请求的场景比较有用：如果某个请求超过备用请求阈值，会触发一个备用请求，但如果该请求在RPC超时阈值之内，最终可以正常处理，因而不会被当做失败请求，这会在偶发网络异常时导致大量重试请求，增加服务端压力甚至引起雪崩。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->