### PR TITLE
feat(codec): Unknown Service Handler (#1321)

### DIFF
--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -7,7 +7,6 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
@@ -27,6 +26,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/streaming"
+	"github.com/cloudwego/kitex/pkg/unknownservice/service"
 )
 
 // Option is used to pack the inbound and outbound handlers.
@@ -112,6 +112,8 @@ type ServerOption struct {
 	GRPCCfg *grpc.ServerConfig
 
 	GRPCUnknownServiceHandler func(ctx context.Context, method string, stream streaming.Stream) error
+
+	UnknownServiceHandler service.UnknownServiceHandler
 
 	Option
 

--- a/pkg/unknownservice/service/unknown_service.go
+++ b/pkg/unknownservice/service/unknown_service.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
+)
+
+const (
+	// UnknownService name
+	UnknownService = "$UnknownService" // private as "$"
+	// UnknownMethod name
+	UnknownMethod = "$UnknownMethod"
+)
+
+type Args struct {
+	Request     []byte
+	Method      string
+	ServiceName string
+}
+
+type Result struct {
+	Success     []byte
+	Method      string
+	ServiceName string
+}
+
+type UnknownServiceHandler interface {
+	UnknownServiceHandler(ctx context.Context, serviceName, method string, request []byte) ([]byte, error)
+}
+
+// NewServiceInfo creates a new ServiceInfo containing unknown methods
+func NewServiceInfo(pcType serviceinfo.PayloadCodec, service, method string) *serviceinfo.ServiceInfo {
+	methods := map[string]serviceinfo.MethodInfo{
+		method: serviceinfo.NewMethodInfo(callHandler, newServiceArgs, newServiceResult, false),
+	}
+	handlerType := (*UnknownServiceHandler)(nil)
+
+	svcInfo := &serviceinfo.ServiceInfo{
+		ServiceName:  service,
+		HandlerType:  handlerType,
+		Methods:      methods,
+		PayloadCodec: pcType,
+		Extra:        make(map[string]interface{}),
+	}
+
+	return svcInfo
+}
+
+func callHandler(ctx context.Context, handler, arg, result interface{}) error {
+	realArg := arg.(*Args)
+	realResult := result.(*Result)
+	realResult.Method = realArg.Method
+	realResult.ServiceName = realArg.ServiceName
+	success, err := handler.(UnknownServiceHandler).UnknownServiceHandler(ctx, realArg.ServiceName, realArg.Method, realArg.Request)
+	if err != nil {
+		return err
+	}
+	realResult.Success = success
+	return nil
+}
+
+func newServiceArgs() interface{} {
+	return &Args{}
+}
+
+func newServiceResult() interface{} {
+	return &Result{}
+}

