### PR TITLE
fix: allow HEADERS frame with empty header block fragment

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_parser.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_parser.go
@@ -170,7 +170,8 @@ func parseHeadersFrame(_ *frameCache, fh http2.FrameHeader, p []byte) (_ http2.F
 			return nil, err
 		}
 	}
-	if len(p)-int(padLength) <= 0 {
+	// note: len(p)-int(padLength) == 0 is valid
+	if len(p)-int(padLength) < 0 {
 		return nil, http2.StreamError{StreamID: fh.StreamID, Code: http2.ErrCodeProtocol}
 	}
 	hf.headerFragBuf = p[:len(p)-int(padLength)]


### PR DESCRIPTION
#### What type of PR is this?
fix: Allow HEADERS frame with empty header block fragment
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Some protocol implementations use HEADERS frame with empty header block fragment to carry END_STREAM flag(for example hyper in rust). This is valid acroading to http2 rfc. However, this causes kitex returning protocol error for gRPC.
This PR fixes it.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->