### PR TITLE
fix: OnError call twice in svrTransHandler.OnRead

### DIFF
--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -172,7 +172,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 	ctx, err = t.transPipe.Read(ctx, conn, recvMsg)
 	if err != nil {
 		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
-		t.OnError(ctx, err, conn)
+		// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
 		return err
 	}
 
@@ -188,8 +188,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 		if methodInfo, err = GetMethodInfo(ri, svcInfo); err != nil {
 			// it won't be err, because the method has been checked in decode, err check here just do defensive inspection
 			t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true)
-			// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded
-			t.OnError(ctx, err, conn)
+			// for proxy case, need read actual remoteAddr, error print must exec after writeErrorReplyIfNeeded,
+			// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
 			return err
 		}
 		if methodInfo.OneWay() {
@@ -214,7 +214,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 
 	remote.FillSendMsgFromRecvMsg(recvMsg, sendMsg)
 	if ctx, err = t.transPipe.Write(ctx, conn, sendMsg); err != nil {
-		t.OnError(ctx, err, conn)
+		// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
 		return err
 	}
 	return


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix: svrTransHandler.OnError will be called twice when some error occured in svrTransHandler.OnRead 
 related issue：https://github.com/cloudwego/kitex/issues/1267

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复 OnError 在 svrTransHandler.OnRead 中调用两次

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
##### 什么原因造成的
在这个已经合入的PR中，https://github.com/cloudwego/kitex/pull/814
err由nil变为传递给外层
![image](https://github.com/cloudwego/kitex/assets/61727602/9c2aae0b-d1be-4c78-977f-34d58efb56f4)
err被传递给外层，但是实际上外层的server是默认会对err进行处理的：
![image](https://github.com/cloudwego/kitex/assets/61727602/52bc9c2f-6a08-44b9-b3e1-59539cdde7c5)

![image](https://github.com/cloudwego/kitex/assets/61727602/c02578fe-366d-4b5c-af6c-0ea73b7a1553)
因此，err被处理了两次
##### 解决办法
内层不再处理err，传递给外层的server处理
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/cloudwego/kitex/issues/1267
