### PR TITLE
perf: replace concurrent string builder with lock

### DIFF
--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -34,63 +34,71 @@ type StringBuilder struct {
 	sb strings.Builder
 }
 
-func (b *StringBuilder) String() (s string) {
+// WithLocked encapsulates a concurrent-safe interface for batch operations on strings.Builder.
+// Please note that you should avoid calling member functions of StringBuilder within the input
+// function, as it may lead to program deadlock.
+func (b *StringBuilder) WithLocked(f func(sb *strings.Builder) error) error {
 	b.Lock()
-	s = b.sb.String()
-	b.Unlock()
-	return
+	defer b.Unlock()
+	return f(&b.sb)
 }
 
-func (b *StringBuilder) Len() (l int) {
-	b.Lock()
-	l = b.sb.Len()
-	b.Unlock()
-	return
+// RawStringBuilder returns the inner strings.Builder of StringBuilder. It allows users to perform
+// lock-free operations in scenarios without concurrency issues, thereby improving performance.
+func (b *StringBuilder) RawStringBuilder() *strings.Builder {
+	return &b.sb
 }
 
-func (b *StringBuilder) Cap() (l int) {
+func (b *StringBuilder) String() string {
 	b.Lock()
-	l = b.sb.Cap()
-	b.Unlock()
-	return
+	defer b.Unlock()
+	return b.sb.String()
+}
+
+func (b *StringBuilder) Len() int {
+	b.Lock()
+	defer b.Unlock()
+	return b.sb.Len()
+}
+
+func (b *StringBuilder) Cap() int {
+	b.Lock()
+	defer b.Unlock()
+	return b.sb.Cap()
 }
 
 func (b *StringBuilder) Reset() {
 	b.Lock()
+	defer b.Unlock()
 	b.sb.Reset()
-	b.Unlock()
 }
 
 func (b *StringBuilder) Grow(n int) {
 	b.Lock()
+	defer b.Unlock()
 	b.sb.Grow(n)
-	b.Unlock()
 }
 
-func (b *StringBuilder) Write(p []byte) (n int, err error) {
+func (b *StringBuilder) Write(p []byte) (int, error) {
 	b.Lock()
-	n, err = b.sb.Write(p)
-	b.Unlock()
-	return
+	defer b.Unlock()
+	return b.sb.Write(p)
 }
 
-func (b *StringBuilder) WriteByte(c byte) (err error) {
+func (b *StringBuilder) WriteByte(c byte) error {
 	b.Lock()
-	err = b.sb.WriteByte(c)
-	b.Unlock()
-	return
+	defer b.Unlock()
+	return b.sb.WriteByte(c)
 }
 
-func (b *StringBuilder) WriteRune(r rune) (n int, err error) {
+func (b *StringBuilder) WriteRune(r rune) (int, error) {
 	b.Lock()
-	n, err = b.sb.WriteRune(r)
-	b.Unlock()
-	return
+	defer b.Unlock()
+	return b.sb.WriteRune(r)
 }
 
-func (b *StringBuilder) WriteString(s string) (n int, err error) {
+func (b *StringBuilder) WriteString(s string) (int, error) {
 	b.Lock()
-	n, err = b.sb.WriteString(s)
-	b.Unlock()
-	return
+	defer b.Unlock()
+	return b.sb.WriteString(s)
 }

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/kitex/internal/test"
+)
+
+func TestStringBuilder(t *testing.T) {
+	sb := &StringBuilder{}
+	sb.Grow(4)
+	test.Assert(t, sb.Cap() == 4)
+	test.Assert(t, sb.Len() == 0)
+	sb.WriteString("1")
+	sb.WriteByte('2')
+	sb.WriteRune(rune('3'))
+	sb.Write([]byte("4"))
+	test.Assert(t, sb.Cap() == 4)
+	test.Assert(t, sb.Len() == 4)
+	test.Assert(t, sb.String() == "1234")
+	sb.Reset()
+	test.Assert(t, sb.String() == "")
+	test.Assert(t, sb.Cap() == 0)
+	test.Assert(t, sb.Len() == 0)
+
+	sb.WithLocked(func(sb *strings.Builder) error {
+		sb.Grow(4)
+		test.Assert(t, sb.Cap() == 4)
+		test.Assert(t, sb.Len() == 0)
+		sb.WriteString("1")
+		sb.WriteByte('2')
+		sb.WriteRune(rune('3'))
+		sb.Write([]byte("4"))
+		test.Assert(t, sb.Cap() == 4)
+		test.Assert(t, sb.Len() == 4)
+		test.Assert(t, sb.String() == "1234")
+		sb.Reset()
+		test.Assert(t, sb.String() == "")
+		test.Assert(t, sb.Cap() == 0)
+		test.Assert(t, sb.Len() == 0)
+		return nil
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
perf

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
perf: 使用互斥锁替换并发string builder

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->