### PR TITLE
feat: add Extra for retry.FailurePolicy for better extension

### DIFF
--- a/pkg/retry/policy.go
+++ b/pkg/retry/policy.go
@@ -88,6 +88,11 @@ type FailurePolicy struct {
 	BackOffPolicy     *BackOffPolicy     `json:"backoff_policy,omitempty"`
 	RetrySameNode     bool               `json:"retry_same_node"`
 	ShouldResultRetry *ShouldResultRetry `json:"-"`
+
+	// Extra is not used directly by kitex. It's used for better integrating your own config source.
+	// After loading FailurePolicy from your config source, `Extra` can be decoded into a user-defined schema,
+	// with which, more complex strategies can be implemented, such as modifying the `ShouldResultRetry`.
+	Extra string `json:"extra"`
 }
 
 // IsRespRetryNonNil is used to check if RespRetry is nil
@@ -203,6 +208,9 @@ func (p *FailurePolicy) Equals(np *FailurePolicy) bool {
 	if p.RetrySameNode != np.RetrySameNode {
 		return false
 	}
+	if p.Extra != np.Extra {
+		return false
+	}
 	// don't need to check `ShouldResultRetry`, ShouldResultRetry is only setup by option
 	// in remote config case will always return false if check it
 	return true
@@ -217,6 +225,7 @@ func (p *FailurePolicy) DeepCopy() *FailurePolicy {
 		BackOffPolicy:     p.BackOffPolicy.DeepCopy(),
 		RetrySameNode:     p.RetrySameNode,
 		ShouldResultRetry: p.ShouldResultRetry, // don't need DeepCopy
+		Extra:             p.Extra,
 	}
 }
 

--- a/pkg/retry/policy_test.go
+++ b/pkg/retry/policy_test.go
@@ -92,6 +92,7 @@ func TestFailureRetryPolicy(t *testing.T) {
 				ErrorRate: defaultCBErrRate,
 			},
 		},
+		Extra: "{}",
 	}
 	jsonRet, err = jsoni.MarshalToString(fp)
 	test.Assert(t, err == nil, err)
@@ -147,6 +148,16 @@ func TestFailureRetryPolicyWithResultRetry(t *testing.T) {
 	test.Assert(t, err == nil, err)
 	test.Assert(t, fp.Equals(&fp10), fp10)
 	test.Assert(t, fp10.ShouldResultRetry == nil)
+
+	t.Run("not-equal-extra", func(t *testing.T) {
+		p1 := &FailurePolicy{
+			Extra: "1",
+		}
+		p2 := &FailurePolicy{
+			Extra: "2",
+		}
+		test.Assert(t, !p1.Equals(p2))
+	})
 }
 
 // test new backupPolicy
@@ -654,6 +665,7 @@ func TestFailurePolicy_DeepCopy(t *testing.T) {
 					BackOffPolicy:     &BackOffPolicy{},
 					RetrySameNode:     true,
 					ShouldResultRetry: &ShouldResultRetry{},
+					Extra:             "{}",
 				},
 			},
 			want: &FailurePolicy{
@@ -661,6 +673,7 @@ func TestFailurePolicy_DeepCopy(t *testing.T) {
 				BackOffPolicy:     &BackOffPolicy{},
 				RetrySameNode:     true,
 				ShouldResultRetry: &ShouldResultRetry{},
+				Extra:             "{}",
 			},
 		},
 	}
@@ -704,6 +717,7 @@ func TestPolicy_DeepCopy(t *testing.T) {
 					Type:   BackupType,
 					FailurePolicy: &FailurePolicy{
 						RetrySameNode: true,
+						Extra:         "{}",
 					},
 					BackupPolicy: &BackupPolicy{
 						RetryDelayMS: 1000,
@@ -715,6 +729,7 @@ func TestPolicy_DeepCopy(t *testing.T) {
 				Type:   BackupType,
 				FailurePolicy: &FailurePolicy{
 					RetrySameNode: true,
+					Extra:         "{}",
 				},
 				BackupPolicy: &BackupPolicy{
 					RetryDelayMS: 1000,

--- a/pkg/retry/retryer_test.go
+++ b/pkg/retry/retryer_test.go
@@ -323,7 +323,7 @@ func TestContainer_Dump(t *testing.T) {
 	test.Assert(t, err == nil, err)
 	test.Assert(t, hasCodeCfg == "true")
 	testStr, err = jsoni.MarshalToString(rcDump["test"])
-	msg = `{"enable":true,"failure_retry":{"stop_policy":{"max_retry_times":2,"max_duration_ms":0,"disable_chain_stop":false,"ddl_stop":false,"cb_policy":{"error_rate":0.1}},"backoff_policy":{"backoff_type":"none"},"retry_same_node":false},"specified_result_retry":{"error_retry":false,"resp_retry":false}}`
+	msg = `{"enable":true,"failure_retry":{"stop_policy":{"max_retry_times":2,"max_duration_ms":0,"disable_chain_stop":false,"ddl_stop":false,"cb_policy":{"error_rate":0.1}},"backoff_policy":{"backoff_type":"none"},"retry_same_node":false,"extra":""},"specified_result_retry":{"error_retry":false,"resp_retry":false}}`
 	test.Assert(t, err == nil, err)
 	test.Assert(t, testStr == msg, testStr)
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Extra is not used directly by kitex. It's used for better integrating your own config source. After loading `retry.FailurePolicy` from your config source, `Extra` can be decoded into a user-defined schema, with which, more complex strategies can be implemented, such as modifying the `ShouldResultRetry` to retry on certain kind of errors (to be configurable, instead of chaning the code each time).
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->