### PR TITLE
feat: add option to specify ip version for default HTTPResolver

### DIFF
--- a/pkg/http/resolver.go
+++ b/pkg/http/resolver.go
@@ -18,7 +18,6 @@
 package http
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"strconv"
@@ -58,7 +57,7 @@ func NewDefaultResolver() Resolver {
 // NewResolverWithIPPolicy creates a resolver with ip policy.
 func NewResolverWithIPPolicy(p IPPolicy) Resolver {
 	if !p.legal() {
-		panic(fmt.Sprintf("Illegal IP policy for resolver, at least one of v4, v6 should be enabled"))
+		panic("Illegal IP policy for resolver, at least one of v4, v6 should be enabled")
 	}
 	network := getNetwork(p)
 	return &defaultResolver{network}

--- a/pkg/http/resolver_test.go
+++ b/pkg/http/resolver_test.go
@@ -81,6 +81,7 @@ func TestResolverWithIPPolicy(t *testing.T) {
 	test.Assert(t, err == nil)
 	ip, err = parseIPPort(ipPort)
 	test.Assert(t, err == nil)
+	test.Assert(t, ip != nil)
 }
 
 func TestGetNetwork(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
zh: feat: default httpResolver 添加 ip 策略

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: If client uses `WithURL` to access a URL, kitex's Resolver will use dual stack ip policy. With the new added configuration, User can build a Resolver with ip policy using `NewResolverWithIPPolicy` and configure using `WithHTTPResolver` to resolve only ipv6.
zh(optional): 当用户使用 `WithURL` 访问 URL 时，kitex 默认的 Resolver 会使用v4/v6双栈进行解析。添加给配置后，用户可使用 `NewResolverWithIPPolicy` 方法来构造指定 ip 策略的 resolver，并用 `WithHTTPResolver` 进行配置，以支持仅解析 ipv6 地址。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->