### PR TITLE
feat(tool): support updating import path for PkgInfo

### DIFF
--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -617,7 +617,7 @@ func (g *generator) setImports(name string, pkg *PackageInfo) {
 		if !g.Config.IsUsingMultipleServicesTpl() {
 			pkg.AddImport(pkg.PkgRefName, util.JoinPath(pkg.ImportPath, strings.ToLower(pkg.ServiceName)))
 		} else {
-			pkg.AddImport("server", "github.com/cloudwego/kitex/server")
+			pkg.AddImports("server")
 			for _, svc := range pkg.Services {
 				pkg.AddImport(svc.RefName, util.JoinPath(pkg.ImportPath, strings.ToLower(svc.ServiceName)))
 			}

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -92,9 +92,9 @@ func (p *PackageInfo) AddImports(pkgs ...string) {
 //
 // if pkg == newPath, then alias would be removed in import sentence:
 //
-//		Original import: context "path/to/custom/context"
-//	 Invocation:      UpdateImport("context", "context")
-//	 New import:      context
+//	Original import: context "path/to/custom/context"
+//	Invocation:      UpdateImport("context", "context")
+//	New import:      context
 func (p *PackageInfo) UpdateImportPath(pkg, newPath string) {
 	if p.Imports == nil || pkg == "" || newPath == "" {
 		return

--- a/tool/internal_pkg/generator/type.go
+++ b/tool/internal_pkg/generator/type.go
@@ -83,7 +83,7 @@ func (p *PackageInfo) AddImports(pkgs ...string) {
 	}
 }
 
-// UpdateImport changed the mapping between alias -> import path
+// UpdateImportPath changed the mapping between alias -> import path
 // For instance:
 //
 //	Original import: alias "original_path"
@@ -95,7 +95,7 @@ func (p *PackageInfo) AddImports(pkgs ...string) {
 //		Original import: context "path/to/custom/context"
 //	 Invocation:      UpdateImport("context", "context")
 //	 New import:      context
-func (p *PackageInfo) UpdateImport(pkg, newPath string) {
+func (p *PackageInfo) UpdateImportPath(pkg, newPath string) {
 	if p.Imports == nil || pkg == "" || newPath == "" {
 		return
 	}

--- a/tool/internal_pkg/generator/type_test.go
+++ b/tool/internal_pkg/generator/type_test.go
@@ -109,7 +109,7 @@ func TestServiceInfo_FixHasStreamingForExtendedService(t *testing.T) {
 	})
 }
 
-func TestPkgInfo_UpdateImport(t *testing.T) {
+func TestPkgInfo_UpdateImportPath(t *testing.T) {
 	testcases := []struct {
 		desc    string
 		imports map[string]map[string]bool
@@ -153,7 +153,7 @@ func TestPkgInfo_UpdateImport(t *testing.T) {
 			pkgInfo := &PackageInfo{
 				Imports: tc.imports,
 			}
-			pkgInfo.UpdateImport(tc.pkg, tc.newPath)
+			pkgInfo.UpdateImportPath(tc.pkg, tc.newPath)
 			tc.expect(t, pkgInfo, tc.pkg, tc.newPath)
 		})
 	}

--- a/tool/internal_pkg/generator/type_test.go
+++ b/tool/internal_pkg/generator/type_test.go
@@ -108,3 +108,53 @@ func TestServiceInfo_FixHasStreamingForExtendedService(t *testing.T) {
 		test.Assert(t, s.Base.HasStreaming)
 	})
 }
+
+func TestPkgInfo_UpdateImport(t *testing.T) {
+	testcases := []struct {
+		desc    string
+		imports map[string]map[string]bool
+		pkg     string
+		newPath string
+		expect  func(t *testing.T, pkgInfo *PackageInfo, pkg, newPath string)
+	}{
+		{
+			desc: "update path for same alias",
+			imports: map[string]map[string]bool{
+				"path/to/server": {
+					"server": true,
+				},
+			},
+			pkg:     "server",
+			newPath: "new/path/to/server",
+			expect: func(t *testing.T, pkgInfo *PackageInfo, pkg, newPath string) {
+				pkgSet := pkgInfo.Imports[newPath]
+				test.Assert(t, pkgSet != nil)
+				test.Assert(t, pkgSet[pkg])
+			},
+		},
+		{
+			desc: "remove alias",
+			imports: map[string]map[string]bool{
+				"path/to/context": {
+					"context": true,
+				},
+			},
+			pkg:     "context",
+			newPath: "context",
+			expect: func(t *testing.T, pkgInfo *PackageInfo, pkg, newPath string) {
+				pkgSet := pkgInfo.Imports[newPath]
+				test.Assert(t, pkgSet == nil)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			pkgInfo := &PackageInfo{
+				Imports: tc.imports,
+			}
+			pkgInfo.UpdateImport(tc.pkg, tc.newPath)
+			tc.expect(t, pkgInfo, tc.pkg, tc.newPath)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(tool): 支持更新 PkgInfo 中的引用路径

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
For scenarios where the aliases are the same but the reference paths are different, you need to provide an update mechanism UpdateImportPath, which modifies the reference paths.
```
import (
    server "github.com/cloudwego/kitex/server"
)

server.NewServer()
```
```
import (
    server "new/path/to/server"
)

server.NewServer()
```
Therefore, when extending the kitex tool, you can call UpdateImportPath from within the middleware to make changes.

zh(optional): 
对于别名相同，但引用路径不同的场景，需要提供更新机制 UpdateImportPath，修改引用路径：
```
import (
    server "github.com/cloudwego/kitex/server"
)

server.NewServer()
```
```
import (
    server "new/path/to/server"
)

server.NewServer()
```
因此扩展 kitex tool 时可以在中间件里调用 UpdateImportPath 进行修改

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->