### PR TITLE
WIP: feat: add binary-grpc-generic-call

### DIFF
--- a/client/genericclient/client.go
+++ b/client/genericclient/client.go
@@ -42,6 +42,11 @@ func NewClientWithServiceInfo(destService string, g generic.Generic, svcInfo *se
 	options = append(options, client.WithDestService(destService))
 	options = append(options, opts...)
 
+	if g.PayloadCodecType() == serviceinfo.Protobuf {
+		svcInfo.Extra["grpcGeneric"] = true
+		svcInfo.ServiceName = generic.GetGrpcSvcName(g)
+	}
+
 	kc, err := client.NewClient(svcInfo, options...)
 	if err != nil {
 		return nil, err

--- a/pkg/generic/generic_grpc.go
+++ b/pkg/generic/generic_grpc.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generic
+
+import (
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
+)
+
+// BinaryGrpcGeneric raw grpc binary Generic
+func BinaryGrpcGeneric(grpcSvcName string) Generic {
+	return &binaryGrpcGeneric{grpcSvcName: grpcSvcName}
+}
+
+type binaryGrpcGeneric struct {
+	grpcSvcName string
+}
+
+func GetGrpcSvcName(g Generic) string {
+	binaryG, ok := g.(*binaryGrpcGeneric)
+	if !ok {
+		return ""
+	}
+	return binaryG.grpcSvcName
+}
+
+func (g *binaryGrpcGeneric) Framed() bool {
+	return true
+}
+
+func (g *binaryGrpcGeneric) PayloadCodecType() serviceinfo.PayloadCodec {
+	return serviceinfo.Protobuf
+}
+
+func (g *binaryGrpcGeneric) PayloadCodec() remote.PayloadCodec {
+	return nil
+}
+
+func (g *binaryGrpcGeneric) GetMethod(req interface{}, method string) (*Method, error) {
+	return &Method{method, false}, nil
+}
+
+func (g *binaryGrpcGeneric) Close() error {
+	return nil
+}

--- a/pkg/remote/trans/nphttp2/client_handler.go
+++ b/pkg/remote/trans/nphttp2/client_handler.go
@@ -39,7 +39,7 @@ func (f *cliTransHandlerFactory) NewTransHandler(opt *remote.ClientOption) (remo
 }
 
 func newCliTransHandler(opt *remote.ClientOption) (*cliTransHandler, error) {
-	if opt.Codec.Name() == "grpcGenericCodec" {
+	if opt.Codec != nil && opt.Codec.Name() == "grpcGenericCodec" {
 		return &cliTransHandler{
 			opt:   opt,
 			codec: opt.Codec,

--- a/pkg/remote/trans/nphttp2/client_handler.go
+++ b/pkg/remote/trans/nphttp2/client_handler.go
@@ -39,6 +39,12 @@ func (f *cliTransHandlerFactory) NewTransHandler(opt *remote.ClientOption) (remo
 }
 
 func newCliTransHandler(opt *remote.ClientOption) (*cliTransHandler, error) {
+	if opt.Codec.Name() == "grpcGenericCodec" {
+		return &cliTransHandler{
+			opt:   opt,
+			codec: opt.Codec,
+		}, nil
+	}
 	return &cliTransHandler{
 		opt:   opt,
 		codec: grpc.NewGRPCCodec(grpc.WithThriftCodec(opt.PayloadCodec)),

--- a/pkg/serviceinfo/serviceinfo.go
+++ b/pkg/serviceinfo/serviceinfo.go
@@ -83,7 +83,8 @@ func (i *ServiceInfo) MethodInfo(name string) MethodInfo {
 	if i == nil {
 		return nil
 	}
-	if i.ServiceName == GenericService {
+	grpcGeneric, ok := i.Extra["grpcGeneric"]
+	if i.ServiceName == GenericService || (ok && grpcGeneric.(bool)) {
 		if i.GenericMethod != nil {
 			return i.GenericMethod(name)
 		}


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: add BinaryGrpcGeneric type for generic client to support grpc in unary generic call.
users can now use something like
 `genericclient.NewClient("a.b.c", generic.BinaryGrpcGeneric("package.service"), ...)`
to create generic client that supports grpc.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->