### PR TITLE
feat(retry): retry use percentage limit by default and add close calback

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -161,7 +161,7 @@ func (kc *kClient) initRetryer() error {
 		if kc.opt.RetryMethodPolicies == nil {
 			return nil
 		}
-		kc.opt.RetryContainer = retry.NewRetryContainer()
+		kc.opt.InitRetryContainer()
 	}
 	return kc.opt.RetryContainer.Init(kc.opt.RetryMethodPolicies, kc.opt.RetryWithResult)
 }
@@ -351,7 +351,7 @@ func (kc *kClient) Call(ctx context.Context, method string, request, response in
 	callOptRetry := getCalloptRetryPolicy(callOpts)
 	if kc.opt.RetryContainer == nil && callOptRetry != nil && callOptRetry.Enable {
 		// setup retry in callopt
-		kc.opt.RetryContainer = retry.NewRetryContainer()
+		kc.opt.InitRetryContainer()
 	}
 
 	if kc.opt.RetryContainer == nil {

--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -199,3 +199,11 @@ func (o *Options) initRemoteOpt() {
 		}
 	}
 }
+
+// InitRetryContainer init retry container and add close callback
+func (o *Options) InitRetryContainer() {
+	if o.RetryContainer == nil {
+		o.RetryContainer = retry.NewRetryContainerWithPercentageLimit()
+		o.CloseCallbacks = append(o.CloseCallbacks, o.RetryContainer.Close)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Defaults to use a Retry.Container with percentage limit enabled which is more robust; and add container.Close to the close callbacks to avoid potential resource leak (each container holds a CBSuite)
zh(optional): 默认创建开启了重试占比限制的 retry.Container，更稳妥；将 container.Close 加入到 client 关闭时的 close callback 列表里，避免潜在的资源泄露（每个 container 都含有一个 CBSuite 的引用）

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->