### PR TITLE
fix(hessian2): idl-ref overwritten when using hessian2

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/hessian2_test.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/hessian2_test.go
@@ -15,12 +15,13 @@
 package thriftgo
 
 import (
-	"github.com/cloudwego/kitex/internal/test"
-	"github.com/cloudwego/thriftgo/config"
 	"io"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/thriftgo/config"
 )
 
 func Test_loadIDLRefConfig(t *testing.T) {

--- a/tool/internal_pkg/pluginmode/thriftgo/hessian2_test.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/hessian2_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thriftgo
+
+import (
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/thriftgo/config"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_loadIDLRefConfig(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		reader   io.Reader
+		expected func(t *testing.T, res *config.RawConfig)
+	}{
+		{
+			desc: "normal idl-ref file",
+			reader: strings.NewReader(`ref:
+    decimal.thrift: dubbo-demo/decimal
+    java.thrift: github.com/kitex-contrib/codec-dubbo/java
+debug: false`),
+			expected: func(t *testing.T, res *config.RawConfig) {
+				test.Assert(t, reflect.DeepEqual(res, &config.RawConfig{
+					Ref: map[string]interface{}{
+						"decimal.thrift": "dubbo-demo/decimal",
+						"java.thrift":    "github.com/kitex-contrib/codec-dubbo/java",
+					},
+					Debug: false,
+				}))
+			},
+		},
+		{
+			desc:   "empty idl-ref file",
+			reader: strings.NewReader(""),
+			expected: func(t *testing.T, res *config.RawConfig) {
+				test.Assert(t, len(res.Ref) == 0, res.Ref)
+				test.Assert(t, res.Debug == false, res.Debug)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			res := loadIDLRefConfig("", tc.reader)
+			tc.expected(t, res)
+		})
+	}
+}

--- a/tool/internal_pkg/pluginmode/thriftgo/hessian2_test.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/hessian2_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
+
 	"github.com/cloudwego/thriftgo/config"
 )
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
When generating Hessian2 code with idl-ref enabled, user's customized configuration would be overwritten except for "java.thrift".
Before:
```
ref:
    decimal.thrift: dubbo-demo/decimal
    java.thrift: github.com/kitex-contrib/codec-dubbo/java
debug: false
```
After:
```
ref:
    java.thrift: github.com/kitex-contrib/codec-dubbo/java
debug: false
```
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->