### PR TITLE
feat(rpcinfo): add kitexutil methods for the convenience to fetch rpc information from RPCInfo

### DIFF
--- a/pkg/utils/kitexutil/kitexutil.go
+++ b/pkg/utils/kitexutil/kitexutil.go
@@ -58,7 +58,7 @@ func GetCallerHandlerMethod(ctx context.Context) (string, bool) {
 	if ri == nil {
 		return "", false
 	}
-	return ri.To().Method(), true
+	return ri.From().Method(), true
 }
 
 // GetIDLServiceName gets the serviceName which defined in IDL.

--- a/pkg/utils/kitexutil/kitexutil.go
+++ b/pkg/utils/kitexutil/kitexutil.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package kitexutil provides some util methods to get RPC information
+package kitexutil
+
+import (
+	"context"
+	"net"
+
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+)
+
+// GetCaller is used to get the Service Name of the caller.
+// Return false if failed to get the information.
+func GetCaller(ctx context.Context) (string, bool) {
+	defer func() { recover() }()
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return "", false
+	}
+	return ri.From().ServiceName(), true
+}
+
+// GetMethod is used to get the current RPC Method name.
+// Return false if failed to get the information.
+func GetMethod(ctx context.Context) (string, bool) {
+	defer func() { recover() }()
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return "", false
+	}
+	return ri.To().Method(), true
+}
+
+// GetCallerHandlerMethod is used to get the method name of caller.
+// Only the caller is a Kitex server will have this method information by default, or you can set K_METHOD into context.Context then kitex will get it.
+// Return false if failed to get the information.
+func GetCallerHandlerMethod(ctx context.Context) (string, bool) {
+	defer func() { recover() }()
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return "", false
+	}
+	return ri.To().Method(), true
+}
+
+// GetIDLServiceName gets the serviceName which defined in IDL.
+// Return false if failed to get the information.
+func GetIDLServiceName(ctx context.Context) (string, bool) {
+	defer func() { recover() }()
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return "", false
+	}
+	return ri.Invocation().ServiceName(), true
+}
+
+// GetCallerAddr is used for the server to get the Address of the caller.
+// Return false if failed to get the information.
+func GetCallerAddr(ctx context.Context) (net.Addr, bool) {
+	defer func() { recover() }()
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return nil, false
+	}
+	return ri.From().Address(), true
+}
+
+// GetTransportProtocol gets the transport protocol of the request.
+// Return false if failed to get the information.
+func GetTransportProtocol(ctx context.Context) (string, bool) {
+	defer func() { recover() }()
+
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return "", false
+	}
+	return ri.Config().TransportProtocol().String(), true
+}
+
+// GetRPCInfo gets the RPCInfo in ctx.
+// Return false if failed to get the information.
+func GetRPCInfo(ctx context.Context) (rpcinfo.RPCInfo, bool) {
+	defer func() { recover() }()
+	ri := rpcinfo.GetRPCInfo(ctx)
+	if ri == nil {
+		return nil, false
+	}
+	return ri, true
+}

