### PR TITLE
feat:(generic) support set fields for empty struct

### DIFF
--- a/internal/test/port.go
+++ b/internal/test/port.go
@@ -17,6 +17,7 @@ package test
 import (
 	"fmt"
 	"hash/fnv"
+	"math/rand"
 	"net"
 	"os"
 	"runtime/debug"
@@ -44,7 +45,7 @@ var curPort uint32 = UnixUserPortStart + hashInt(os.Getpid())%200*200
 // This API ensures no repeated addr returned in one UNIX OS
 func GetLocalAddress() string {
 	for {
-		port := atomic.AddUint32(&curPort, 1)
+		port := atomic.AddUint32(&curPort, 1+uint32(rand.Intn(10)))
 		addr := "127.0.0.1:" + strconv.Itoa(int(port))
 		if !IsAddressInUse(addr) {
 			trace := strings.Split(string(debug.Stack()), "\n")
@@ -59,7 +60,7 @@ func GetLocalAddress() string {
 // tells if a net address is already in use.
 func IsAddressInUse(address string) bool {
 	// Attempt to establish a TCP connection to the address
-	conn, err := net.DialTimeout("tcp", address, 1*time.Second)
+	conn, err := net.DialTimeout("tcp", address, time.Duration(1+rand.Intn(10))*100*time.Millisecond)
 	if err != nil {
 		// If there's an error, the address is likely not in use or not reachable
 		return false

--- a/internal/test/port.go
+++ b/internal/test/port.go
@@ -45,6 +45,7 @@ var curPort uint32 = UnixUserPortStart + hashInt(os.Getpid())%200*200
 // This API ensures no repeated addr returned in one UNIX OS
 func GetLocalAddress() string {
 	for {
+		time.Sleep(time.Millisecond * time.Duration(1+rand.Intn(10)))
 		port := atomic.AddUint32(&curPort, 1+uint32(rand.Intn(10)))
 		addr := "127.0.0.1:" + strconv.Itoa(int(port))
 		if !IsAddressInUse(addr) {

--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -185,7 +185,8 @@ func SetBinaryWithByteSlice(g Generic, enable bool) error {
 	return nil
 }
 
-// SetSetFieldsForEmptyStruct enable/disable set all fields in map-generic even if a struct is empty.
+// SetSetFieldsForEmptyStruct enable/disable set all fields of a struct even if it is empty. 
+// This option is only applicable to map-generic response (reading) now.
 //
 //	mode == 0 means disable
 //	mode == 1 means only set required and default fields

--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -185,19 +185,31 @@ func SetBinaryWithByteSlice(g Generic, enable bool) error {
 	return nil
 }
 
-// SetSetFieldsForEmptyStruct enable/disable set all fields of a struct even if it is empty. 
+// SetFieldsForEmptyStructMode is a enum for EnableSetFieldsForEmptyStruct()
+type SetFieldsForEmptyStructMode uint8
+
+const (
+	// NotSetFields means disable
+	NotSetFields SetFieldsForEmptyStructMode = iota
+	// SetNonOptiontionalFields means only set required and default fields
+	SetNonOptiontionalFields
+	// SetAllFields means set all fields
+	SetAllFields
+)
+
+// EnableSetFieldsForEmptyStruct enable/disable set all fields of a struct even if it is empty.
 // This option is only applicable to map-generic response (reading) now.
 //
 //	mode == 0 means disable
 //	mode == 1 means only set required and default fields
 //	mode == 2 means set all fields
-func SetSetFieldsForEmptyStruct(g Generic, mode uint8) error {
+func EnableSetFieldsForEmptyStruct(g Generic, mode SetFieldsForEmptyStructMode) error {
 	switch c := g.(type) {
 	case *mapThriftGeneric:
 		if c.codec == nil {
 			return fmt.Errorf("empty codec for %#v", c)
 		}
-		c.codec.setFieldsForEmptyStruct = mode
+		c.codec.setFieldsForEmptyStruct = uint8(mode)
 	default:
 		return fmt.Errorf("SetFieldsForEmptyStruct only supports map-generic at present")
 	}

--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -185,6 +185,24 @@ func SetBinaryWithByteSlice(g Generic, enable bool) error {
 	return nil
 }
 
+// SetSetFieldsForEmptyStruct enable/disable set all fields in map-generic even if a struct is empty.
+//
+//	mode == 0 means disable
+//	mode == 1 means only set required and default fields
+//	mode == 2 means set all fields
+func SetSetFieldsForEmptyStruct(g Generic, mode uint8) error {
+	switch c := g.(type) {
+	case *mapThriftGeneric:
+		if c.codec == nil {
+			return fmt.Errorf("empty codec for %#v", c)
+		}
+		c.codec.setFieldsForEmptyStruct = mode
+	default:
+		return fmt.Errorf("SetFieldsForEmptyStruct only supports map-generic at present")
+	}
+	return nil
+}
+
 var thriftCodec = thrift.NewThriftCodec()
 
 var pbCodec = protobuf.NewProtobufCodec()

--- a/pkg/generic/map_test/generic_test.go
+++ b/pkg/generic/map_test/generic_test.go
@@ -405,7 +405,7 @@ func initThriftClientByIDL(t *testing.T, addr, idl string, base64Binary, byteSli
 	test.Assert(t, err == nil)
 	err = generic.SetBinaryWithByteSlice(g, byteSlice)
 	test.Assert(t, err == nil)
-	err = generic.SetSetFieldsForEmptyStruct(g, setEmptyStruct)
+	err = generic.EnableSetFieldsForEmptyStruct(g, generic.SetFieldsForEmptyStructMode(setEmptyStruct))
 	test.Assert(t, err == nil)
 	cli := newGenericClient("destServiceName", g, addr)
 	test.Assert(t, err == nil)

--- a/pkg/generic/map_test/generic_test.go
+++ b/pkg/generic/map_test/generic_test.go
@@ -39,7 +39,7 @@ import (
 func TestThrift(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceImpl), false, false)
-	cli := initThriftClient(t, addr, false, false, false)
+	cli := initThriftClient(t, addr, false, false, 0)
 
 	cases := []struct {
 		reqMsg   interface{}
@@ -267,7 +267,7 @@ func TestThrift(t *testing.T) {
 func TestThriftPingMethod(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServicePingImpl), false, false)
-	cli := initThriftClient(t, addr, false, false, false)
+	cli := initThriftClient(t, addr, false, false, 0)
 
 	resp, err := cli.GenericCall(context.Background(), "Ping", "hello", callopt.WithRPCTimeout(100*time.Second))
 	test.Assert(t, err == nil, err)
@@ -280,7 +280,7 @@ func TestThriftPingMethod(t *testing.T) {
 func TestThriftError(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceErrorImpl), false, false)
-	cli := initThriftClient(t, addr, false, false, false)
+	cli := initThriftClient(t, addr, false, false, 0)
 
 	_, err := cli.GenericCall(context.Background(), "ExampleMethod", reqMsg, callopt.WithRPCTimeout(100*time.Second))
 	test.Assert(t, err != nil)
@@ -291,7 +291,7 @@ func TestThriftError(t *testing.T) {
 func TestThriftOnewayMethod(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceOnewayImpl), false, false)
-	cli := initThriftClient(t, addr, false, false, false)
+	cli := initThriftClient(t, addr, false, false, 0)
 
 	resp, err := cli.GenericCall(context.Background(), "Oneway", "hello", callopt.WithRPCTimeout(100*time.Second))
 	test.Assert(t, err == nil, err)
@@ -302,7 +302,7 @@ func TestThriftOnewayMethod(t *testing.T) {
 func TestThriftVoidMethod(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceVoidImpl), false, false)
-	cli := initThriftClient(t, addr, false, false, false)
+	cli := initThriftClient(t, addr, false, false, 0)
 
 	resp, err := cli.GenericCall(context.Background(), "Void", "hello", callopt.WithRPCTimeout(100*time.Second))
 	test.Assert(t, err == nil, err)
@@ -313,7 +313,7 @@ func TestThriftVoidMethod(t *testing.T) {
 func TestBase64Binary(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceWithBase64Binary), true, false)
-	cli := initThriftClient(t, addr, true, false, false)
+	cli := initThriftClient(t, addr, true, false, 0)
 
 	reqMsg = map[string]interface{}{"BinaryMsg": []byte("hello")}
 	resp, err := cli.GenericCall(context.Background(), "ExampleMethod", reqMsg, callopt.WithRPCTimeout(100*time.Second))
@@ -325,10 +325,29 @@ func TestBase64Binary(t *testing.T) {
 	svr.Stop()
 }
 
+func TestSetSetFieldsForEmptyStruct(t *testing.T) {
+	addr := test.GetLocalAddress()
+	svr := initThriftServer(t, addr, new(GenericServiceWithBase64Binary), true, false)
+	cli := initThriftClient(t, addr, true, false, 1)
+
+	reqMsg = map[string]interface{}{"BinaryMsg": []byte("hello")}
+	resp, err := cli.GenericCall(context.Background(), "ExampleMethod", reqMsg, callopt.WithRPCTimeout(100*time.Second))
+	test.Assert(t, err == nil, err)
+	gr, ok := resp.(map[string]interface{})
+	test.Assert(t, ok)
+	test.Assert(t, reflect.DeepEqual(gr["Base"], map[string]interface{}{
+		"LogID":  "",
+		"Caller": "",
+		"Addr":   "",
+		"Client": "",
+	}))
+	svr.Stop()
+}
+
 func TestBinaryWithByteSlice(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceWithByteSliceImpl), false, true)
-	cli := initThriftClient(t, addr, false, false, false)
+	cli := initThriftClient(t, addr, false, false, 0)
 
 	reqMsg = map[string]interface{}{"BinaryMsg": []byte("hello")}
 	resp, err := cli.GenericCall(context.Background(), "ExampleMethod", reqMsg, callopt.WithRPCTimeout(100*time.Second))
@@ -342,7 +361,7 @@ func TestBinaryWithByteSlice(t *testing.T) {
 func TestBinaryWithBase64AndByteSlice(t *testing.T) {
 	addr := test.GetLocalAddress()
 	svr := initThriftServer(t, addr, new(GenericServiceWithByteSliceImpl), true, true)
-	cli := initThriftClient(t, addr, true, true, false)
+	cli := initThriftClient(t, addr, true, true, 0)
 
 	reqMsg = map[string]interface{}{"BinaryMsg": []byte("hello")}
 	resp, err := cli.GenericCall(context.Background(), "ExampleMethod", reqMsg, callopt.WithRPCTimeout(100*time.Second))
@@ -373,11 +392,11 @@ func initThriftMockClient(t *testing.T, address string) genericclient.Client {
 	return cli
 }
 
-func initThriftClient(t *testing.T, addr string, base64Binary, byteSlice bool, setEmptyStruct bool) genericclient.Client {
+func initThriftClient(t *testing.T, addr string, base64Binary, byteSlice bool, setEmptyStruct uint8) genericclient.Client {
 	return initThriftClientByIDL(t, addr, "./idl/example.thrift", base64Binary, byteSlice, setEmptyStruct)
 }
 
-func initThriftClientByIDL(t *testing.T, addr, idl string, base64Binary, byteSlice bool, setEmptyStruct bool) genericclient.Client {
+func initThriftClientByIDL(t *testing.T, addr, idl string, base64Binary, byteSlice bool, setEmptyStruct uint8) genericclient.Client {
 	p, err := generic.NewThriftFileProvider(idl)
 	test.Assert(t, err == nil)
 	g, err := generic.MapThriftGeneric(p)

--- a/pkg/generic/mapthrift_codec.go
+++ b/pkg/generic/mapthrift_codec.go
@@ -35,12 +35,13 @@ var (
 )
 
 type mapThriftCodec struct {
-	svcDsc              atomic.Value // *idl
-	provider            DescriptorProvider
-	codec               remote.PayloadCodec
-	forJSON             bool
-	binaryWithBase64    bool
-	binaryWithByteSlice bool
+	svcDsc                  atomic.Value // *idl
+	provider                DescriptorProvider
+	codec                   remote.PayloadCodec
+	forJSON                 bool
+	binaryWithBase64        bool
+	binaryWithByteSlice     bool
+	setFieldsForEmptyStruct uint8
 }
 
 func newMapThriftCodec(p DescriptorProvider, codec remote.PayloadCodec) (*mapThriftCodec, error) {
@@ -111,6 +112,7 @@ func (c *mapThriftCodec) Unmarshal(ctx context.Context, msg remote.Message, in r
 		rm = thrift.NewReadStruct(svcDsc, msg.RPCRole() == remote.Client)
 	}
 	rm.SetBinaryOption(c.binaryWithBase64, c.binaryWithByteSlice)
+	rm.SetSetFieldsForEmptyStruct(c.setFieldsForEmptyStruct)
 	msg.Data().(WithCodec).SetCodec(rm)
 	return c.codec.Unmarshal(ctx, msg, in)
 }

--- a/pkg/generic/thrift/read.go
+++ b/pkg/generic/thrift/read.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jhump/protoreflect/desc"
@@ -40,6 +41,9 @@ type readerOption struct {
 	http                bool
 	binaryWithBase64    bool
 	binaryWithByteSlice bool
+
+	setFieldsForEmptyStruct uint8
+
 	// describe struct of current level
 	pbDsc proto.MessageDescriptor
 }
@@ -336,6 +340,20 @@ func readStruct(ctx context.Context, in thrift.TProtocol, t *descriptor.TypeDesc
 	// void is nil struct
 	// default value with struct NOT SUPPORT pb.
 	if t.Struct != nil {
+		// set all fields even if it is empty, to be compatible with code-gen
+		if opt.setFieldsForEmptyStruct != 0 {
+			for _, field := range t.Struct.FieldsByID {
+				if opt.setFieldsForEmptyStruct == 1 {
+					// ignore optional fields if setFieldsForEmptyStruct == 1
+					if field.Optional {
+						continue
+					}
+				}
+				if err := fs(field, readEmptyValue(field.Type, opt)); err != nil {
+					return nil, err
+				}
+			}
+		}
 		for _, field := range t.Struct.DefaultFields {
 			val := field.DefaultValue
 			if field.ValueMapping != nil {
@@ -500,5 +518,47 @@ func unnestPb(opt *readerOption, fieldId int32) func() {
 	}
 	return func() {
 		opt.pbDsc = pbDsc
+	}
+}
+
+func readEmptyValue(t *descriptor.TypeDescriptor, opt *readerOption) interface{} {
+	rtype := getRType(t)
+	if rtype == nil {
+		return nil
+	}
+	return reflect.New(rtype).Elem().Interface()
+}
+
+func getRType(t *descriptor.TypeDescriptor) reflect.Type {
+	switch t.Type {
+	case descriptor.BOOL:
+		return reflect.TypeOf(false)
+	case descriptor.I08:
+		if t.Name == "byte" {
+			return reflect.TypeOf(byte(0))
+		}
+		return reflect.TypeOf(int8(0))
+	case descriptor.I16:
+		return reflect.TypeOf(int16(0))
+	case descriptor.I32:
+		return reflect.TypeOf(int32(0))
+	case descriptor.I64:
+		return reflect.TypeOf(int64(0))
+	case descriptor.DOUBLE:
+		return reflect.TypeOf(float64(0))
+	case descriptor.STRING:
+		if t.Name == "binary" {
+			return reflect.TypeOf([]byte(nil))
+		} else {
+			return reflect.TypeOf("")
+		}
+	case descriptor.LIST, descriptor.SET:
+		return reflect.SliceOf(getRType(t.Elem))
+	case descriptor.MAP:
+		return reflect.MapOf(getRType(t.Key), getRType(t.Elem))
+	case descriptor.STRUCT:
+		return reflect.TypeOf(map[string]interface{}{})
+	default:
+		return nil
 	}
 }

--- a/pkg/generic/thrift/read_test.go
+++ b/pkg/generic/thrift/read_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cloudwego/kitex/internal/mocks"
 	"github.com/cloudwego/kitex/pkg/generic/descriptor"
@@ -588,25 +589,29 @@ func Test_readStruct(t *testing.T) {
 						5:  {Name: "i32", Type: &descriptor.TypeDescriptor{Type: descriptor.I32, Name: "i32"}},
 						6:  {Name: "i64", Type: &descriptor.TypeDescriptor{Type: descriptor.I64, Name: "i64"}},
 						7:  {Name: "double", Type: &descriptor.TypeDescriptor{Type: descriptor.DOUBLE, Name: "double"}},
-						8:  {Name: "list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
-						9:  {Name: "set", Type: &descriptor.TypeDescriptor{Type: descriptor.SET, Name: "set", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
-						10: {Name: "map", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}, Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						8:  {Name: "list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "binary"}}},
+						9:  {Name: "set", Type: &descriptor.TypeDescriptor{Type: descriptor.SET, Name: "set", Elem: &descriptor.TypeDescriptor{Type: descriptor.BOOL}}},
+						10: {Name: "map", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}, Elem: &descriptor.TypeDescriptor{Type: descriptor.DOUBLE}}},
 						11: {Name: "struct", Type: &descriptor.TypeDescriptor{Type: descriptor.STRUCT}},
+						12: {Name: "list-list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "binary"}}}},
+						13: {Name: "map-list", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}, Elem: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "binary"}}}},
 					},
 				},
 			}, opt: &readerOption{setFieldsForEmptyStruct: 1}},
 			map[string]interface{}{
-				"string": "",
-				"byte":   byte(0),
-				"i8":     int8(0),
-				"i16":    int16(0),
-				"i32":    int32(0),
-				"i64":    int64(0),
-				"double": float64(0),
-				"list":   []string(nil),
-				"set":    []string(nil),
-				"map":    map[string]string(nil),
-				"struct": map[string]interface{}(nil),
+				"string":    "",
+				"byte":      byte(0),
+				"i8":        int8(0),
+				"i16":       int16(0),
+				"i32":       int32(0),
+				"i64":       int64(0),
+				"double":    float64(0),
+				"list":      [][]byte(nil),
+				"set":       []bool(nil),
+				"map":       map[string]float64(nil),
+				"struct":    map[string]interface{}(nil),
+				"list-list": [][][]byte(nil),
+				"map-list":  map[string][][]byte(nil),
 			},
 			false,
 		},
@@ -623,9 +628,9 @@ func Test_readStruct(t *testing.T) {
 						5:  {Name: "i32", Type: &descriptor.TypeDescriptor{Type: descriptor.I32, Name: "i32"}},
 						6:  {Name: "i64", Type: &descriptor.TypeDescriptor{Type: descriptor.I64, Name: "i64"}},
 						7:  {Name: "double", Type: &descriptor.TypeDescriptor{Type: descriptor.DOUBLE, Name: "double"}},
-						8:  {Name: "list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
-						9:  {Name: "set", Type: &descriptor.TypeDescriptor{Type: descriptor.SET, Name: "set", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
-						10: {Name: "map", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}, Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						8:  {Name: "list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.I08}}},
+						9:  {Name: "set", Type: &descriptor.TypeDescriptor{Type: descriptor.SET, Name: "set", Elem: &descriptor.TypeDescriptor{Type: descriptor.I16}}},
+						10: {Name: "map", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.I32}, Elem: &descriptor.TypeDescriptor{Type: descriptor.I64}}},
 						11: {Name: "struct", Type: &descriptor.TypeDescriptor{Type: descriptor.STRUCT}, Optional: true},
 					},
 				},
@@ -637,9 +642,9 @@ func Test_readStruct(t *testing.T) {
 				"i32":    int32(0),
 				"i64":    int64(0),
 				"double": float64(0),
-				"list":   []string(nil),
-				"set":    []string(nil),
-				"map":    map[string]string(nil),
+				"list":   []int8(nil),
+				"set":    []int16(nil),
+				"map":    map[int32]int64(nil),
 			},
 			false,
 		},
@@ -677,9 +682,7 @@ func Test_readStruct(t *testing.T) {
 				t.Errorf("readStruct() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("readStruct() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/generic/thrift/read_test.go
+++ b/pkg/generic/thrift/read_test.go
@@ -538,6 +538,17 @@ func Test_readStruct(t *testing.T) {
 			return "world", nil
 		},
 	}
+	mockTTransport2 := &mocks.MockThriftTTransport{
+		ReadStructBeginFunc: func() (name string, err error) {
+			return "Demo", nil
+		},
+		ReadFieldBeginFunc: func() (name string, typeID thrift.TType, id int16, err error) {
+			return "", thrift.STOP, 0, nil
+		},
+		ReadStringFunc: func() (string, error) {
+			return "world", nil
+		},
+	}
 	readError := false
 	mockTTransportError := &mocks.MockThriftTTransport{
 		ReadStructBeginFunc: func() (name string, err error) {
@@ -564,6 +575,74 @@ func Test_readStruct(t *testing.T) {
 		wantErr bool
 	}{
 		// TODO: Add test cases.
+		{
+			"readStruct with setFieldsForEmptyStruct",
+			args{in: mockTTransport2, t: &descriptor.TypeDescriptor{
+				Type: descriptor.STRUCT,
+				Struct: &descriptor.StructDescriptor{
+					FieldsByID: map[int32]*descriptor.FieldDescriptor{
+						1:  {Name: "string", Type: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}},
+						2:  {Name: "byte", Type: &descriptor.TypeDescriptor{Type: descriptor.BYTE, Name: "byte"}},
+						3:  {Name: "i8", Type: &descriptor.TypeDescriptor{Type: descriptor.I08, Name: "i8"}},
+						4:  {Name: "i16", Type: &descriptor.TypeDescriptor{Type: descriptor.I16, Name: "i16"}},
+						5:  {Name: "i32", Type: &descriptor.TypeDescriptor{Type: descriptor.I32, Name: "i32"}},
+						6:  {Name: "i64", Type: &descriptor.TypeDescriptor{Type: descriptor.I64, Name: "i64"}},
+						7:  {Name: "double", Type: &descriptor.TypeDescriptor{Type: descriptor.DOUBLE, Name: "double"}},
+						8:  {Name: "list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						9:  {Name: "set", Type: &descriptor.TypeDescriptor{Type: descriptor.SET, Name: "set", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						10: {Name: "map", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}, Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						11: {Name: "struct", Type: &descriptor.TypeDescriptor{Type: descriptor.STRUCT}},
+					},
+				},
+			}, opt: &readerOption{setFieldsForEmptyStruct: 1}},
+			map[string]interface{}{
+				"string": "",
+				"byte":   byte(0),
+				"i8":     int8(0),
+				"i16":    int16(0),
+				"i32":    int32(0),
+				"i64":    int64(0),
+				"double": float64(0),
+				"list":   []string(nil),
+				"set":    []string(nil),
+				"map":    map[string]string(nil),
+				"struct": map[string]interface{}(nil),
+			},
+			false,
+		},
+		{
+			"readStruct with setFieldsForEmptyStruct optional",
+			args{in: mockTTransport2, t: &descriptor.TypeDescriptor{
+				Type: descriptor.STRUCT,
+				Struct: &descriptor.StructDescriptor{
+					FieldsByID: map[int32]*descriptor.FieldDescriptor{
+						1:  {Name: "string", Type: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}},
+						2:  {Name: "byte", Type: &descriptor.TypeDescriptor{Type: descriptor.BYTE, Name: "byte"}, Optional: true},
+						3:  {Name: "i8", Type: &descriptor.TypeDescriptor{Type: descriptor.I08, Name: "i8"}},
+						4:  {Name: "i16", Type: &descriptor.TypeDescriptor{Type: descriptor.I16, Name: "i16"}},
+						5:  {Name: "i32", Type: &descriptor.TypeDescriptor{Type: descriptor.I32, Name: "i32"}},
+						6:  {Name: "i64", Type: &descriptor.TypeDescriptor{Type: descriptor.I64, Name: "i64"}},
+						7:  {Name: "double", Type: &descriptor.TypeDescriptor{Type: descriptor.DOUBLE, Name: "double"}},
+						8:  {Name: "list", Type: &descriptor.TypeDescriptor{Type: descriptor.LIST, Name: "list", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						9:  {Name: "set", Type: &descriptor.TypeDescriptor{Type: descriptor.SET, Name: "set", Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						10: {Name: "map", Type: &descriptor.TypeDescriptor{Type: descriptor.MAP, Name: "map", Key: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}, Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING, Name: "string"}}},
+						11: {Name: "struct", Type: &descriptor.TypeDescriptor{Type: descriptor.STRUCT}, Optional: true},
+					},
+				},
+			}, opt: &readerOption{setFieldsForEmptyStruct: 1}},
+			map[string]interface{}{
+				"string": "",
+				"i8":     int8(0),
+				"i16":    int16(0),
+				"i32":    int32(0),
+				"i64":    int64(0),
+				"double": float64(0),
+				"list":   []string(nil),
+				"set":    []string(nil),
+				"map":    map[string]string(nil),
+			},
+			false,
+		},
 		{
 			"readStruct",
 			args{in: mockTTransport, t: &descriptor.TypeDescriptor{

--- a/pkg/generic/thrift/struct.go
+++ b/pkg/generic/thrift/struct.go
@@ -82,11 +82,12 @@ func NewReadStructForJSON(svc *descriptor.ServiceDescriptor, isClient bool) *Rea
 
 // ReadStruct implement of MessageReaderWithMethod
 type ReadStruct struct {
-	svc                 *descriptor.ServiceDescriptor
-	isClient            bool
-	forJSON             bool
-	binaryWithBase64    bool
-	binaryWithByteSlice bool
+	svc                     *descriptor.ServiceDescriptor
+	isClient                bool
+	forJSON                 bool
+	binaryWithBase64        bool
+	binaryWithByteSlice     bool
+	setFieldsForEmptyStruct uint8
 }
 
 var _ MessageReader = (*ReadStruct)(nil)
@@ -96,6 +97,15 @@ var _ MessageReader = (*ReadStruct)(nil)
 func (m *ReadStruct) SetBinaryOption(base64, byteSlice bool) {
 	m.binaryWithBase64 = base64
 	m.binaryWithByteSlice = byteSlice
+}
+
+// SetBinaryOption enable/disable set all fields in map-generic even if a struct is empty
+//
+//	mode == 0 means disable
+//	mode == 1 means only set required and default fields
+//	mode == 2 means set all fields
+func (m *ReadStruct) SetSetFieldsForEmptyStruct(mode uint8) {
+	m.setFieldsForEmptyStruct = mode
 }
 
 // Read ...
@@ -108,5 +118,5 @@ func (m *ReadStruct) Read(ctx context.Context, method string, in thrift.TProtoco
 	if !m.isClient {
 		fDsc = fnDsc.Request
 	}
-	return skipStructReader(ctx, in, fDsc, &readerOption{throwException: true, forJSON: m.forJSON, binaryWithBase64: m.binaryWithBase64, binaryWithByteSlice: m.binaryWithByteSlice})
+	return skipStructReader(ctx, in, fDsc, &readerOption{throwException: true, forJSON: m.forJSON, binaryWithBase64: m.binaryWithBase64, binaryWithByteSlice: m.binaryWithByteSlice, setFieldsForEmptyStruct: m.setFieldsForEmptyStruct})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: to be compatible with behaviors of real go struct, support set fields of a empty struct (actual map[string]interface{}) in map generic calls
zh(optional): 为了实现与真正的go结构体行为一致，在map泛化调用中支持设置空 struct（实际上是map[string]interface{})的字段

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->