### PR TITLE
feat(retry): add ctx param for customized result retry funcs

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -382,7 +382,7 @@ func WithRetryMethodPolicies(mp map[string]retry.Policy) Option {
 // But if your retry policy is enabled by remote config, WithSpecifiedResultRetry is useful.
 func WithSpecifiedResultRetry(rr *retry.ShouldResultRetry) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
-		if rr == nil || (rr.RespRetry == nil && rr.ErrorRetry == nil) {
+		if rr == nil || !rr.IsValid() {
 			panic(fmt.Errorf("WithSpecifiedResultRetry: invalid '%+v'", rr))
 		}
 		di.Push(fmt.Sprintf("WithSpecifiedResultRetry(%+v)", rr))

--- a/client/option_test.go
+++ b/client/option_test.go
@@ -57,26 +57,26 @@ func TestRetryOptionDebugInfo(t *testing.T) {
 	fp.WithDDLStop()
 	expectPolicyStr := "WithFailureRetry({StopPolicy:{MaxRetryTimes:2 MaxDurationMS:0 DisableChainStop:false DDLStop:true " +
 		"CBPolicy:{ErrorRate:0.1}} BackOffPolicy:&{BackOffType:none CfgItems:map[]} RetrySameNode:false ShouldResultRetry:{ErrorRetry:false, RespRetry:false}})"
-	policyStr := fmt.Sprintf("WithFailureRetry(%+v)", *fp)
+	policyStr := fmt.Sprintf("WithFailureRetry(%+v)", fp)
 	test.Assert(t, policyStr == expectPolicyStr, policyStr)
 
 	fp.WithFixedBackOff(10)
 	expectPolicyStr = "WithFailureRetry({StopPolicy:{MaxRetryTimes:2 MaxDurationMS:0 DisableChainStop:false DDLStop:true " +
 		"CBPolicy:{ErrorRate:0.1}} BackOffPolicy:&{BackOffType:fixed CfgItems:map[fix_ms:10]} RetrySameNode:false ShouldResultRetry:{ErrorRetry:false, RespRetry:false}})"
-	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", *fp)
+	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", fp)
 	test.Assert(t, policyStr == expectPolicyStr, policyStr)
 
 	fp.WithRandomBackOff(10, 20)
 	fp.DisableChainRetryStop()
 	expectPolicyStr = "WithFailureRetry({StopPolicy:{MaxRetryTimes:2 MaxDurationMS:0 DisableChainStop:true DDLStop:true " +
 		"CBPolicy:{ErrorRate:0.1}} BackOffPolicy:&{BackOffType:random CfgItems:map[max_ms:20 min_ms:10]} RetrySameNode:false ShouldResultRetry:{ErrorRetry:false, RespRetry:false}})"
-	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", *fp)
+	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", fp)
 	test.Assert(t, policyStr == expectPolicyStr, policyStr)
 
 	fp.WithRetrySameNode()
 	expectPolicyStr = "WithFailureRetry({StopPolicy:{MaxRetryTimes:2 MaxDurationMS:0 DisableChainStop:true DDLStop:true " +
 		"CBPolicy:{ErrorRate:0.1}} BackOffPolicy:&{BackOffType:random CfgItems:map[max_ms:20 min_ms:10]} RetrySameNode:true ShouldResultRetry:{ErrorRetry:false, RespRetry:false}})"
-	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", *fp)
+	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", fp)
 	test.Assert(t, policyStr == expectPolicyStr, policyStr)
 
 	fp.WithSpecifiedResultRetry(&retry.ShouldResultRetry{ErrorRetry: func(err error, ri rpcinfo.RPCInfo) bool {
@@ -84,13 +84,13 @@ func TestRetryOptionDebugInfo(t *testing.T) {
 	}})
 	expectPolicyStr = "WithFailureRetry({StopPolicy:{MaxRetryTimes:2 MaxDurationMS:0 DisableChainStop:true DDLStop:true " +
 		"CBPolicy:{ErrorRate:0.1}} BackOffPolicy:&{BackOffType:random CfgItems:map[max_ms:20 min_ms:10]} RetrySameNode:true ShouldResultRetry:{ErrorRetry:true, RespRetry:false}})"
-	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", *fp)
+	policyStr = fmt.Sprintf("WithFailureRetry(%+v)", fp)
 	test.Assert(t, policyStr == expectPolicyStr, policyStr)
 
 	bp := retry.NewBackupPolicy(20)
 	expectPolicyStr = "WithBackupRequest({RetryDelayMS:20 StopPolicy:{MaxRetryTimes:1 MaxDurationMS:0 DisableChainStop:false " +
 		"DDLStop:false CBPolicy:{ErrorRate:0.1}} RetrySameNode:false})"
-	policyStr = fmt.Sprintf("WithBackupRequest(%+v)", *bp)
+	policyStr = fmt.Sprintf("WithBackupRequest(%+v)", bp)
 	test.Assert(t, policyStr == expectPolicyStr, policyStr)
 	WithBackupRequest(bp)
 }

--- a/pkg/retry/backup.go
+++ b/pkg/retry/backup.go
@@ -68,6 +68,6 @@ func (p *BackupPolicy) WithRetrySameNode() {
 }
 
 // String is used to print human readable debug info.
-func (p BackupPolicy) String() string {
+func (p *BackupPolicy) String() string {
 	return fmt.Sprintf("{RetryDelayMS:%+v StopPolicy:%+v RetrySameNode:%+v}", p.RetryDelayMS, p.StopPolicy, p.RetrySameNode)
 }

--- a/pkg/retry/backup_retryer.go
+++ b/pkg/retry/backup_retryer.go
@@ -209,7 +209,7 @@ func (r *backupRetryer) UpdatePolicy(rp Policy) (err error) {
 }
 
 // AppendErrMsgIfNeeded implements the Retryer interface.
-func (r *backupRetryer) AppendErrMsgIfNeeded(err error, ri rpcinfo.RPCInfo, msg string) {
+func (r *backupRetryer) AppendErrMsgIfNeeded(ctx context.Context, err error, ri rpcinfo.RPCInfo, msg string) {
 	if kerrors.IsTimeoutError(err) {
 		// Add additional reason to the error message when timeout occurs but the backup request is not sent.
 		appendErrMsg(err, msg)

--- a/pkg/retry/failure.go
+++ b/pkg/retry/failure.go
@@ -17,6 +17,7 @@
 package retry
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -112,14 +113,14 @@ func (p *FailurePolicy) WithSpecifiedResultRetry(rr *ShouldResultRetry) {
 }
 
 // String prints human readable information.
-func (p FailurePolicy) String() string {
+func (p *FailurePolicy) String() string {
 	return fmt.Sprintf("{StopPolicy:%+v BackOffPolicy:%+v RetrySameNode:%+v "+
 		"ShouldResultRetry:{ErrorRetry:%t, RespRetry:%t}}", p.StopPolicy, p.BackOffPolicy, p.RetrySameNode, p.IsErrorRetryNonNil(), p.IsRespRetryNonNil())
 }
 
 // AllErrorRetry is common choice for ShouldResultRetry.
 func AllErrorRetry() *ShouldResultRetry {
-	return &ShouldResultRetry{ErrorRetry: func(err error, ri rpcinfo.RPCInfo) bool {
+	return &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
 		return err != nil
 	}}
 }

--- a/pkg/retry/policy.go
+++ b/pkg/retry/policy.go
@@ -358,6 +358,10 @@ func (p *BackOffPolicy) copyCfgItems() map[BackOffCfgKey]float64 {
 	return cfgItems
 }
 
+func (rr *ShouldResultRetry) IsValid() bool {
+	return rr.ErrorRetryWithCtx != nil || rr.RespRetryWithCtx != nil || rr.RespRetry != nil || rr.ErrorRetry != nil
+}
+
 func checkCBErrorRate(p *CBPolicy) error {
 	if p.ErrorRate <= 0 || p.ErrorRate > 0.3 {
 		return fmt.Errorf("invalid retry circuit breaker rate, errRate=%0.2f", p.ErrorRate)

--- a/pkg/retry/retryer.go
+++ b/pkg/retry/retryer.go
@@ -47,7 +47,7 @@ type Retryer interface {
 
 	// Retry policy execute func. recycleRI is to decide if the firstRI can be recycled.
 	Do(ctx context.Context, rpcCall RPCCallFunc, firstRI rpcinfo.RPCInfo, request interface{}) (lastRI rpcinfo.RPCInfo, recycleRI bool, err error)
-	AppendErrMsgIfNeeded(err error, ri rpcinfo.RPCInfo, msg string)
+	AppendErrMsgIfNeeded(ctx context.Context, err error, ri rpcinfo.RPCInfo, msg string)
 
 	// Prepare to do something needed before retry call.
 	Prepare(ctx context.Context, prevRI, retryRI rpcinfo.RPCInfo)
@@ -339,7 +339,7 @@ func (rc *Container) WithRetryIfNeeded(ctx context.Context, callOptRetry *Policy
 			return ri, true, err
 		}
 		if msg != "" {
-			retryer.AppendErrMsgIfNeeded(err, ri, msg)
+			retryer.AppendErrMsgIfNeeded(ctx, err, ri, msg)
 		}
 		return ri, false, err
 	}

--- a/pkg/retry/retryer_test.go
+++ b/pkg/retry/retryer_test.go
@@ -325,7 +325,7 @@ func TestContainer_Dump(t *testing.T) {
 	test.Assert(t, err == nil, err)
 	test.Assert(t, hasCodeCfg == "true")
 	testStr, err = jsoni.MarshalToString(rcDump["test"])
-	msg = `{"enable":true,"failure_retry":{"stop_policy":{"max_retry_times":2,"max_duration_ms":0,"disable_chain_stop":false,"ddl_stop":false,"cb_policy":{"error_rate":0.1}},"backoff_policy":{"backoff_type":"none"},"retry_same_node":false,"extra":""},"specified_result_retry":{"error_retry":false,"resp_retry":false}}`
+	msg = `{"enable":true,"failure_retry":{"stop_policy":{"max_retry_times":2,"max_duration_ms":0,"disable_chain_stop":false,"ddl_stop":false,"cb_policy":{"error_rate":0.1}},"backoff_policy":{"backoff_type":"none"},"retry_same_node":false,"extra":""},"specified_result_retry":{"error_retry":false,"old_error_retry":false,"old_resp_retry":false,"resp_retry":false}}`
 	test.Assert(t, err == nil, err)
 	test.Assert(t, testStr == msg, testStr)
 }
@@ -593,6 +593,278 @@ func TestSpecifiedRespRetry(t *testing.T) {
 	test.Assert(t, !ok)
 }
 
+// test specified error to retry with ErrorRetryWithCtx
+func TestSpecifiedErrorRetryWithCtx(t *testing.T) {
+	retryWithTransError := func(callTimes int32) RPCCallFunc {
+		// fails for the first call if callTimes is initialized to 0
+		return func(ctx context.Context, r Retryer) (rpcinfo.RPCInfo, interface{}, error) {
+			newVal := atomic.AddInt32(&callTimes, 1)
+			if newVal == 1 {
+				return genRPCInfo(), nil, remote.NewTransErrorWithMsg(1000, "mock")
+			} else {
+				return genRPCInfoWithRemoteTag(remoteTags), nil, nil
+			}
+		}
+	}
+	ri := genRPCInfo()
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+
+	// case1: specified method retry with error
+	t.Run("case1", func(t *testing.T) {
+		rc := NewRetryContainer()
+		shouldResultRetry := &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
+			if ri.To().Method() == method {
+				if te, ok := err.(*remote.TransError); ok && te.TypeID() == 1000 {
+					return true
+				}
+			}
+			return false
+		}}
+		err := rc.Init(map[string]Policy{Wildcard: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+		test.Assert(t, err == nil, err)
+		ri, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithTransError(0), ri, nil)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, !ok)
+		v, ok := ri.To().Tag(remoteTagKey)
+		test.Assert(t, ok)
+		test.Assert(t, v == remoteTagValue)
+	})
+
+	// case2: specified method retry with error, but use backup request config cannot be effective
+	t.Run("case2", func(t *testing.T) {
+		shouldResultRetry := &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
+			if ri.To().Method() == method {
+				if te, ok := err.(*remote.TransError); ok && te.TypeID() == 1000 {
+					return true
+				}
+			}
+			return false
+		}}
+		rc := NewRetryContainer()
+		err := rc.Init(map[string]Policy{Wildcard: BuildBackupRequest(NewBackupPolicy(10))}, shouldResultRetry)
+		test.Assert(t, err == nil, err)
+		ri = genRPCInfo()
+		_, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithTransError(0), ri, nil)
+		test.Assert(t, err != nil, err)
+		test.Assert(t, !ok)
+	})
+
+	// case3: specified method retry with error, but method not match
+	t.Run("case3", func(t *testing.T) {
+		shouldResultRetry := &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
+			return ri.To().Method() != method
+		}}
+		rc := NewRetryContainer()
+		err := rc.Init(map[string]Policy{method: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+		test.Assert(t, err == nil, err)
+		ri = genRPCInfo()
+		ri, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithTransError(0), ri, nil)
+		test.Assert(t, err != nil)
+		test.Assert(t, !ok)
+		_, ok = ri.To().Tag(remoteTagKey)
+		test.Assert(t, !ok)
+	})
+
+	// case4: all error retry
+	t.Run("case4", func(t *testing.T) {
+		rc := NewRetryContainer()
+		p := BuildFailurePolicy(NewFailurePolicyWithResultRetry(AllErrorRetry()))
+		ri = genRPCInfo()
+		ri, ok, err := rc.WithRetryIfNeeded(ctx, &p, retryWithTransError(0), ri, nil)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, !ok)
+		v, ok := ri.To().Tag(remoteTagKey)
+		test.Assert(t, ok)
+		test.Assert(t, v == remoteTagValue)
+	})
+
+	// case5: specified method retry with error, only ctx has some info then retry
+	ctxKeyVal := "ctxKeyVal"
+	t.Run("case5", func(t *testing.T) {
+		shouldResultRetry := &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
+			val := ctx.Value(ctxKeyVal)
+			if ri.To().Method() == method && val == ctxKeyVal {
+				if te, ok := err.(*remote.TransError); ok && te.TypeID() == 1000 {
+					return true
+				}
+			}
+			return false
+		}}
+		rc := NewRetryContainer()
+		err := rc.Init(map[string]Policy{method: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+		test.Assert(t, err == nil, err)
+		ri = genRPCInfo()
+		ctx = context.WithValue(ctx, ctxKeyVal, ctxKeyVal)
+		ri, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithTransError(0), ri, nil)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, !ok)
+		v, ok := ri.To().Tag(remoteTagKey)
+		test.Assert(t, ok)
+		test.Assert(t, v == remoteTagValue)
+	})
+}
+
+// test specified error to retry, but has both old and new policy, the new one will be effective
+func TestSpecifiedErrorRetryHasOldAndNew(t *testing.T) {
+	retryWithTransError := func(callTimes int32) RPCCallFunc {
+		// fails for the first call if callTimes is initialized to 0
+		return func(ctx context.Context, r Retryer) (rpcinfo.RPCInfo, interface{}, error) {
+			newVal := atomic.AddInt32(&callTimes, 1)
+			if newVal == 1 {
+				return genRPCInfo(), nil, remote.NewTransErrorWithMsg(1000, "mock")
+			} else {
+				return genRPCInfoWithRemoteTag(remoteTags), nil, nil
+			}
+		}
+	}
+	ri := genRPCInfo()
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+
+	// case1: ErrorRetryWithCtx will retry, but ErrorRetry not retry, the expect result is do retry
+	t.Run("case1", func(t *testing.T) {
+		rc := NewRetryContainer()
+		shouldResultRetry := &ShouldResultRetry{
+			ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
+				return true
+			},
+			ErrorRetry: func(err error, ri rpcinfo.RPCInfo) bool {
+				return false
+			},
+		}
+		err := rc.Init(map[string]Policy{Wildcard: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+		test.Assert(t, err == nil, err)
+		ri, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithTransError(0), ri, nil)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, !ok)
+		v, ok := ri.To().Tag(remoteTagKey)
+		test.Assert(t, ok)
+		test.Assert(t, v == remoteTagValue)
+	})
+
+	// case2: ErrorRetryWithCtx not retry, but ErrorRetry retry, the expect result is that not do retry
+	t.Run("case2", func(t *testing.T) {
+		shouldResultRetry := &ShouldResultRetry{
+			ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
+				return false
+			},
+			ErrorRetry: func(err error, ri rpcinfo.RPCInfo) bool {
+				return true
+			},
+		}
+		rc := NewRetryContainer()
+		err := rc.Init(map[string]Policy{Wildcard: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+		test.Assert(t, err == nil, err)
+		ri, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithTransError(0), ri, nil)
+		test.Assert(t, err != nil)
+		test.Assert(t, !ok)
+		_, ok = ri.To().Tag(remoteTagKey)
+		test.Assert(t, !ok)
+	})
+}
+
+// test specified resp to retry with ErrorRetryWithCtx
+func TestSpecifiedRespRetryWithCtx(t *testing.T) {
+	retryResult := &mockResult{}
+	retryResp := mockResp{
+		code: 500,
+		msg:  "retry",
+	}
+	noRetryResp := mockResp{
+		code: 0,
+		msg:  "noretry",
+	}
+	var callTimes int32
+	retryWithResp := func(ctx context.Context, r Retryer) (rpcinfo.RPCInfo, interface{}, error) {
+		newVal := atomic.AddInt32(&callTimes, 1)
+		if newVal == 1 {
+			retryResult.SetResult(retryResp)
+			return genRPCInfo(), retryResult, nil
+		} else {
+			retryResult.SetResult(noRetryResp)
+			return genRPCInfoWithRemoteTag(remoteTags), retryResult, nil
+		}
+	}
+	ctx := context.Background()
+	ri := genRPCInfo()
+	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
+	rc := NewRetryContainer()
+	// case1: specified method retry with resp
+	shouldResultRetry := &ShouldResultRetry{RespRetryWithCtx: func(ctx context.Context, resp interface{}, ri rpcinfo.RPCInfo) bool {
+		if ri.To().Method() == method {
+			if r, ok := resp.(*mockResult); ok && r.GetResult() == retryResp {
+				return true
+			}
+		}
+		return false
+	}}
+	err := rc.Init(map[string]Policy{Wildcard: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+	test.Assert(t, err == nil, err)
+	ri, ok, err := rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithResp, ri, nil)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, retryResult.GetResult() == noRetryResp, retryResult)
+	test.Assert(t, !ok)
+	v, ok := ri.To().Tag(remoteTagKey)
+	test.Assert(t, ok)
+	test.Assert(t, v == remoteTagValue)
+
+	// case2 specified method retry with resp, but use backup request config cannot be effective
+	atomic.StoreInt32(&callTimes, 0)
+	rc = NewRetryContainer()
+	err = rc.Init(map[string]Policy{Wildcard: BuildBackupRequest(NewBackupPolicy(100))}, shouldResultRetry)
+	test.Assert(t, err == nil, err)
+	ri = genRPCInfo()
+	ctx = rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+	_, ok, err = rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithResp, ri, nil)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, retryResult.GetResult() == retryResp, retryResp)
+	test.Assert(t, !ok)
+
+	// case3: specified method retry with resp, but method not match
+	atomic.StoreInt32(&callTimes, 0)
+	shouldResultRetry = &ShouldResultRetry{RespRetryWithCtx: func(ctx context.Context, resp interface{}, ri rpcinfo.RPCInfo) bool {
+		if ri.To().Method() != method {
+			if r, ok := resp.(*mockResult); ok && r.GetResult() == retryResp {
+				return true
+			}
+		}
+		return false
+	}}
+	rc = NewRetryContainer()
+	err = rc.Init(map[string]Policy{method: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry)
+	test.Assert(t, err == nil, err)
+	ri = genRPCInfo()
+	ctx = rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+	ri, ok, err = rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithResp, ri, nil)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, retryResult.GetResult() == retryResp, retryResult)
+	test.Assert(t, ok)
+	_, ok = ri.To().Tag(remoteTagKey)
+	test.Assert(t, !ok)
+
+	// case4: specified method retry with resp, only ctx has some info then retry
+	ctxKeyVal := "ctxKeyVal"
+	atomic.StoreInt32(&callTimes, 0)
+	shouldResultRetry2 := &ShouldResultRetry{RespRetryWithCtx: func(ctx context.Context, resp interface{}, ri rpcinfo.RPCInfo) bool {
+		val := ctx.Value(ctxKeyVal)
+		if ri.To().Method() == method && val == ctxKeyVal {
+			if r, ok := resp.(*mockResult); ok && r.GetResult() == retryResp {
+				return true
+			}
+		}
+		return false
+	}}
+	err = rc.Init(map[string]Policy{Wildcard: BuildFailurePolicy(NewFailurePolicy())}, shouldResultRetry2)
+	test.Assert(t, err == nil, err)
+	ctx = context.WithValue(ctx, ctxKeyVal, ctxKeyVal)
+	ri, ok, err = rc.WithRetryIfNeeded(ctx, &Policy{}, retryWithResp, ri, nil)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, retryResult.GetResult() == noRetryResp, retryResult)
+	test.Assert(t, !ok)
+	v, ok = ri.To().Tag(remoteTagKey)
+	test.Assert(t, ok)
+	test.Assert(t, v == remoteTagValue)
+}
+
 // test different method use different retry policy
 func TestDifferentMethodConfig(t *testing.T) {
 	var callTimes int32
@@ -664,6 +936,34 @@ func TestDifferentMethodConfig(t *testing.T) {
 func TestResultRetryWithPolicyChange(t *testing.T) {
 	rc := NewRetryContainer()
 	shouldResultRetry := &ShouldResultRetry{ErrorRetry: func(err error, ri rpcinfo.RPCInfo) bool {
+		if ri.To().Method() == method {
+			if te, ok := err.(*remote.TransError); ok && te.TypeID() == 1000 {
+				return true
+			}
+		}
+		return false
+	}}
+	err := rc.Init(nil, shouldResultRetry)
+	test.Assert(t, err == nil, err)
+
+	// case 1: first time trigger NotifyPolicyChange, the `initRetryer` will be executed, check if the ShouldResultRetry is not nil
+	rc.NotifyPolicyChange(Wildcard, BuildFailurePolicy(NewFailurePolicy()))
+	r := rc.getRetryer(genRPCInfo())
+	fr, ok := r.(*failureRetryer)
+	test.Assert(t, ok)
+	test.Assert(t, fr.policy.ShouldResultRetry == shouldResultRetry)
+
+	// case 2: second time trigger NotifyPolicyChange, the `UpdatePolicy` will be executed, check if the ShouldResultRetry is not nil
+	rc.NotifyPolicyChange(Wildcard, BuildFailurePolicy(NewFailurePolicy()))
+	r = rc.getRetryer(genRPCInfo())
+	fr, ok = r.(*failureRetryer)
+	test.Assert(t, ok)
+	test.Assert(t, fr.policy.ShouldResultRetry == shouldResultRetry)
+}
+
+func TestResultRetryWithCtxWhenPolicyChange(t *testing.T) {
+	rc := NewRetryContainer()
+	shouldResultRetry := &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
 		if ri.To().Method() == method {
 			if te, ok := err.(*remote.TransError); ok && te.TypeID() == 1000 {
 				return true

--- a/pkg/retry/retryer_test.go
+++ b/pkg/retry/retryer_test.go
@@ -682,8 +682,7 @@ func TestSpecifiedErrorRetryWithCtx(t *testing.T) {
 	ctxKeyVal := "ctxKeyVal"
 	t.Run("case5", func(t *testing.T) {
 		shouldResultRetry := &ShouldResultRetry{ErrorRetryWithCtx: func(ctx context.Context, err error, ri rpcinfo.RPCInfo) bool {
-			val := ctx.Value(ctxKeyVal)
-			if ri.To().Method() == method && val == ctxKeyVal {
+			if ri.To().Method() == method && ctx.Value(ctxKeyVal) == ctxKeyVal {
 				if te, ok := err.(*remote.TransError); ok && te.TypeID() == 1000 {
 					return true
 				}
@@ -845,8 +844,7 @@ func TestSpecifiedRespRetryWithCtx(t *testing.T) {
 	ctxKeyVal := "ctxKeyVal"
 	atomic.StoreInt32(&callTimes, 0)
 	shouldResultRetry2 := &ShouldResultRetry{RespRetryWithCtx: func(ctx context.Context, resp interface{}, ri rpcinfo.RPCInfo) bool {
-		val := ctx.Value(ctxKeyVal)
-		if ri.To().Method() == method && val == ctxKeyVal {
+		if ri.To().Method() == method && ctx.Value(ctxKeyVal) == ctxKeyVal {
 			if r, ok := resp.(*mockResult); ok && r.GetResult() == retryResp {
 				return true
 			}


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
zh: feat(retry): 自定义结果重试方法增加 ctx 参数

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->