--- a/pkg/unknownservice/unknownservice_codec.go
+++ b/pkg/unknownservice/unknownservice_codec.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unknownservice
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	gthrift "github.com/cloudwego/gopkg/protocol/thrift"
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/codec"
+	"github.com/cloudwego/kitex/pkg/remote/codec/perrors"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	unknownservice "github.com/cloudwego/kitex/pkg/unknownservice/service"
+)
+
+// UnknownCodec implements PayloadCodec
+type unknownServiceCodec struct {
+	Codec remote.PayloadCodec
+}
+
+// NewUnknownServiceCodec creates the unknown binary codec.
+func NewUnknownServiceCodec(code remote.PayloadCodec) remote.PayloadCodec {
+	return &unknownServiceCodec{code}
+}
+
+// Marshal implements the remote.PayloadCodec interface.
+func (c unknownServiceCodec) Marshal(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
+	ink := msg.RPCInfo().Invocation()
+	data := msg.Data()
+
+	res, ok := data.(*unknownservice.Result)
+	if !ok {
+		return c.Codec.Marshal(ctx, msg, out)
+	}
+	if msg.MessageType() == remote.Exception {
+		return c.Codec.Marshal(ctx, msg, out)
+	}
+	if ink, ok := ink.(rpcinfo.InvocationSetter); ok {
+		ink.SetMethodName(res.Method)
+		ink.SetServiceName(res.ServiceName)
+	} else {
+		return errors.New("the interface Invocation doesn't implement InvocationSetter")
+	}
+
+	if res.Success == nil {
+		sz := gthrift.Binary.MessageBeginLength(msg.RPCInfo().Invocation().MethodName())
+		if msg.ProtocolInfo().CodecType == serviceinfo.Thrift {
+			sz += gthrift.Binary.FieldStopLength()
+			buf, err := out.Malloc(sz)
+			if err != nil {
+				return perrors.NewProtocolError(fmt.Errorf("binary thrift generic marshal, remote.ByteBuffer Malloc err: %w", err))
+			}
+			buf = gthrift.Binary.AppendMessageBegin(buf[:0],
+				msg.RPCInfo().Invocation().MethodName(), gthrift.TMessageType(msg.MessageType()), msg.RPCInfo().Invocation().SeqID())
+			buf = gthrift.Binary.AppendFieldStop(buf)
+			_ = buf
+		}
+
+		if msg.ProtocolInfo().CodecType == serviceinfo.Protobuf {
+			buf, err := out.Malloc(sz)
+			if err != nil {
+				return perrors.NewProtocolError(fmt.Errorf("binary thrift generic marshal, remote.ByteBuffer Malloc err: %w", err))
+			}
+			binary.BigEndian.PutUint32(buf, codec.ProtobufV1Magic+uint32(msg.MessageType()))
+			offset := 4
+			offset += gthrift.Binary.WriteString(buf[offset:], res.Method)
+			offset += gthrift.Binary.WriteI32(buf[offset:], msg.RPCInfo().Invocation().SeqID())
+			_ = buf
+		}
+		return nil
+	}
+	out.WriteBinary(res.Success)
+	return nil
+}
+
+// Unmarshal implements the remote.PayloadCodec interface.
+func (c unknownServiceCodec) Unmarshal(ctx context.Context, message remote.Message, in remote.ByteBuffer) error {
+	ink := message.RPCInfo().Invocation()
+	magicAndMsgType, err := codec.PeekUint32(in)
+	if err != nil {
+		return err
+	}
+	msgType := magicAndMsgType & codec.FrontMask
+	if msgType == uint32(remote.Exception) {
+		return c.Codec.Unmarshal(ctx, message, in)
+	}
+	if err = codec.UpdateMsgType(msgType, message); err != nil {
+		return err
+	}
+	service, method, err := readDecode(message, in)
+	if err != nil {
+		return err
+	}
+	err = codec.SetOrCheckMethodName(method, message)
+	var te *remote.TransError
+	if errors.As(err, &te) && (te.TypeID() == remote.UnknownMethod || te.TypeID() == remote.UnknownService) {
+		svcInfo, err := message.SpecifyServiceInfo(unknownservice.UnknownService, unknownservice.UnknownMethod)
+		if err != nil {
+			return err
+		}
+
+		if ink, ok := ink.(rpcinfo.InvocationSetter); ok {
+			ink.SetMethodName(unknownservice.UnknownMethod)
+			ink.SetPackageName(svcInfo.GetPackageName())
+			ink.SetServiceName(unknownservice.UnknownService)
+		} else {
+			return errors.New("the interface Invocation doesn't implement InvocationSetter")
+		}
+		if err = codec.NewDataIfNeeded(unknownservice.UnknownMethod, message); err != nil {
+			return err
+		}
+
+		data := message.Data()
+
+		if data, ok := data.(*unknownservice.Args); ok {
+			data.Method = method
+			data.ServiceName = service
+			buf, err := in.Next(in.ReadableLen())
+			if err != nil {
+				return err
+			}
+			data.Request = buf
+		}
+		return nil
+	}
+
+	return c.Codec.Unmarshal(ctx, message, in)
+}
+
+// Name implements the remote.PayloadCodec interface.
+func (c unknownServiceCodec) Name() string {
+	return "unknownServiceCodec"
+}
+
+func readDecode(message remote.Message, in remote.ByteBuffer) (string, string, error) {
+	code := message.ProtocolInfo().CodecType
+	if code == serviceinfo.Thrift || code == serviceinfo.Protobuf {
+		method, size, err := peekMethod(in)
+		if err != nil {
+			return "", "", err
+		}
+
+		seqID, err := peekSeqID(in, size)
+		if err != nil {
+			return "", "", err
+		}
+		if err = codec.SetOrCheckSeqID(seqID, message); err != nil {
+			return "", "", err
+		}
+		return message.RPCInfo().Invocation().ServiceName(), method, nil
+	}
+	return "", "", nil
+}
+
+func peekMethod(in remote.ByteBuffer) (string, int32, error) {
+	buf, err := in.Peek(8)
+	if err != nil {
+		return "", 0, err
+	}
+	buf = buf[4:]
+	size := int32(binary.BigEndian.Uint32(buf))
+	buf, err = in.Peek(int(size + 8))
+	if err != nil {
+		return "", 0, perrors.NewProtocolError(err)
+	}
+	buf = buf[8:]
+	method := string(buf)
+	return method, size + 8, nil
+}
+
+func peekSeqID(in remote.ByteBuffer, size int32) (int32, error) {
+	buf, err := in.Peek(int(size + 4))
+	if err != nil {
+		return 0, perrors.NewProtocolError(err)
+	}
+	buf = buf[size:]
+	seqID := int32(binary.BigEndian.Uint32(buf))
+	return seqID, nil
+}

