### PR TITLE
fix: init default values when using liner allocator

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
@@ -514,6 +514,7 @@ const FieldFastReadMap = `
 		{{- $ctx := (.ValCtx.WithTarget $val).WithFieldMask $curFieldMask}}
 		{{- if $isStructVal}}
 		{{$val}} := &values[i]
+		{{$val}}.InitDefault()
 		{{- else}}
 		{{- $ctx = $ctx.WithDecl}}
 		{{- end}}
@@ -564,6 +565,7 @@ const FieldFastReadSet = `
 		{{- $ctx := (.ValCtx.WithTarget $val).WithFieldMask $curFieldMask}}
 		{{- if $isStructVal}}
 		{{$val}} := &values[i]
+		{{$val}}.InitDefault()
 		{{- else}}
 		{{- $ctx = $ctx.WithDecl}}
 		{{- end}}
@@ -614,6 +616,7 @@ const FieldFastReadList = `
 		{{- $ctx := (.ValCtx.WithTarget $val).WithFieldMask $curFieldMask}}
 		{{- if $isStructVal}}
 		{{$val}} := &values[i]
+		{{$val}}.InitDefault()
 		{{- else}}
 		{{- $ctx = $ctx.WithDecl}}
 		{{- end}}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

fix: 当使用线性分配容器元素时，初始化默认值

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->