### PR TITLE
fix(retry): always set RespOp && preventive panic to avoid dead loop

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -161,7 +161,7 @@ func (kc *kClient) initRetryer() error {
 		if kc.opt.RetryMethodPolicies == nil {
 			return nil
 		}
-		kc.opt.RetryContainer = retry.NewRetryContainer()
+		kc.opt.InitRetryContainer()
 	}
 	return kc.opt.RetryContainer.Init(kc.opt.RetryMethodPolicies, kc.opt.RetryWithResult)
 }
@@ -351,8 +351,11 @@ func (kc *kClient) Call(ctx context.Context, method string, request, response in
 	callOptRetry := getCalloptRetryPolicy(callOpts)
 	if kc.opt.RetryContainer == nil && callOptRetry != nil && callOptRetry.Enable {
 		// setup retry in callopt
-		kc.opt.RetryContainer = retry.NewRetryContainer()
+		kc.opt.InitRetryContainer()
 	}
+
+	// Add necessary keys to context for isolation between kitex client method calls
+	ctx = retry.PrepareRetryContext(ctx)
 
 	if kc.opt.RetryContainer == nil {
 		// call without retry policy

--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -199,3 +199,11 @@ func (o *Options) initRemoteOpt() {
 		}
 	}
 }
+
+// InitRetryContainer init retry container and add close callback
+func (o *Options) InitRetryContainer() {
+	if o.RetryContainer == nil {
+		o.RetryContainer = retry.NewRetryContainerWithPercentageLimit()
+		o.CloseCallbacks = append(o.CloseCallbacks, o.RetryContainer.Close)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Backup request relies on the RespOp to avoid concurrent read/write to the response object, but it's not properly isolated between two method calls (specifically, one request without retry happens within the middleware of another request with retry enabled), leading to a dead loop.
zh(optional): 备用请求依赖 RespOp 来避免并发读写 response 对象，但它并没有在多个方法调用之间完全隔离（具体而言，是一个"需要重试的请求"的中间件里发起了一个"不需要重试的请求"），导致死循环。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->