### PR TITLE
feat(generic): compatible with lossless conversion for int8-64

### DIFF
--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -132,6 +132,10 @@ func Test_writeInt8(t *testing.T) {
 				test.Assert(t, val == v)
 				return nil
 			},
+			WriteI16Func: func(val int16) error {
+				test.Assert(t, val == int16(v))
+				return nil
+			},
 		}
 	}
 	tests := []struct {
@@ -175,6 +179,18 @@ func Test_writeInt8(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "writeInt8 to i16",
+			args: args{
+				val: int8(2),
+				out: mockTTransport(2),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -730,7 +730,7 @@ func Test_writeInt64(t *testing.T) {
 			false,
 		},
 		{
-			"writeInt64ToInt8 Faild",
+			"writeInt64ToInt8 failed",
 			args{
 				val: int64(1000),
 				out: mockTTransport(1000),

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -37,6 +37,7 @@ import (
 )
 
 func Test_nextWriter(t *testing.T) {
+	// add some testcases
 	type args struct {
 		val interface{}
 		out thrift.TProtocol


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
泛化调用无损兼容 int8,int16,int32,int64间相互转换

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Previously, conversion from int32 to int8 and int16 was supported, but lossless conversion between ints was not fully supported.
zh(optional): 之前支持了 int32到int8，int16 的转换，但int之间的无损转换没有完全支持

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->