### PR TITLE
fix(grpc): identify kitex errors before conv in convertStatus

### DIFF
--- a/pkg/remote/trans/nphttp2/codes_test.go
+++ b/pkg/remote/trans/nphttp2/codes_test.go
@@ -27,10 +27,78 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 
+var _ error = (*mockError)(nil)
+
+type mockError struct{}
+
+func (m mockError) Error() string {
+	return "mock"
+}
+
 func TestConvertStatus(t *testing.T) {
-	test.Assert(t, convertStatus(nil).Code() == codes.OK)
-	test.Assert(t, convertStatus(errors.New("mock")).Code() == codes.Internal)
-	test.Assert(t, convertStatus(status.Err(100, "mock")).Code() == 100)
-	test.Assert(t, convertStatus(remote.NewTransErrorWithMsg(100, "mock")).Code() == 100)
-	test.Assert(t, convertStatus(kerrors.ErrInternalException).Code() == codes.Internal)
+	t.Run("nil", func(t *testing.T) {
+		test.Assert(t, convertStatus(nil).Code() == codes.OK)
+	})
+
+	t.Run("Biz-GRPCStatusError", func(t *testing.T) {
+		err := kerrors.ErrBiz.WithCause(status.Err(100, "mock"))
+		test.Assert(t, convertStatus(err).Code() == 100)
+	})
+
+	t.Run("Biz-TransError", func(t *testing.T) {
+		transErr := remote.NewTransError(101, errors.New("mock_trans_err"))
+		err := kerrors.ErrBiz.WithCause(transErr)
+		test.Assert(t, convertStatus(err).Code() == 101)
+	})
+
+	t.Run("Biz-Other", func(t *testing.T) {
+		err := kerrors.ErrBiz.WithCause(errors.New("mock"))
+		test.Assert(t, convertStatus(err).Code() == codes.Internal)
+	})
+
+	t.Run("GRPCStatusError", func(t *testing.T) {
+		test.Assert(t, convertStatus(status.Err(102, "mock")).Code() == 102)
+	})
+
+	t.Run("TransError", func(t *testing.T) {
+		test.Assert(t, convertStatus(remote.NewTransErrorWithMsg(103, "mock")).Code() == 103)
+	})
+
+	t.Run("basicError-conv-table-ACL", func(t *testing.T) {
+		test.Assert(t, convertStatus(kerrors.ErrACL).Code() == codes.PermissionDenied)
+	})
+
+	t.Run("basicError-conv-table-ErrInternalException", func(t *testing.T) {
+		test.Assert(t, convertStatus(kerrors.ErrInternalException).Code() == codes.Internal)
+	})
+
+	t.Run("basicError-conv-table-OverLimit", func(t *testing.T) {
+		test.Assert(t, convertStatus(kerrors.ErrOverlimit).Code() == codes.ResourceExhausted)
+	})
+
+	t.Run("basicError-conv-table-RemoteOrNetwork", func(t *testing.T) {
+		test.Assert(t, convertStatus(kerrors.ErrRemoteOrNetwork).Code() == codes.Unavailable)
+	})
+
+	t.Run("basicError-unknown", func(t *testing.T) {
+		test.Assert(t, convertStatus(kerrors.ErrServiceDiscovery).Code() == codes.Internal)
+	})
+
+	t.Run("DetailedError-with-known-basicError", func(t *testing.T) {
+		err := kerrors.ErrACL.WithCause(errors.New("mock"))
+		test.Assert(t, convertStatus(err).Code() == codes.PermissionDenied)
+	})
+
+	t.Run("DetailedError-with-unknown-basicError", func(t *testing.T) {
+		err := kerrors.ErrServiceDiscovery.WithCause(errors.New("mock"))
+		test.Assert(t, convertStatus(err).Code() == codes.Internal)
+	})
+
+	t.Run("std-error", func(t *testing.T) {
+		test.Assert(t, convertStatus(errors.New("mock")).Code() == codes.Internal)
+	})
+
+	t.Run("user-defined-error", func(t *testing.T) {
+		test.Assert(t, convertStatus(&mockError{}).Code() == codes.Internal)
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: 在 convertStatus 转换 kitex errors 之前先校验类型

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->