### PR TITLE
feat(timeout): support timeout transparent transmission by default when using TTHeader transport protocol

### DIFF
--- a/pkg/transmeta/ttheader.go
+++ b/pkg/transmeta/ttheader.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/remote"
@@ -67,6 +68,11 @@ func (ch *clientTTHeaderHandler) WriteMeta(ctx context.Context, msg remote.Messa
 		hd[transmeta.TransportType] = framedTransportType
 	} else {
 		hd[transmeta.TransportType] = unframedTransportType
+	}
+
+	cfg := rpcinfo.AsMutableRPCConfig(ri.Config())
+	if cfg.IsRPCTimeoutLocked() {
+		hd[transmeta.RPCTimeout] = strconv.Itoa(int(ri.Config().RPCTimeout().Milliseconds()))
 	}
 
 	transInfo.PutTransIntInfo(hd)
@@ -117,6 +123,13 @@ func (sh *serverTTHeaderHandler) ReadMeta(ctx context.Context, msg remote.Messag
 		}
 		if v := intInfo[transmeta.FromMethod]; v != "" {
 			ci.SetMethod(v)
+		}
+	}
+
+	if cfg := rpcinfo.AsMutableRPCConfig(ri.Config()); cfg != nil {
+		timeout := intInfo[transmeta.RPCTimeout]
+		if timeoutMS, err := strconv.Atoi(timeout); err == nil {
+			cfg.SetRPCTimeout(time.Duration(timeoutMS) * time.Millisecond)
 		}
 	}
 	return ctx, nil

--- a/pkg/transmeta/ttheader_test.go
+++ b/pkg/transmeta/ttheader_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/cloudwego/kitex/internal/mocks"
 	"github.com/cloudwego/kitex/internal/test"
@@ -48,9 +49,14 @@ func TestIsTTHeader(t *testing.T) {
 func TestTTHeaderClientWriteMetainfo(t *testing.T) {
 	ctx := context.Background()
 
+	cfg := rpcinfo.NewRPCConfig()
+	cfgMutable := rpcinfo.AsMutableRPCConfig(cfg)
+	cfgMutable.SetRPCTimeout(time.Millisecond * 100)
+	cfgMutable.LockConfig(rpcinfo.BitRPCTimeout)
+
 	fromInfo := rpcinfo.NewEndpointInfo("fromServiceName", "fromMethod", nil, nil)
 	toInfo := rpcinfo.NewEndpointInfo("toServiceName", "toMethod", nil, nil)
-	ri := rpcinfo.NewRPCInfo(fromInfo, toInfo, rpcinfo.NewInvocation("", ""), nil, rpcinfo.NewRPCStats())
+	ri := rpcinfo.NewRPCInfo(fromInfo, toInfo, rpcinfo.NewInvocation("", ""), cfg, rpcinfo.NewRPCStats())
 	msg := remote.NewMessage(nil, mocks.ServiceInfo(), ri, remote.Call, remote.Client)
 
 	// pure paylod, no effect
@@ -72,16 +78,19 @@ func TestTTHeaderClientWriteMetainfo(t *testing.T) {
 	test.Assert(t, kvs[transmeta.ToMethod] == toInfo.Method())
 	test.Assert(t, kvs[transmeta.MsgType] == strconv.Itoa(int(remote.Call)))
 	test.Assert(t, kvs[transmeta.TransportType] == unframedTransportType)
+	test.Assert(t, kvs[transmeta.RPCTimeout] == "100")
 }
 
 func TestTTHeaderServerReadMetainfo(t *testing.T) {
 	ctx := context.Background()
-	ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), nil, rpcinfo.NewInvocation("", ""), nil, rpcinfo.NewRPCStats())
+	ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), nil, rpcinfo.NewInvocation("", ""),
+		rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())
 	msg := remote.NewMessage(nil, mocks.ServiceInfo(), ri, remote.Call, remote.Client)
 
 	hd := map[uint16]string{
 		transmeta.FromService: "fromService",
 		transmeta.FromMethod:  "fromMethod",
+		transmeta.RPCTimeout:  "100",
 	}
 	msg.TransInfo().PutTransIntInfo(hd)
 
@@ -97,11 +106,13 @@ func TestTTHeaderServerReadMetainfo(t *testing.T) {
 	test.Assert(t, err == nil)
 	test.Assert(t, msg.RPCInfo().From().ServiceName() == hd[transmeta.FromService])
 	test.Assert(t, msg.RPCInfo().From().Method() == hd[transmeta.FromMethod])
+	test.Assert(t, ri.Config().RPCTimeout() == 100*time.Millisecond)
 }
 
 func TestTTHeaderServerWriteMetainfo(t *testing.T) {
 	ctx := context.Background()
-	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", ""), nil, rpcinfo.NewRPCStats())
+	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", ""),
+		rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())
 	msg := remote.NewMessage(nil, mocks.ServiceInfo(), ri, remote.Call, remote.Client)
 
 	msg.SetProtocolInfo(remote.NewProtocolInfo(transport.PurePayload, serviceinfo.Thrift))


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
使用 TTHeader 传输协议时，默认支持超时透传

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: for client, write `RPCInfo.Config().RPCTimeout()`(if set) to ttheader, and for server, read rpctimeout from ttheader to `RPCInfo.Config()`. Note: client/server should specify the metahandler manually by `client.WithMetaHandler(transmeta.ClientTTHeaderHandler)` and `server.WithMetaHandler(transmeta.ServerTTHeaderHandler)`
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->