### PR TITLE
optimize: remove gen deep equal for less codegen

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -131,7 +131,6 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"naming_style=golint",
 		"ignore_initialisms",
 		"gen_setter",
-		"gen_deep_equal",
 		"compatible_names",
 		"frugal_tag",
 		"thrift_streaming",


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
optimize: 删除 deep equal 的代码生成以减小产物体积

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: The "deep equal" function consumes a significant amount of generated code size, but it improves performance when checking for set deduplication. However, in the majority of scenarios, it is not necessary. Without generating the "deep equal" function, set deduplication will use the "reflect.DeepEqual" method instead, which slightly reduces performance but significantly decreases the default generated code size.
zh(optional): deep equal函数会占用很多代码生成的体积，但在set去重检查时提升性能，绝大部分场景用不到。不生成 deep equal 后，set去重会改为reflect.DeepEqual 方法，性能略有下降，但默认的代码生成体积能大幅度下降

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->