### PR TITLE
feat(tool): support generating multiple handlers for multiple services

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -128,6 +128,8 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"Skip dependency checking.")
 	f.BoolVar(&a.Rapid, "rapid", false,
 		"Use embedded thriftgo.")
+	f.StringVar(&a.Tpl, "tpl", "",
+		"Specify a kitex built-in template.")
 
 	a.RecordCmd = os.Args
 	a.Version = version

--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -128,8 +128,7 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"Skip dependency checking.")
 	f.BoolVar(&a.Rapid, "rapid", false,
 		"Use embedded thriftgo.")
-	f.StringVar(&a.BuiltinTpl, "tpl", "",
-		"Specify a kitex built-in template.")
+	f.Var(&a.BuiltinTpl, "tpl", "Specify kitex built-in template.")
 
 	a.RecordCmd = os.Args
 	a.Version = version

--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -128,7 +128,7 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"Skip dependency checking.")
 	f.BoolVar(&a.Rapid, "rapid", false,
 		"Use embedded thriftgo.")
-	f.StringVar(&a.Tpl, "tpl", "",
+	f.StringVar(&a.BuiltinTpl, "tpl", "",
 		"Specify a kitex built-in template.")
 
 	a.RecordCmd = os.Args

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -459,16 +459,20 @@ func (g *generator) GenerateService(pkg *PackageInfo) ([]*File, error) {
 			Ext:  ext.ExtendServer,
 		},
 		{
-			Name: InvokerFileName,
-			Path: util.JoinPath(output, InvokerFileName),
-			Text: tpl.InvokerTpl,
-			Ext:  ext.ExtendInvoker,
-		},
-		{
 			Name: ServiceFileName,
 			Path: util.JoinPath(output, svcPkg+".go"),
 			Text: tpl.ServiceTpl,
 		},
+	}
+
+	// do not generate invoker.go in service package by default
+	if g.Config.GenerateInvoker {
+		tasks = append(tasks, &Task{
+			Name: InvokerFileName,
+			Path: util.JoinPath(output, InvokerFileName),
+			Text: tpl.InvokerTpl,
+			Ext:  ext.ExtendInvoker,
+		})
 	}
 
 	var fs []*File

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -375,7 +375,10 @@ func (g *generator) GenerateMainPackage(pkg *PackageInfo) (fs []*File, err error
 		if err != nil {
 			return nil, err
 		}
-		fs = append(fs, f)
+		// when there is no new method, f would be nil
+		if f != nil {
+			fs = append(fs, f)
+		}
 	} else {
 		for _, svc := range pkg.Services {
 			// set the target service
@@ -385,7 +388,10 @@ func (g *generator) GenerateMainPackage(pkg *PackageInfo) (fs []*File, err error
 			if err != nil {
 				return nil, err
 			}
-			fs = append(fs, f)
+			// when there is no new method, f would be nil
+			if f != nil {
+				fs = append(fs, f)
+			}
 		}
 	}
 	return

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -293,7 +293,7 @@ func (c *Config) ApplyExtension() error {
 	return nil
 }
 
-func (c *Config) IsMultipleServicesTpl() bool {
+func (c *Config) IsUsingMultipleServicesTpl() bool {
 	return c.Tpl == MultipleServicesTpl
 }
 
@@ -346,7 +346,7 @@ func (g *generator) GenerateMainPackage(pkg *PackageInfo) (fs []*File, err error
 		},
 	}
 	if !g.Config.GenerateInvoker {
-		if !g.Config.IsMultipleServicesTpl() {
+		if !g.Config.IsUsingMultipleServicesTpl() {
 			tasks = append(tasks, &Task{
 				Name: MainFileName,
 				Path: util.JoinPath(g.OutputPath, MainFileName),
@@ -377,7 +377,7 @@ func (g *generator) GenerateMainPackage(pkg *PackageInfo) (fs []*File, err error
 		fs = append(fs, f)
 	}
 
-	if !g.Config.IsMultipleServicesTpl() {
+	if !g.Config.IsUsingMultipleServicesTpl() {
 		f, err := g.generateHandler(pkg, pkg.ServiceInfo, HandlerFileName)
 		if err != nil {
 			return nil, err
@@ -605,7 +605,7 @@ func (g *generator) setImports(name string, pkg *PackageInfo) {
 		}
 	case MainFileName:
 		pkg.AddImport("log", "log")
-		if !g.Config.IsMultipleServicesTpl() {
+		if !g.Config.IsUsingMultipleServicesTpl() {
 			pkg.AddImport(pkg.PkgRefName, util.JoinPath(pkg.ImportPath, strings.ToLower(pkg.ServiceName)))
 		} else {
 			pkg.AddImport("server", "github.com/cloudwego/kitex/server")

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -127,7 +127,6 @@ type Config struct {
 	FrugalPretouch        bool
 	ThriftPluginTimeLimit time.Duration
 	CompilerPath          string // specify the path of thriftgo or protoc
-	BuiltinTpl            string // specify the built-in template to use
 
 	ExtensionFile string
 	tmplExt       *TemplateExtension
@@ -145,6 +144,7 @@ type Config struct {
 
 	NoDependencyCheck bool
 	Rapid             bool
+	BuiltinTpl        string // specify the built-in template to use
 }
 
 // Pack packs the Config into a slice of "key=val" strings.

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -144,7 +144,7 @@ type Config struct {
 
 	NoDependencyCheck bool
 	Rapid             bool
-	BuiltinTpl        string // specify the built-in template to use
+	BuiltinTpl        util.StringSlice // specify the built-in template to use
 }
 
 // Pack packs the Config into a slice of "key=val" strings.
@@ -294,7 +294,12 @@ func (c *Config) ApplyExtension() error {
 }
 
 func (c *Config) IsUsingMultipleServicesTpl() bool {
-	return c.BuiltinTpl == MultipleServicesTpl
+	for _, part := range c.BuiltinTpl {
+		if part == MultipleServicesTpl {
+			return true
+		}
+	}
+	return false
 }
 
 // NewGenerator .

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -127,7 +127,7 @@ type Config struct {
 	FrugalPretouch        bool
 	ThriftPluginTimeLimit time.Duration
 	CompilerPath          string // specify the path of thriftgo or protoc
-	Tpl                   string // specify the template to use
+	BuiltinTpl            string // specify the built-in template to use
 
 	ExtensionFile string
 	tmplExt       *TemplateExtension
@@ -294,7 +294,7 @@ func (c *Config) ApplyExtension() error {
 }
 
 func (c *Config) IsUsingMultipleServicesTpl() bool {
-	return c.Tpl == MultipleServicesTpl
+	return c.BuiltinTpl == MultipleServicesTpl
 }
 
 // NewGenerator .

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -595,6 +595,7 @@ func (g *generator) setImports(name string, pkg *PackageInfo) {
 		if !g.Config.MultipleServices {
 			pkg.AddImport(pkg.PkgRefName, util.JoinPath(pkg.ImportPath, strings.ToLower(pkg.ServiceName)))
 		} else {
+			pkg.AddImport("server", "github.com/cloudwego/kitex/server")
 			for _, svc := range pkg.Services {
 				pkg.AddImport(svc.RefName, util.JoinPath(pkg.ImportPath, strings.ToLower(svc.ServiceName)))
 			}

--- a/tool/internal_pkg/generator/generator_test.go
+++ b/tool/internal_pkg/generator/generator_test.go
@@ -69,7 +69,7 @@ func TestConfig_Pack(t *testing.T) {
 		{
 			name:    "some",
 			fields:  fields{Features: []feature{feature(999)}, ThriftPluginTimeLimit: 30 * time.Second},
-			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "Tpl=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false"},
+			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "BuiltinTpl=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false"},
 		},
 	}
 	for _, tt := range tests {

--- a/tool/internal_pkg/generator/generator_test.go
+++ b/tool/internal_pkg/generator/generator_test.go
@@ -69,7 +69,7 @@ func TestConfig_Pack(t *testing.T) {
 		{
 			name:    "some",
 			fields:  fields{Features: []feature{feature(999)}, ThriftPluginTimeLimit: 30 * time.Second},
-			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "BuiltinTpl=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false"},
+			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false", "BuiltinTpl="},
 		},
 	}
 	for _, tt := range tests {

--- a/tool/internal_pkg/generator/generator_test.go
+++ b/tool/internal_pkg/generator/generator_test.go
@@ -69,7 +69,7 @@ func TestConfig_Pack(t *testing.T) {
 		{
 			name:    "some",
 			fields:  fields{Features: []feature{feature(999)}, ThriftPluginTimeLimit: 30 * time.Second},
-			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false"},
+			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "Tpl=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false"},
 		},
 	}
 	for _, tt := range tests {

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -37,6 +37,7 @@ type PackageInfo struct {
 	Namespace    string            // a dot-separated string for generating service package under kitex_gen
 	Dependencies map[string]string // package name => import path, used for searching imports
 	*ServiceInfo                   // the target service
+	Services     []*ServiceInfo    // all services defined in a IDL for multiple services scenario
 
 	// the following fields will be filled and used by the generator
 	Codec            string
@@ -106,6 +107,8 @@ type ServiceInfo struct {
 	Protocol              string
 	HandlerReturnKeepResp bool
 	UseThriftReflection   bool
+	// for multiple services scenario, the reference name for the service
+	RefName string
 }
 
 // AllMethods returns all methods that the service have.

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -109,6 +109,8 @@ type ServiceInfo struct {
 	UseThriftReflection   bool
 	// for multiple services scenario, the reference name for the service
 	RefName string
+	// identify whether this service would generate a corresponding handler.
+	GenerateHandler bool
 }
 
 // AllMethods returns all methods that the service have.

--- a/tool/internal_pkg/pluginmode/thriftgo/convertor.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/convertor.go
@@ -324,6 +324,9 @@ func (c *converter) convertTypes(req *plugin.Request) error {
 				return fmt.Errorf("%s: makeService '%s': %w", ast.Filename, svc.Name, err)
 			}
 			si.ServiceFilePath = ast.Filename
+			if ast == req.AST {
+				si.GenerateHandler = true
+			}
 			all[ast.Filename] = append(all[ast.Filename], si)
 			c.svc2ast[si] = ast
 		}
@@ -379,6 +382,7 @@ func (c *converter) convertTypes(req *plugin.Request) error {
 				Methods:         methods,
 				ServiceFilePath: ast.Filename,
 				HasStreaming:    hasStreaming,
+				GenerateHandler: true,
 			}
 
 			if c.IsHessian2() {

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -17,8 +17,9 @@ package thriftgo
 import (
 	"errors"
 	"fmt"
-	"github.com/cloudwego/kitex/tool/internal_pkg/log"
 	"os"
+
+	"github.com/cloudwego/kitex/tool/internal_pkg/log"
 
 	"github.com/cloudwego/thriftgo/plugin"
 

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -88,7 +88,7 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 			return conv.failResp(errors.New("no service defined in the IDL"))
 		}
 		if !conv.Config.IsUsingMultipleServicesTpl() {
-			// if -multiple-services is not set, specify the last service as the target service
+			// if -tpl multiple_services is not set, specify the last service as the target service
 			conv.Package.ServiceInfo = conv.Services[len(conv.Services)-1]
 		} else {
 			var svcs []*generator.ServiceInfo

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -87,7 +87,7 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 		if len(conv.Services) == 0 {
 			return conv.failResp(errors.New("no service defined in the IDL"))
 		}
-		if !conv.Config.IsMultipleServicesTpl() {
+		if !conv.Config.IsUsingMultipleServicesTpl() {
 			// if -multiple-services is not set, specify the last service as the target service
 			conv.Package.ServiceInfo = conv.Services[len(conv.Services)-1]
 		} else {

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cloudwego/kitex/tool/internal_pkg/log"
-
 	"github.com/cloudwego/thriftgo/plugin"
 
 	"github.com/cloudwego/kitex/tool/internal_pkg/generator"
@@ -125,7 +123,6 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 		Warnings: conv.Warnings,
 	}
 	for _, f := range files {
-		log.Warnf("f: %+v", f)
 		res.Contents = append(res.Contents, &plugin.Generated{
 			Name:    &f.Name,
 			Content: f.Content,

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -87,7 +87,7 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 		if len(conv.Services) == 0 {
 			return conv.failResp(errors.New("no service defined in the IDL"))
 		}
-		if !conv.Config.MultipleServices {
+		if !conv.Config.IsMultipleServicesTpl() {
 			// if -multiple-services is not set, specify the last service as the target service
 			conv.Package.ServiceInfo = conv.Services[len(conv.Services)-1]
 		} else {

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -87,7 +87,15 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 		if len(conv.Services) == 0 {
 			return conv.failResp(errors.New("no service defined in the IDL"))
 		}
-		conv.Package.ServiceInfo = conv.Services[len(conv.Services)-1]
+		if !conv.Config.MultipleServices {
+			// if -multiple-services is not set, specify the last service as the target service
+			conv.Package.ServiceInfo = conv.Services[len(conv.Services)-1]
+		} else {
+			conv.Package.Services = conv.Services
+			for _, svc := range conv.Package.Services {
+				svc.RefName = "service" + svc.ServiceName
+			}
+		}
 		fs, err := gen.GenerateMainPackage(&conv.Package)
 		if err != nil {
 			return conv.failResp(err)

--- a/tool/internal_pkg/tpl/main.go
+++ b/tool/internal_pkg/tpl/main.go
@@ -39,3 +39,37 @@ func main() {
     }
 }
 `
+
+var MainMultipleServicesTpl string = `package main
+
+import (
+    "github.com/cloudwego/kitex/pkg/server"
+
+	{{- range $path, $aliases := .Imports}}
+		{{- if not $aliases}}
+			"{{$path}}"
+		{{- else}}
+			{{- range $alias, $is := $aliases}}
+				{{$alias}} "{{$path}}"
+			{{- end}}
+		{{- end}}
+	{{- end}}
+)
+
+func main() {
+    svr := server.NewServer()
+
+    {{- range $idx, $svc := .Services}}
+    if err := {{$svc.RefName}}.RegisterService(svr, new({{$svc.ServiceName}}Impl)); err != nil {
+        panic(err)
+    }
+    {{- end}}
+
+    err := svr.Run()
+
+    if err != nil {
+        log.Println(err.Error())
+    }
+}
+
+`

--- a/tool/internal_pkg/tpl/main.go
+++ b/tool/internal_pkg/tpl/main.go
@@ -43,8 +43,6 @@ func main() {
 var MainMultipleServicesTpl string = `package main
 
 import (
-    "github.com/cloudwego/kitex/pkg/server"
-
 	{{- range $path, $aliases := .Imports}}
 		{{- if not $aliases}}
 			"{{$path}}"


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(工具): 在多 Service 场景下，支持生成多个 Handler

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
1. How to use
```kitex -tpl multiple_services```
2. generating code example
- idl
```
namespace go multiple.services.test

service A {
  string EchoA(1: string req)
}

service B {
  string EchoB(1: string req)
}

service C {
  string EchoC(1: string req)
}
```
- directory structure
  -handler_gen
  -script
  handler_A.go
  handler_B.go
  handler_C.go
  main.go
- handler content
Use handler_A.go as example
```
package main

import (
	"context"
)

// AImpl implements the last service interface defined in the IDL.
type AImpl struct{}

// EchoA implements the AImpl interface.
func (s *AImpl) EchoA(ctx context.Context, req string) (resp string, err error) {
	// TODO: Your code here...
	return
}
```
- main.go content
```
package main

import (
	serviceA "demo/kitex_gen/multiple/services/test/a"
	serviceB "demo/kitex_gen/multiple/services/test/b"
	serviceC "demo/kitex_gen/multiple/services/test/c"
	server "github.com/cloudwego/kitex/server"
	"log"
)

func main() {
	svr := server.NewServer()
	if err := serviceA.RegisterService(svr, new(AImpl)); err != nil {
		panic(err)
	}
	if err := serviceB.RegisterService(svr, new(BImpl)); err != nil {
		panic(err)
	}
	if err := serviceC.RegisterService(svr, new(CImpl)); err != nil {
		panic(err)
	}

	err := svr.Run()

	if err != nil {
		log.Println(err.Error())
	}
}
```
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->