### PR TITLE
fix(kitex tool): import unused protection when -module is not set

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -128,6 +128,10 @@ func Run() int {
 		protocol:              conv.Config.Protocol,
 		handlerReturnKeepResp: conv.Config.HandlerReturnKeepResp,
 	}
+	// for cmd without setting -module
+	if p.module == "" {
+		p.module = conv.Config.PackagePrefix
+	}
 	patches, err := p.patch(req)
 	if err != nil {
 		return conv.fail(fmt.Errorf("patch: %w", err))


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复(kitex 工具)：当 -module 未设置时，引用 unused protection

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
If idl A includes another idl B, but does not refer to any element in B. Then the generated code in k-XXX.go would not import ```B.KitexUnuesdProtection```.
e.g.
- IDL:
```
namespace go test

include "base.thrift"

struct ApiReq {
    1: optional string req
}

struct ApiResp {
    1: optional string resp
}
```
- generated code:
```
// Code generated by Kitex v0.10.0. DO NOT EDIT.

package test

import (
	"bytes"
	"fmt"
	"kitex_gen/another"
	"reflect"
	"strings"

	"github.com/apache/thrift/lib/go/thrift"
	"github.com/cloudwego/kitex/pkg/protocol/bthrift"
)

// unused protection
var (
	_ = fmt.Formatter(nil)
	_ = (*bytes.Buffer)(nil)
	_ = (*strings.Builder)(nil)
	_ = reflect.Type(nil)
	_ = thrift.TProtocol(nil)
	_ = bthrift.BinaryWriter(nil)
)
```
There is no ```another.KitexUnusedProtection```.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->