--- a/pkg/utils/kitexutil/kitexutil_test.go
+++ b/pkg/utils/kitexutil/kitexutil_test.go
@@ -28,20 +28,22 @@ import (
 )
 
 var (
-	testRi   rpcinfo.RPCInfo
-	testCtx  context.Context
-	panicCtx context.Context
-	caller   = "kitexutil.from.service"
-	callee   = "kitexutil.to.service"
-	fromAddr = utils.NewNetAddr("test", "127.0.0.1:12345")
-	method   = "method"
-	tp       = transport.TTHeader
+	testRi         rpcinfo.RPCInfo
+	testCtx        context.Context
+	panicCtx       context.Context
+	caller         = "kitexutil.from.service"
+	callee         = "kitexutil.to.service"
+	idlServiceName = "MockService"
+	fromAddr       = utils.NewNetAddr("test", "127.0.0.1:12345")
+	fromMethod     = "from_method"
+	method         = "method"
+	tp             = transport.TTHeader
 )
 
 func TestMain(m *testing.M) {
-	from := rpcinfo.NewEndpointInfo(caller, "-", fromAddr, nil)
+	from := rpcinfo.NewEndpointInfo(caller, fromMethod, fromAddr, nil)
 	to := rpcinfo.NewEndpointInfo(callee, method, nil, nil)
-	ink := rpcinfo.NewInvocation(callee, method)
+	ink := rpcinfo.NewInvocation(idlServiceName, method)
 	config := rpcinfo.NewRPCConfig()
 	config.(rpcinfo.MutableRPCConfig).SetTransportProtocol(tp)
 
@@ -130,6 +132,60 @@ func TestGetMethod(t *testing.T) {
 			}
 			if got1 != tt.want1 {
 				t.Errorf("GetMethod() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetCallerHandlerMethod(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: fromMethod, want1: true},
+		{name: "Failure", args: args{context.Background()}, want: "", want1: false},
+		{name: "Panic recovered", args: args{panicCtx}, want: "", want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetCallerHandlerMethod(tt.args.ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCallerHandlerMethod() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetCallerHandlerMethod() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetIDLServiceName(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: idlServiceName, want1: true},
+		{name: "Failure", args: args{context.Background()}, want: "", want1: false},
+		{name: "Panic recovered", args: args{panicCtx}, want: "", want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetIDLServiceName(tt.args.ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCallerHandlerMethod() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetCallerHandlerMethod() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}

--- a/pkg/utils/kitexutil/kitexutil_test.go
+++ b/pkg/utils/kitexutil/kitexutil_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kitexutil
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/utils"
+	"github.com/cloudwego/kitex/transport"
+)
+
+var (
+	testRi   rpcinfo.RPCInfo
+	testCtx  context.Context
+	panicCtx context.Context
+	caller   = "kitexutil.from.service"
+	callee   = "kitexutil.to.service"
+	fromAddr = utils.NewNetAddr("test", "127.0.0.1:12345")
+	method   = "method"
+	tp       = transport.TTHeader
+)
+
+func TestMain(m *testing.M) {
+	from := rpcinfo.NewEndpointInfo(caller, "-", fromAddr, nil)
+	to := rpcinfo.NewEndpointInfo(callee, method, nil, nil)
+	ink := rpcinfo.NewInvocation(callee, method)
+	config := rpcinfo.NewRPCConfig()
+	config.(rpcinfo.MutableRPCConfig).SetTransportProtocol(tp)
+
+	stats := rpcinfo.NewRPCStats()
+	testRi = rpcinfo.NewRPCInfo(from, to, ink, config, stats)
+
+	testCtx = context.Background()
+	testCtx = rpcinfo.NewCtxWithRPCInfo(testCtx, testRi)
+	panicCtx = rpcinfo.NewCtxWithRPCInfo(context.Background(), &panicRPCInfo{})
+
+	m.Run()
+}
+
+func TestGetCaller(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: caller, want1: true},
+		{name: "Failure", args: args{context.Background()}, want: "", want1: false},
+		{name: "Panic recovered", args: args{panicCtx}, want: "", want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetCaller(tt.args.ctx)
+			if got != tt.want {
+				t.Errorf("GetCaller() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetCaller() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetCallerAddr(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  net.Addr
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: fromAddr, want1: true},
+		{name: "Failure", args: args{context.Background()}, want: nil, want1: false},
+		{name: "Panic recovered", args: args{panicCtx}, want: nil, want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetCallerAddr(tt.args.ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCallerAddr() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetCallerAddr() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetMethod(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: method, want1: true},
+		{name: "Failure", args: args{context.Background()}, want: "", want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetMethod(tt.args.ctx)
+			if got != tt.want {
+				t.Errorf("GetMethod() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetMethod() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetRPCInfo(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  rpcinfo.RPCInfo
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: testRi, want1: true},
+		{name: "Failure", args: args{context.Background()}, want: nil, want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetRPCInfo(tt.args.ctx)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRPCInfo() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetRPCInfo() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestGetCtxTransportProtocol(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		{name: "Success", args: args{testCtx}, want: tp.String(), want1: true},
+		{name: "Failure", args: args{context.Background()}, want: "", want1: false},
+		{name: "Panic recovered", args: args{panicCtx}, want: "", want1: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetTransportProtocol(tt.args.ctx)
+			if got != tt.want {
+				t.Errorf("GetTransportProtocol() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetTransportProtocol() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+type panicRPCInfo struct{}
+
+func (m *panicRPCInfo) From() rpcinfo.EndpointInfo     { panic("Panic when invoke From") }
+func (m *panicRPCInfo) To() rpcinfo.EndpointInfo       { panic("Panic when invoke To") }
+func (m *panicRPCInfo) Invocation() rpcinfo.Invocation { panic("Panic when invoke Invocation") }
+func (m *panicRPCInfo) Config() rpcinfo.RPCConfig      { panic("Panic when invoke Config") }
+func (m *panicRPCInfo) Stats() rpcinfo.RPCStats        { panic("Panic when invoke Stats") }

--- a/pkg/utils/kitexutil/kitexutil_test.go
+++ b/pkg/utils/kitexutil/kitexutil_test.go
@@ -19,6 +19,7 @@ package kitexutil
 import (
 	"context"
 	"net"
+	"os"
 	"reflect"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestMain(m *testing.M) {
 	testCtx = rpcinfo.NewCtxWithRPCInfo(testCtx, testRi)
 	panicCtx = rpcinfo.NewCtxWithRPCInfo(context.Background(), &panicRPCInfo{})
 
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func TestGetCaller(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
zh: feat(rpcinfo): 添加kitextil方法以方便从RPCInfo获取rpc信息


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: usage see https://www.cloudwego.io/docs/kitex/tutorials/basic-feature/acquire_rpcinfo/
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->