### PR TITLE
fix(kitex tool): import unused protection when -module is not set

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/patcher.go
@@ -52,7 +52,7 @@ var protectionInsertionPoint = "KitexUnusedProtection"
 type patcher struct {
 	noFastAPI             bool
 	utils                 *golang.CodeUtils
-	module                string
+	packagePrefix         string
 	copyIDL               bool
 	version               string
 	record                bool
@@ -302,7 +302,7 @@ func (p *patcher) patch(req *plugin.Request) (patches []*plugin.Generated, err e
 		for path, alias := range p.libs {
 			imps[path] = alias
 		}
-		data.Imports = util.SortImports(imps, p.module)
+		data.Imports = util.SortImports(imps, p.packagePrefix)
 		data.Includes = p.extractLocalLibs(data.Imports)
 
 		// replace imports insert-pointer with newly rendered output
@@ -384,7 +384,7 @@ func getBashPath() string {
 
 func (p *patcher) extractLocalLibs(imports []util.Import) []util.Import {
 	ret := make([]util.Import, 0)
-	prefix := p.module + "/"
+	prefix := p.packagePrefix + "/"
 	// remove std libs and thrift to prevent duplicate import.
 	for _, v := range imports {
 		// local packages

--- a/tool/internal_pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/patcher.go
@@ -52,7 +52,7 @@ var protectionInsertionPoint = "KitexUnusedProtection"
 type patcher struct {
 	noFastAPI             bool
 	utils                 *golang.CodeUtils
-	packagePrefix         string
+	module                string
 	copyIDL               bool
 	version               string
 	record                bool
@@ -302,7 +302,7 @@ func (p *patcher) patch(req *plugin.Request) (patches []*plugin.Generated, err e
 		for path, alias := range p.libs {
 			imps[path] = alias
 		}
-		data.Imports = util.SortImports(imps, p.packagePrefix)
+		data.Imports = util.SortImports(imps, p.module)
 		data.Includes = p.extractLocalLibs(data.Imports)
 
 		// replace imports insert-pointer with newly rendered output
@@ -384,7 +384,7 @@ func getBashPath() string {
 
 func (p *patcher) extractLocalLibs(imports []util.Import) []util.Import {
 	ret := make([]util.Import, 0)
-	prefix := p.packagePrefix + "/"
+	prefix := p.module + "/"
 	// remove std libs and thrift to prevent duplicate import.
 	for _, v := range imports {
 		// local packages

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -119,7 +119,7 @@ func Run() int {
 	p := &patcher{
 		noFastAPI:             conv.Config.NoFastAPI,
 		utils:                 conv.Utils,
-		packagePrefix:         conv.Config.PackagePrefix,
+		module:                conv.Config.ModuleName,
 		copyIDL:               conv.Config.CopyIDL,
 		version:               conv.Config.Version,
 		record:                conv.Config.Record,
@@ -127,6 +127,10 @@ func Run() int {
 		deepCopyAPI:           conv.Config.DeepCopyAPI,
 		protocol:              conv.Config.Protocol,
 		handlerReturnKeepResp: conv.Config.HandlerReturnKeepResp,
+	}
+	// for cmd without
+	if p.module == "" {
+		p.module = conv.Config.PackagePrefix
 	}
 	patches, err := p.patch(req)
 	if err != nil {

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -119,7 +119,7 @@ func Run() int {
 	p := &patcher{
 		noFastAPI:             conv.Config.NoFastAPI,
 		utils:                 conv.Utils,
-		module:                conv.Config.ModuleName,
+		packagePrefix:         conv.Config.PackagePrefix,
 		copyIDL:               conv.Config.CopyIDL,
 		version:               conv.Config.Version,
 		record:                conv.Config.Record,


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复(kitex 工具)：当 -module 未设置时，引用 unused protection

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
If idl A includes another idl B, but does not refer to any element in B. Then the generated code in k-XXX.go would not import ```B.KitexUnuesdProtection```.
e.g.
- IDL:
```
namespace go test

include "base.thrift"

struct ApiReq {
    1: optional string req
}

struct ApiResp {
    1: optional string resp
}
```
- generated code:
```
// Code generated by Kitex v0.10.0. DO NOT EDIT.

package test

import (
	"bytes"
	"fmt"
	"kitex_gen/another"
	"reflect"
	"strings"

	"github.com/apache/thrift/lib/go/thrift"
	"github.com/cloudwego/kitex/pkg/protocol/bthrift"
)

// unused protection
var (
	_ = fmt.Formatter(nil)
	_ = (*bytes.Buffer)(nil)
	_ = (*strings.Builder)(nil)
	_ = reflect.Type(nil)
	_ = thrift.TProtocol(nil)
	_ = bthrift.BinaryWriter(nil)
)
```
There is no ```another.KitexUnusedProtection```.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->