--- a/pkg/unknownservice/unknownservice_codec_test.go
+++ b/pkg/unknownservice/unknownservice_codec_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unknownservice
+
+import (
+	"context"
+	"testing"
+
+	gthrift "github.com/cloudwego/gopkg/protocol/thrift"
+	"github.com/cloudwego/kitex/internal/mocks"
+	mt "github.com/cloudwego/kitex/internal/mocks/thrift"
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
+	netpolltrans "github.com/cloudwego/kitex/pkg/remote/trans/netpoll"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/unknownservice/service"
+	"github.com/cloudwego/kitex/transport"
+	"github.com/cloudwego/netpoll"
+)
+
+var (
+	thr          = thrift.NewThriftCodec()
+	payloadCodec = unknownServiceCodec{thr}
+	svcInfo      = mocks.ServiceInfo()
+)
+
+func TestNormal(t *testing.T) {
+	sendMsg := initSendMsg(transport.TTHeader)
+	buf := netpolltrans.NewReaderWriterByteBuffer(netpoll.NewLinkBuffer(1024))
+	ctx := context.Background()
+	err := payloadCodec.Marshal(ctx, sendMsg, buf)
+	test.Assert(t, err == nil, err)
+	err = buf.Flush()
+	test.Assert(t, err == nil, err)
+	recvMsg := initRecvMsg()
+	recvMsg.SetPayloadLen(buf.ReadableLen())
+	_, size, err := peekMethod(buf)
+	test.Assert(t, err == nil, err)
+	err = payloadCodec.Unmarshal(ctx, recvMsg, buf)
+	test.Assert(t, err == nil, err)
+
+	req := (sendMsg.Data()).(*service.Result).Success
+	resp := (recvMsg.Data()).(*service.Args).Request
+	req = req[size+4:]
+	resp = resp[size+4:]
+	for i, item := range req {
+		test.Assert(t, item == resp[i])
+	}
+	var _req mt.MockTestArgs
+	var _resp mt.MockTestArgs
+	reqMsg, err := _req.FastRead(req)
+	test.Assert(t, err == nil, err)
+	respMsg, err := _resp.FastRead(resp)
+	test.Assert(t, err == nil && reqMsg == respMsg, err)
+	test.Assert(t, len(_req.Req.StrList) == len(_resp.Req.StrList))
+	test.Assert(t, len(_req.Req.StrMap) == len(_resp.Req.StrList))
+	for i, item := range _req.Req.StrList {
+		test.Assert(t, item == _resp.Req.StrList[i])
+	}
+	for k := range _resp.Req.StrMap {
+		test.Assert(t, _req.Req.StrMap[k] == _resp.Req.StrMap[k])
+	}
+}
+
+func initSendMsg(tp transport.Protocol) remote.Message {
+	var _args mt.MockTestArgs
+	_args.Req = prepareReq()
+	length := _args.BLength()
+	method := "mock"
+	size := gthrift.Binary.MessageBeginLength(method)
+	bytes := make([]byte, length+size)
+	offset := gthrift.Binary.WriteMessageBegin(bytes, method, int32(remote.Call), 1)
+	_args.FastWriteNocopy(bytes[offset:], nil)
+	arg := service.Result{Success: bytes, Method: method, ServiceName: ""}
+	ink := rpcinfo.NewInvocation("", service.UnknownMethod)
+	ri := rpcinfo.NewRPCInfo(nil, nil, ink, nil, nil)
+
+	msg := remote.NewMessage(&arg, svcInfo, ri, remote.Call, remote.Client)
+
+	msg.SetProtocolInfo(remote.NewProtocolInfo(tp, svcInfo.PayloadCodec))
+	return msg
+}
+
+func initRecvMsg() remote.Message {
+	arg := service.Args{Request: make([]byte, 0), Method: "mock", ServiceName: ""}
+	ink := rpcinfo.NewInvocation("", service.UnknownMethod)
+	ri := rpcinfo.NewRPCInfo(nil, nil, ink, nil, nil)
+	svc := service.NewServiceInfo(svcInfo.PayloadCodec, service.UnknownService, service.UnknownMethod)
+	msg := remote.NewMessage(&arg, svc, ri, remote.Call, remote.Server)
+	return msg
+}
+
+func prepareReq() *mt.MockReq {
+	strMap := make(map[string]string)
+	strMap["key1"] = "val1"
+	strMap["key2"] = "val2"
+	strList := []string{"str1", "str2"}
+	req := &mt.MockReq{
+		Msg:     "MockReq",
+		StrMap:  strMap,
+		StrList: strList,
+	}
+	return req
+}


