### PR TITLE
feat(generic): compatible with lossless conversion for int8-64

### DIFF
--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -36,6 +36,191 @@ import (
 	"github.com/cloudwego/kitex/pkg/generic/proto"
 )
 
+func Test_nextWriter(t *testing.T) {
+	// add some testcases
+	type args struct {
+		val interface{}
+		out thrift.TProtocol
+		t   *descriptor.TypeDescriptor
+		opt *writerOption
+	}
+	mockTTransport := func(v int64) *mocks.MockThriftTTransport {
+		return &mocks.MockThriftTTransport{
+			WriteByteFunc: func(val int8) error {
+				test.Assert(t, val == int8(v))
+				return nil
+			},
+			WriteI16Func: func(val int16) error {
+				test.Assert(t, val == int16(v))
+				return nil
+			},
+			WriteI32Func: func(val int32) error {
+				test.Assert(t, val == int32(v))
+				return nil
+			},
+			WriteI64Func: func(val int64) error {
+				test.Assert(t, val == v)
+				return nil
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			"nextWriteri8 success",
+			args{
+				val: int8(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			false,
+		},
+		{
+			"nextWriteri16 success",
+			args{
+				val: int16(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			false,
+		},
+		{
+			"nextWriteri32 success",
+			args{
+				val: int32(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I32,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			false,
+		},
+		{
+			"nextWriteri64 success",
+			args{
+				val: int64(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I64,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			false,
+		},
+		{
+			"nextWriteri8 failed",
+			args{
+				val: 10000000,
+				out: mockTTransport(10000000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			true,
+		},
+		{
+			"nextWriteri16 failed",
+			args{
+				val: 10000000,
+				out: mockTTransport(10000000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			true,
+		},
+		{
+			"nextWriteri32 failed",
+			args{
+				val: 10000000,
+				out: mockTTransport(10000000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I32,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			true,
+		},
+		{
+			"nextWriteri64 failed",
+			args{
+				val: "10000000",
+				out: mockTTransport(10000000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I64,
+					Struct: &descriptor.StructDescriptor{},
+				},
+				opt: &writerOption{
+					requestBase:      &Base{},
+					binaryWithBase64: false,
+				},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			var writerfunc writer
+			if writerfunc, err = nextWriter(tt.args.val, tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
+				t.Errorf("nextWriter() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if writerfunc == nil {
+				t.Error("nextWriter() error = nil, but writerfunc == nil")
+				return
+			}
+			if err := writerfunc(context.Background(), tt.args.val, tt.args.out, tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
+				t.Errorf("writerfunc() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_writeVoid(t *testing.T) {
 	type args struct {
 		val interface{}
@@ -132,6 +317,10 @@ func Test_writeInt8(t *testing.T) {
 				test.Assert(t, val == v)
 				return nil
 			},
+			WriteI16Func: func(val int16) error {
+				test.Assert(t, val == int16(v))
+				return nil
+			},
 		}
 	}
 	tests := []struct {
@@ -175,6 +364,18 @@ func Test_writeInt8(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "writeInt8 to i16",
+			args: args{
+				val: int8(2),
+				out: mockTTransport(2),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -275,11 +476,21 @@ func Test_writeInt16(t *testing.T) {
 		t   *descriptor.TypeDescriptor
 		opt *writerOption
 	}
-	mockTTransport := &mocks.MockThriftTTransport{
-		WriteI16Func: func(val int16) error {
-			test.Assert(t, val == 1)
-			return nil
-		},
+	mockTTransport := func(v int64) *mocks.MockThriftTTransport {
+		return &mocks.MockThriftTTransport{
+			WriteI32Func: func(val int32) error {
+				test.Assert(t, val == int32(v))
+				return nil
+			},
+			WriteI16Func: func(val int16) error {
+				test.Assert(t, val == int16(v))
+				return nil
+			},
+			WriteByteFunc: func(val int8) error {
+				test.Assert(t, val == int8(v))
+				return nil
+			},
+		}
 	}
 	tests := []struct {
 		name    string
@@ -291,9 +502,45 @@ func Test_writeInt16(t *testing.T) {
 			"writeInt16",
 			args{
 				val: int16(1),
-				out: mockTTransport,
+				out: mockTTransport(1),
 				t: &descriptor.TypeDescriptor{
 					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt16toInt8 Success",
+			args{
+				val: int16(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt16toInt8 Failed",
+			args{
+				val: int16(10000),
+				out: mockTTransport(10000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			true,
+		},
+		{
+			"writeInt16toInt32 Success",
+			args{
+				val: int16(10000),
+				out: mockTTransport(10000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I32,
 					Struct: &descriptor.StructDescriptor{},
 				},
 			},
@@ -316,12 +563,27 @@ func Test_writeInt32(t *testing.T) {
 		t   *descriptor.TypeDescriptor
 		opt *writerOption
 	}
-	mockTTransport := &mocks.MockThriftTTransport{
-		WriteI32Func: func(val int32) error {
-			test.Assert(t, val == 1)
-			return nil
-		},
+	mockTTransport := func(v int64) *mocks.MockThriftTTransport {
+		return &mocks.MockThriftTTransport{
+			WriteI64Func: func(val int64) error {
+				test.Assert(t, val == v)
+				return nil
+			},
+			WriteI32Func: func(val int32) error {
+				test.Assert(t, val == int32(v))
+				return nil
+			},
+			WriteI16Func: func(val int16) error {
+				test.Assert(t, val == int16(v))
+				return nil
+			},
+			WriteByteFunc: func(val int8) error {
+				test.Assert(t, val == int8(v))
+				return nil
+			},
+		}
 	}
+
 	tests := []struct {
 		name    string
 		args    args
@@ -332,9 +594,69 @@ func Test_writeInt32(t *testing.T) {
 			"writeInt32",
 			args{
 				val: int32(1),
-				out: mockTTransport,
+				out: mockTTransport(1),
 				t: &descriptor.TypeDescriptor{
 					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt32",
+			args{
+				val: int32(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I32,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt32ToInt08 success",
+			args{
+				val: int32(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt32ToInt16 success",
+			args{
+				val: int32(1),
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt32ToInt16 failed",
+			args{
+				val: int32(100000),
+				out: mockTTransport(100000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I16,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			true,
+		},
+		{
+			"writeInt32ToInt64 Success",
+			args{
+				val: int32(10000000),
+				out: mockTTransport(10000000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I64,
 					Struct: &descriptor.StructDescriptor{},
 				},
 			},
@@ -357,11 +679,25 @@ func Test_writeInt64(t *testing.T) {
 		t   *descriptor.TypeDescriptor
 		opt *writerOption
 	}
-	mockTTransport := &mocks.MockThriftTTransport{
-		WriteI64Func: func(val int64) error {
-			test.Assert(t, val == 1)
-			return nil
-		},
+	mockTTransport := func(v int64) *mocks.MockThriftTTransport {
+		return &mocks.MockThriftTTransport{
+			WriteI64Func: func(val int64) error {
+				test.Assert(t, val == v)
+				return nil
+			},
+			WriteI32Func: func(val int32) error {
+				test.Assert(t, val == int32(v))
+				return nil
+			},
+			WriteI16Func: func(val int16) error {
+				test.Assert(t, val == int16(v))
+				return nil
+			},
+			WriteByteFunc: func(val int8) error {
+				test.Assert(t, val == int8(v))
+				return nil
+			},
+		}
 	}
 	tests := []struct {
 		name    string
@@ -373,13 +709,37 @@ func Test_writeInt64(t *testing.T) {
 			"writeInt64",
 			args{
 				val: int64(1),
-				out: mockTTransport,
+				out: mockTTransport(1),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I64,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			false,
+		},
+		{
+			"writeInt64ToInt8 Success",
+			args{
+				val: int64(1),
+				out: mockTTransport(1),
 				t: &descriptor.TypeDescriptor{
 					Type:   descriptor.I08,
 					Struct: &descriptor.StructDescriptor{},
 				},
 			},
 			false,
+		},
+		{
+			"writeInt64ToInt8 failed",
+			args{
+				val: int64(1000),
+				out: mockTTransport(1000),
+				t: &descriptor.TypeDescriptor{
+					Type:   descriptor.I08,
+					Struct: &descriptor.StructDescriptor{},
+				},
+			},
+			true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
泛化调用无损兼容 int8,int16,int32,int64间相互转换

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Previously, conversion from int32 to int8 and int16 was supported, but lossless conversion between ints was not fully supported.
zh(optional): 之前支持了 int32到int8，int16 的转换，但int之间的无损转换没有完全支持

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->