### PR TITLE
feat: client.WithSpecifiedResultRetry should have higher priority

### DIFF
--- a/pkg/retry/failure_retryer.go
+++ b/pkg/retry/failure_retryer.go
@@ -295,10 +295,12 @@ func (r *failureRetryer) Dump() map[string]interface{} {
 
 func (r *failureRetryer) setSpecifiedResultRetryIfNeeded(rr *ShouldResultRetry) {
 	if rr != nil {
+		// save the object specified by client.WithSpecifiedResultRetry(..)
 		r.specifiedResultRetry = rr
 	}
-	if r.policy != nil && r.policy.ShouldResultRetry == nil {
-		// The priority of FailurePolicy.ShouldResultRetry is higher, so only update it when it's nil
+	if r.policy != nil && r.specifiedResultRetry != nil {
+		// The priority of client.WithSpecifiedResultRetry(..) is higher, so always update it
+		// NOTE: client.WithSpecifiedResultRetry(..) will always reject a nil object
 		r.policy.ShouldResultRetry = r.specifiedResultRetry
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: The old implementation is not consistent: if a `FailurePolicy` with non-nil `ShouldResultRetry` is specified, it has higher priority over `client.WithSpecifiedResultRetry`. But if `FailurePolicy.ShouldResultRetry` is nil, the priority is lower.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->