### PR TITLE
fix(hessian2): correct code-ref behavior when thrift file is not in project dir

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/hessian2.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/hessian2.go
@@ -72,8 +72,8 @@ func runOption(cfg *generator.Config, opt string) {
 
 // runJavaExtensionOption Pull the extension file of java class from remote
 func runJavaExtensionOption(cfg *generator.Config) {
-	// get java.thrift
-	if path := util.JoinPath(filepath.Dir(cfg.IDL), "java.thrift"); !util.Exists(path) {
+	// get java.thrift, we need to put java.thrift in project root directory
+	if path := util.JoinPath(cfg.OutputPath, "java.thrift"); !util.Exists(path) {
 		if err := util.DownloadFile(JavaThrift, path); err != nil {
 			log.Warn("Downloading java.thrift file failed:", err.Error())
 			abs, err := filepath.Abs(path)
@@ -92,9 +92,10 @@ func runJavaExtensionOption(cfg *generator.Config) {
 // patchIDLRefConfig merge idl-ref configuration patch
 func patchIDLRefConfig(cfg *generator.Config) {
 	// load the idl-ref config file (create it first if it does not exist)
-	idlRef := filepath.Join(filepath.Dir(cfg.IDL), "idl-ref.yaml")
+	// for making use of idl-ref of thriftgo, we need to check the project root directory
+	idlRef := filepath.Join(cfg.OutputPath, "idl-ref.yaml")
 	if !util.Exists(idlRef) {
-		idlRef = filepath.Join(filepath.Dir(cfg.IDL), "idl-ref.yml")
+		idlRef = filepath.Join(cfg.OutputPath, "idl-ref.yml")
 	}
 	file, err := os.OpenFile(idlRef, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {

--- a/tool/internal_pkg/pluginmode/thriftgo/hessian2.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/hessian2.go
@@ -73,7 +73,7 @@ func runOption(cfg *generator.Config, opt string) {
 
 // runJavaExtensionOption Pull the extension file of java class from remote
 func runJavaExtensionOption(cfg *generator.Config) {
-	// get java.thrift, we need to put java.thrift in project root directory
+	// get java.thrift, we assume java.thrift and IDL in the same directory so that IDL just needs to include "java.thrift"
 	if path := util.JoinPath(filepath.Dir(cfg.IDL), JavaThrift); !util.Exists(path) {
 		if err := util.DownloadFile(JavaThriftAddress, path); err != nil {
 			log.Warn("Downloading java.thrift file failed:", err.Error())
@@ -106,7 +106,7 @@ func patchIDLRefConfig(cfg *generator.Config) {
 	defer file.Close()
 	idlRefCfg := loadIDLRefConfig(file.Name(), file)
 
-	// update the idl-ref config file
+	// assume java.thrift and IDL are in the same directory
 	javaRef := filepath.Join(filepath.Dir(cfg.IDL), JavaThrift)
 	idlRefCfg.Ref[javaRef] = DubboCodec + "/java"
 	out, err := yaml.Marshal(idlRefCfg)

--- a/tool/internal_pkg/pluginmode/thriftgo/hessian2.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/hessian2.go
@@ -33,8 +33,9 @@ import (
 const (
 	JavaExtensionOption = "java_extension"
 
-	DubboCodec = "github.com/kitex-contrib/codec-dubbo"
-	JavaThrift = "https://raw.githubusercontent.com/kitex-contrib/codec-dubbo/main/java/java.thrift"
+	DubboCodec        = "github.com/kitex-contrib/codec-dubbo"
+	JavaThrift        = "java.thrift"
+	JavaThriftAddress = "https://raw.githubusercontent.com/kitex-contrib/codec-dubbo/main/java/java.thrift"
 )
 
 // Hessian2PreHook Hook before building cmd
@@ -73,14 +74,14 @@ func runOption(cfg *generator.Config, opt string) {
 // runJavaExtensionOption Pull the extension file of java class from remote
 func runJavaExtensionOption(cfg *generator.Config) {
 	// get java.thrift, we need to put java.thrift in project root directory
-	if path := util.JoinPath(cfg.OutputPath, "java.thrift"); !util.Exists(path) {
-		if err := util.DownloadFile(JavaThrift, path); err != nil {
+	if path := util.JoinPath(filepath.Dir(cfg.IDL), JavaThrift); !util.Exists(path) {
+		if err := util.DownloadFile(JavaThriftAddress, path); err != nil {
 			log.Warn("Downloading java.thrift file failed:", err.Error())
 			abs, err := filepath.Abs(path)
 			if err != nil {
 				abs = path
 			}
-			log.Warnf("You can try to download again. If the download still fails, you can choose to manually download \"%s\" to the local path \"%s\".", JavaThrift, abs)
+			log.Warnf("You can try to download again. If the download still fails, you can choose to manually download \"%s\" to the local path \"%s\".", JavaThriftAddress, abs)
 			os.Exit(1)
 		}
 	}
@@ -106,7 +107,8 @@ func patchIDLRefConfig(cfg *generator.Config) {
 	idlRefCfg := loadIDLRefConfig(file.Name(), file)
 
 	// update the idl-ref config file
-	idlRefCfg.Ref["java.thrift"] = DubboCodec + "/java"
+	javaRef := filepath.Join(filepath.Dir(cfg.IDL), JavaThrift)
+	idlRefCfg.Ref[javaRef] = DubboCodec + "/java"
 	out, err := yaml.Marshal(idlRefCfg)
 	if err != nil {
 		log.Warn("Marshal configuration failed:", err.Error())


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
project structure:
```
-project
  -idl
    api.thrift
```

When we run ```kitex -module project -protocol Hessian2 -hessian2 java_extension idl/api.thrift```, **java.thrift** and **idl-ref.yml** would be in the same directory as **api.thrift**.
new project structure:
```
-project
  -idl
    api.thrift
    java.thrift
    idl-ref.yml
```

Since thriftgo would read **idl-ref.yml** in the project root directory, we need to move it. Then
```
-project
  -idl
    api.thrift
    java.thrift
  idl-ref.yml
```

zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->