### PR TITLE
fix(grpc): read status code when server returns both data frame and status for non server stream

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -98,7 +98,7 @@ func rpcTimeoutMW(mwCtx context.Context) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request, response interface{}) error {
 			ri := rpcinfo.GetRPCInfo(ctx)
-			if ri.Config().InteractionMode() == rpcinfo.Streaming {
+			if ri.Config().InteractionMode().IsStreaming() {
 				return next(ctx, request, response)
 			}
 

--- a/client/rpctimeout_test.go
+++ b/client/rpctimeout_test.go
@@ -108,7 +108,7 @@ func TestNewRPCTimeoutMW(t *testing.T) {
 
 	// 7. panic with streaming, panic won't be recovered in timeout mw, but it will be recoverd in client.Call
 	m = rpcinfo.AsMutableRPCConfig(c)
-	m.SetInteractionMode(rpcinfo.Streaming)
+	m.SetInteractionMode(rpcinfo.StreamingClient)
 	mw1 = rpctimeout.MiddlewareBuilder(0)(mwCtx)
 	mw2 = rpcTimeoutMW(mwCtx)
 	test.Panic(t, func() { mw1(mw2(panicEp))(ctx, nil, nil) })

--- a/client/stream.go
+++ b/client/stream.go
@@ -51,7 +51,7 @@ func (kc *kClient) Stream(ctx context.Context, method string, request, response 
 	var ri rpcinfo.RPCInfo
 	ctx, ri, _ = kc.initRPCInfo(ctx, method, 0, nil)
 
-	rpcinfo.AsMutableRPCConfig(ri.Config()).SetInteractionMode(rpcinfo.Streaming)
+	rpcinfo.AsMutableRPCConfig(ri.Config()).SetInteractionMode(rpcinfo.StreamingToInteractionMode(kc.getStreamingMode(ri)))
 	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
 
 	ctx = kc.opt.TracerCtl.DoStart(ctx, ri)

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -480,8 +480,8 @@ func (s *Stream) Read(p []byte) (n int, err error) {
 }
 
 // StreamWrite only used for unit test
-func StreamWrite(s *Stream, buffer *bytes.Buffer) {
-	s.write(recvMsg{buffer: buffer})
+func StreamWrite(s *Stream, buffer *bytes.Buffer, err error) {
+	s.write(recvMsg{buffer: buffer, err: err})
 }
 
 // CreateStream only used for unit test. Create an independent stream out of http2client / http2server

--- a/pkg/remote/trans/nphttp2/mocks_test.go
+++ b/pkg/remote/trans/nphttp2/mocks_test.go
@@ -395,11 +395,11 @@ func newMockServerTransport(npConn *mockNetpollConn) (grpc.ServerTransport, erro
 	return tr, err
 }
 
-func mockStreamRecv(s *grpc.Stream, data string) {
+func mockStreamRecv(s *grpc.Stream, data string, err error) {
 	buffer := new(bytes.Buffer)
 	buffer.Reset()
 	buffer.Write([]byte(data))
-	grpc.StreamWrite(s, buffer)
+	grpc.StreamWrite(s, buffer, err)
 }
 
 func newMockStreamRecvHelloRequest(s *grpc.Stream) {
@@ -407,7 +407,7 @@ func newMockStreamRecvHelloRequest(s *grpc.Stream) {
 	buffer := new(bytes.Buffer)
 	buffer.Reset()
 	buffer.Write(hdr)
-	grpc.StreamWrite(s, buffer)
+	grpc.StreamWrite(s, buffer, nil)
 }
 
 var _ remote.Message = &mockMessage{}

--- a/pkg/remote/trans/nphttp2/server_conn_test.go
+++ b/pkg/remote/trans/nphttp2/server_conn_test.go
@@ -45,7 +45,7 @@ func TestServerConn(t *testing.T) {
 	// test Read()
 	testStr := "1234567890"
 	testByte := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	mockStreamRecv(s, testStr)
+	mockStreamRecv(s, testStr, nil)
 	n, err := serverConn.Read(testByte)
 	test.Assert(t, err == nil, err)
 	test.Assert(t, n == len(testStr))

--- a/pkg/rpcinfo/rpcconfig.go
+++ b/pkg/rpcinfo/rpcconfig.go
@@ -50,11 +50,36 @@ const (
 
 type InteractionMode int32
 
+func (mode InteractionMode) IsStreaming() bool {
+	return mode == StreamingClient || mode == StreamingServer || mode == StreamingBidi
+}
+
+func (mode InteractionMode) IsServerStreaming() bool {
+	return mode == StreamingServer || mode == StreamingBidi
+}
+
 const (
-	PingPong  InteractionMode = 0
-	Oneway    InteractionMode = 1
-	Streaming InteractionMode = 2
+	PingPong        InteractionMode = 0
+	Oneway          InteractionMode = 1
+	StreamingClient InteractionMode = 2
+	StreamingServer InteractionMode = 3
+	StreamingBidi   InteractionMode = 4
 )
+
+// StreamingToInteractionMode converts streaming mode to interaction mode.
+func StreamingToInteractionMode(mode serviceinfo.StreamingMode) InteractionMode {
+	switch mode {
+	case serviceinfo.StreamingNone, serviceinfo.StreamingUnary:
+		return PingPong
+	case serviceinfo.StreamingClient:
+		return StreamingClient
+	case serviceinfo.StreamingServer:
+		return StreamingServer
+	case serviceinfo.StreamingBidirectional:
+		return StreamingBidi
+	}
+	return PingPong
+}
 
 // rpcConfig is a set of configurations used during RPC calls.
 type rpcConfig struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -170,7 +170,7 @@ func TestInitOrResetRPCInfo(t *testing.T) {
 	mc.SetTransportProtocol(transport.TTHeader)
 	mc.SetConnectTimeout(10 * time.Second)
 	mc.SetRPCTimeout(20 * time.Second)
-	mc.SetInteractionMode(rpcinfo.Streaming)
+	mc.SetInteractionMode(rpcinfo.StreamingClient)
 	mc.SetIOBufferSize(1024)
 	mc.SetReadWriteTimeout(30 * time.Second)
 
@@ -200,7 +200,7 @@ func TestInitOrResetRPCInfo(t *testing.T) {
 	test.Assert(t, ri.Config().TransportProtocol() == transport.TTHeader)
 	test.Assert(t, ri.Config().ConnectTimeout() == 10*time.Second)
 	test.Assert(t, ri.Config().RPCTimeout() == 20*time.Second)
-	test.Assert(t, ri.Config().InteractionMode() == rpcinfo.Streaming)
+	test.Assert(t, ri.Config().InteractionMode().IsStreaming())
 	test.Assert(t, ri.Config().IOBufferSize() == 1024)
 	test.Assert(t, ri.Config().ReadWriteTimeout() == rwTimeout)
 


### PR DESCRIPTION

#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->