### PR DESCRIPTION
#### What type of PR is this?
feat:  Unknown Service Handle new feature

#### Check the PR title.
we UnknownServiceHandler mechanism for a normal Kitex server to deal with requests with unknown service.

- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
我们为普通的Kitex服务器提供了UnknownServiceHandler机制来处理带有未知服务和方法的请求。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

### unknown Service方案
#### 1. 注入Handler
1. Unknow Service 该实现放在pkg/unknownservice包下。
2. 当用户通过WithUnknownServiceHandler注入 UnknownServiceHandler功能,进行处理 Unknown Service和Unknown Method 的功能处理, 目前只支持Thrift和Protobuf协议。
3. 通过remote.PutPayloadCode形式进行重新包装Thrift和Protobuf,所有的请求都优先经过UnknownServiceCodec中处理。
```
// WithUnknownServiceHandler Inject an implementation of a method for handling unknown requests
// supporting only Thrift and Kitex protobuf protocols
func WithUnknownServiceHandler(f unknown.UnknownServiceHandler) Option {
    return Option{F: func(o *internal_server.Options, di *utils.Slice) {
       di.Push(fmt.Sprintf("WithUnknownServiceHandler(%+v)", utils.GetFuncName(f)))
       o.RemoteOpt.UnknownServiceHandler = f
       remote.PutPayloadCode(serviceinfo.Thrift, unknownservice.NewUnknownServiceCodec(thrift.NewThriftCodec()))
       remote.PutPayloadCode(serviceinfo.Protobuf, 
       unknownservice.NewUnknownServiceCodec(protobuf.NewProtobufCodec()))
    }}
}
```
4. 在服务启动过程中会通过registerUnknownServiceHandler 基于多service 注入一个ServiceInfo。
5. service name为$UnknownService, method name为$UnknownMethod, Args 和 Result 参数都为 []byte 格式
```
func (s *server) registerUnknownServiceHandler() {
    if s.opt.RemoteOpt.UnknownServiceHandler != nil {
       if len(s.svcs.svcMap) == 1 && s.svcs.svcMap[serviceinfo.GenericService] != nil {
          panic(errors.New("generic services do not support handling of unknown methods"))
       } else {
          serviceInfo := unknownservice.NewServiceInfo(serviceinfo.Thrift, unknownservice.UnknownService, unknownservice.UnknownMethod)
          if err := s.RegisterService(serviceInfo, s.opt.RemoteOpt.UnknownServiceHandler); err != nil {
             panic(err)
          }
       }
    }
}
```
#### 2. 处理请求
1. UnknownServiceCodec 实现了接口remote.PayloadCodec,
```
type unknownCodec struct {
    Codec remote.PayloadCodec
}
func (c unknownCodec) Marshal(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {}

func (c unknownCodec) Unmarshal(ctx context.Context, message remote.Message, in remote.ByteBuffer) error {}

func (c unknownCodec) Name() string { return "unknownServiceCodec"}
```
2. 当客户端发送请求到服务端，都会优先经过unknownCodec 的 Unmarshal, 通过Peek形式解析到MsgType、Service Name 、Method Name,  且check msgType 是否是 Exception
```
func (c unknownCodec) Unmarshal(ctx context.Context, message remote.Message, in remote.ByteBuffer) error {
    magicAndMsgType, err := codec.PeekUint32(in)
    if err != nil {
        return err
    }
    msgType := magicAndMsgType & codec.FrontMask
    if msgType == uint32(remote.Exception) {
        return c.Codec.Unmarshal(ctx, message, in)
    }
    if err = codec.UpdateMsgType(msgType, message); err != nil {
        return err
    }
    service, method, err := readDecode(message, in)
    if err != nil {
        return err
    }
    err = codec.SetOrCheckMethodName(method, message)
    ...
}

func readDecode(message remote.Message, in remote.ByteBuffer) (string, string, error) {
    code := message.ProtocolInfo().CodecType
    if code == serviceinfo.Thrift || code == serviceinfo.Protobuf {
       method, size, err := peekMethod(in)
       ....
       return message.RPCInfo().Invocation().ServiceName(), method, nil
    }
    return "", "", nil
}

func peekMethod(in remote.ByteBuffer) (string, int32, error) {
    buf, err := in.Peek(8)
    if err != nil {
       return "", 0, err
    }
    buf = buf[4:]
    size := int32(binary.BigEndian.Uint32(buf))
    buf, err = in.Peek(int(size + 8))
    if err != nil {
       return "", 0, perrors.NewProtocolError(err)
    }
    buf = buf[8:]
    method := string(buf)
    return method, size + 8, nil
}
```
3. 通过codec.SetOrCheckMethodName 检测service name和 method name , 校验返回异常类型是否remote.UnknownMethod和remote.UnknownService
4. 如果不是这两种异常类型,则直接调用Codec.Unmarshal进行后续处理。
```
err = codec.SetOrCheckMethodName(method, message)
var te *remote.TransError
if errors.As(err, &te) && (te.TypeID() == remote.UnknownMethod || te.TypeID() == remote.UnknownService) {
    svcInfo, err := message.SpecifyServiceInfo(service2.UnknownService, service2.UnknownMethod)
    if err != nil {
       return err
    }
    ...
 }
 return c.Codec.Unmarshal(ctx, message, in)
```
5. 如果正常捕获到两种UnknownMethod和UnknownService异常，则重新包装rpcinfo.InvocationSetter信息
```
if ink, ok := ink.(rpcinfo.InvocationSetter); ok {
    ink.SetMethodName(service2.UnknownMethod)
    ink.SetPackageName(svcInfo.GetPackageName())
    ink.SetServiceName(service2.UnknownService)
} else {
    return errors.New("the interface Invocation doesn't implement InvocationSetter")
}
```
6. 封装好请求信息后调用用户注入的UnknownServiceHandler接口实现类, 该接口会给用户传递 Context, serviceName, method 
string, request []byte 信息，返回一个 Result []byte
```
func callHandler(ctx context.Context, handler, arg, result interface{}) error {
    realArg := arg.(*Args)
    realResult := result.(*Result)
    realResult.Method = realArg.Method
    realResult.ServiceName = realArg.ServiceName
    success, err := handler.(UnknownServiceHandler).UnknownServiceHandler(ctx, realArg.ServiceName, realArg.Method, realArg.Request)
    if err != nil {
       return err
    }
    realResult.Success = success
    return nil
}
```
#### 3. 处理响应
1. 响应一个Result []byte 用户需要自行处理客户端接收参数,需要保持一致
2. 在Marshal中会校验响应对象是否Unknow的Result, 如果不是该对象会调用Codec.Marshal进行处理，如果不是UnknownService的功能不要使用Unknow Result 对象
```
func (c unknownCodec) Marshal(ctx context.Context, msg remote.Message, out remote.ByteBuffer) error {
    ink := msg.RPCInfo().Invocation()
    data := msg.Data()

    res, ok := data.(*service2.Result)
    if !ok {
       return c.Codec.Marshal(ctx, msg, out)
    }
 }
```
3. 如果是Unknow的Result对象,进行还原rpcinfo中信息,重新封装响应给客户端
```
if ink, ok := ink.(rpcinfo.InvocationSetter); ok {
    ink.SetMethodName(res.Method)
    ink.SetServiceName(res.ServiceName)
} else {
    return errors.New("the interface Invocation doesn't implement InvocationSetter")
}
```
4. 根据Thrift和Protobuf不同的协议吧 UnknownServiceHandler中响应的 [] byte信息 封装到remote.ByteBuffer中
```
func encode(res *service2.Result, msg remote.Message, out remote.ByteBuffer) error {
    if msg.ProtocolInfo().CodecType == serviceinfo.Thrift {
       return encodeThrift(res, msg, out)
    }
    if msg.ProtocolInfo().CodecType == serviceinfo.Protobuf {
       return encodeKitexProtobuf(res, msg, out)
    }
    return nil
}
```
#### 4. 如何使用
- server.UnknownServiceHandler接收一个UnknownServiceHandler类型接口, 只有一个实现方法，UnknownServiceHandler
- UnknownServiceHandler(ctx context.Context, serviceName, method string, request []byte) ([]byte, error)
- 接收一个Context， serviceName, method  和请求体。
- 响应一个 []byte, 需要用户自己包装客户端对应的参数信息。
type UnknownServiceImpl struct{}
```
// 实现UnknownServiceHandler接口,用来处理未知的请求
func (g *UnknownServiceImpl) UnknownServiceHandler(ctx context.Context, serviceName, method string, request []byte) (response []byte, err error) {
    m := request.([]byte)
    fmt.Printf("Recv: %v\n", m)
    req := "{\"Msg\": \"world\"}"
    return byte(req), nil
}

func NewServer(){
    var opts []server.Option
    // 把UnknownServiceHandler 添加到service中进行处理
    opts = append(opts, server.UnknownServiceHandler(new(UnknownServiceImpl)))
    svr := echo.NewServer(new(EchoImpl), opts...)
    if err := svr.Run(); err != nil {
        log.Fatal(err)
    }
}
```

#### (Optional) Which issue(s) this PR fixes:
Fixes #1321 


#### (optional) The PR that updates user documentation:
