### PR TITLE
fix(streaming): resolve ctx diverge in server-side streaming

### DIFF
--- a/internal/mocks/serviceinfo.go
+++ b/internal/mocks/serviceinfo.go
@@ -36,6 +36,7 @@ const (
 	MockExceptionMethod string = "mockException"
 	MockErrorMethod     string = "mockError"
 	MockOnewayMethod    string = "mockOneway"
+	MockStreamingMethod string = "mockStreaming"
 )
 
 // ServiceInfo return mock serviceInfo

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -485,7 +485,7 @@ func StreamWrite(s *Stream, buffer *bytes.Buffer) {
 }
 
 // CreateStream only used for unit test. Create an independent stream out of http2client / http2server
-func CreateStream(id uint32, requestRead func(i int)) *Stream {
+func CreateStream(ctx context.Context, id uint32, requestRead func(i int), method string) *Stream {
 	recvBuffer := newRecvBuffer()
 	trReader := &transportReader{
 		reader: &recvBufferReader{
@@ -499,6 +499,8 @@ func CreateStream(id uint32, requestRead func(i int)) *Stream {
 
 	stream := &Stream{
 		id:          id,
+		ctx:         ctx,
+		method:      method,
 		buf:         recvBuffer,
 		trReader:    trReader,
 		wq:          newWriteQuota(defaultWriteQuota, nil),

--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -215,10 +215,13 @@ func (t *svrTransHandler) handleFunc(s *grpcTransport.Stream, svrTrans *SvrTrans
 		conn:    newServerConn(tr, s),
 		handler: t,
 	}
+	// inject rawStream so that GetServerConn only relies on it
+	rCtx = context.WithValue(rCtx, serverConnKey{}, rawStream)
 	st := newStreamWithMiddleware(rawStream, t.opt.RecvEndpoint, t.opt.SendEndpoint)
-
 	// bind stream into ctx, in order to let user set header and trailer by provided api in meta_api.go
 	rCtx = streaming.NewCtxWithStream(rCtx, st)
+	// GetServerConn could retrieve rawStream by Stream.Context().Value(serverConnKey{})
+	rawStream.ctx = rCtx
 
 	if methodInfo == nil {
 		unknownServiceHandlerFunc := t.opt.GRPCUnknownServiceHandler

--- a/pkg/remote/trans/nphttp2/server_handler_test.go
+++ b/pkg/remote/trans/nphttp2/server_handler_test.go
@@ -74,7 +74,7 @@ func TestServerHandler(t *testing.T) {
 	npConn.mockSettingFrame()
 	tr, err := newMockServerTransport(npConn)
 	test.Assert(t, err == nil, err)
-	s := grpc.CreateStream(1, func(i int) {})
+	s := grpc.CreateStream(context.Background(), 1, func(i int) {}, "")
 	serverConn := newServerConn(tr, s)
 	defer serverConn.Close()
 

--- a/pkg/remote/trans/nphttp2/stream_test.go
+++ b/pkg/remote/trans/nphttp2/stream_test.go
@@ -17,6 +17,7 @@
 package nphttp2
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
@@ -31,7 +32,7 @@ func TestStream(t *testing.T) {
 	conn.mockSettingFrame()
 	tr, err := newMockServerTransport(conn)
 	test.Assert(t, err == nil, err)
-	s := grpc.CreateStream(1, func(i int) {})
+	s := grpc.CreateStream(context.Background(), 1, func(i int) {}, "")
 	serverConn := newServerConn(tr, s)
 	defer serverConn.Close()
 

--- a/server/invoke.go
+++ b/server/invoke.go
@@ -104,6 +104,7 @@ func (s *tInvoker) Init() (err error) {
 	if len(s.server.svcs.svcMap) == 0 {
 		return errors.New("run: no service. Use RegisterService to set one")
 	}
+	s.buildFullInvokeChain()
 	s.initBasicRemoteOption()
 	// for server trans info handler
 	if len(s.server.opt.MetaHandlers) > 0 {

--- a/server/middlewares.go
+++ b/server/middlewares.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/streaming"
 )
 
 func serverTimeoutMW(initCtx context.Context) endpoint.Middleware {
@@ -41,6 +42,25 @@ func serverTimeoutMW(initCtx context.Context) endpoint.Middleware {
 					cancel()
 				}
 			}()
+			return next(ctx, request, response)
+		}
+	}
+}
+
+// newCtxInjectMW must be placed at the end
+func newCtxInjectMW() endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request, response interface{}) (err error) {
+			args, ok := request.(*streaming.Args)
+			if !ok {
+				return next(ctx, request, response)
+			}
+			// use contextStream to wrap the original Stream and rewrite Context()
+			// so that we can get this ctx by Stream.Context()
+			args.Stream = contextStream{
+				Stream: args.Stream,
+				ctx:    ctx,
+			}
 			return next(ctx, request, response)
 		}
 	}

--- a/server/option_test.go
+++ b/server/option_test.go
@@ -49,23 +49,18 @@ func TestOptionDebugInfo(t *testing.T) {
 	var opts []Option
 	md := newMockDiagnosis()
 	opts = append(opts, WithDiagnosisService(md))
-	buildMw := 0
 	opts = append(opts, WithMiddleware(func(next endpoint.Endpoint) endpoint.Endpoint {
-		buildMw++
 		return func(ctx context.Context, req, resp interface{}) (err error) {
 			return next(ctx, req, resp)
 		}
 	}))
 	opts = append(opts, WithMiddlewareBuilder(func(ctx context.Context) endpoint.Middleware {
 		return func(next endpoint.Endpoint) endpoint.Endpoint {
-			buildMw++
 			return next
 		}
 	}))
 
 	svr := NewServer(opts...)
-	// check middleware build
-	test.Assert(t, buildMw == 2)
 
 	// check probe result
 	pp := md.ProbePairs()

--- a/server/stream.go
+++ b/server/stream.go
@@ -44,3 +44,15 @@ func (s *server) invokeSendEndpoint() endpoint.SendEndpoint {
 		return stream.SendMsg(req)
 	}
 }
+
+// contextStream is responsible for solving ctx diverge in server side streaming.
+// it receives the ctx from previous middlewares and the Stream that exposed to users，then rewrite
+// Context() method so that users could call Stream.Context() in handler to get the processed ctx.
+type contextStream struct {
+	streaming.Stream
+	ctx context.Context
+}
+
+func (cs contextStream) Context() context.Context {
+	return cs.ctx
+}


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: 修复 server 侧 streaming 接口 ctx 分叉的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
Currently in the server-side streaming scenario, the middleware func(ctx context.Context, request, response interface{}) after processing the ctx (e.g. WithValue) is not perceived by the Stream.Context() in the handler.
Use contextStream to wrap the Stream provided to the user handler, inject the middleware-processed ctx, and override the Stream.Context() method exposed to the user to solve this problem.
zh(optional): 
当前在 server 侧 streaming 场景，middleware func(ctx context.Context, request, response interface{}) 对 ctx 进行处理后(例如 WithValue)并不能通过 handler 中的 Stream.Context() 感知到。
利用 contextStream wrap 一下提供给用户 handler 的 Stream，注入经过 middleware 处理后的 ctx，并重写暴露给用户的 Stream.Context() 方法来解决这个问题。
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->