### PR TITLE
fix(payloadCodec): replace the registered PayloadCodec if the type is same when using WithPayloadCodec for server-side

### DIFF
--- a/pkg/remote/codec/protobuf/protobuf.go
+++ b/pkg/remote/codec/protobuf/protobuf.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/codec"
 	"github.com/cloudwego/kitex/pkg/remote/codec/perrors"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
 
 /**
@@ -48,6 +49,12 @@ const (
 // NewProtobufCodec ...
 func NewProtobufCodec() remote.PayloadCodec {
 	return &protobufCodec{}
+}
+
+// IsProtobufCodec checks if the codec is protobufCodec
+func IsProtobufCodec(c remote.PayloadCodec) bool {
+	_, ok := c.(*protobufCodec)
+	return ok
 }
 
 // protobufCodec implements  PayloadMarshaler
@@ -210,7 +217,7 @@ func (c protobufCodec) Unmarshal(ctx context.Context, message remote.Message, in
 }
 
 func (c protobufCodec) Name() string {
-	return "protobuf"
+	return serviceinfo.Protobuf.String()
 }
 
 // MessageWriterWithContext  writes to output bytebuffer

--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/codec"
 	"github.com/cloudwego/kitex/pkg/remote/codec/perrors"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
 )
 
@@ -231,7 +232,7 @@ func validateMessageBeforeDecode(message remote.Message, seqID int32, methodName
 
 // Name implements the remote.PayloadCodec interface.
 func (c thriftCodec) Name() string {
-	return "thrift"
+	return serviceinfo.Thrift.String()
 }
 
 // MessageWriterWithContext write to thrift.TProtocol

--- a/server/option.go
+++ b/server/option.go
@@ -22,9 +22,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/cloudwego/kitex/pkg/remote/codec/protobuf"
-	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
-	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/localsession/backup"
 
 	internal_server "github.com/cloudwego/kitex/internal/server"
@@ -34,9 +31,12 @@ import (
 	"github.com/cloudwego/kitex/pkg/limiter"
 	"github.com/cloudwego/kitex/pkg/registry"
 	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/codec/protobuf"
+	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
 	"github.com/cloudwego/kitex/pkg/remote/trans/netpollmux"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
 	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/pkg/utils"


### PR DESCRIPTION
#### What type of PR is this?
<!--
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: 使用 WithPayloadCodec 设置的 PayloadCodec 如果是预注册的，则替换预注册的PayloadCodec

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): WithPayloadCodec 设置 PayloadCodec 后，会限定Server所有请求都用该 PayloadCodec，但如果设置的是预注册的PayloadCodec类型，是为了对预注册的PayloadCodec添加额外的配置，只需替换掉注册的 PayloadCodec。
如果不做此修改，在多 Service 场景，假如用户设置了 NewThriftCodecWithConfig 就会导致 Protobuf 的请求无法被解码。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->