### PR TITLE
fix(gRPC): fix data race in gRPC client trailer with lock

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -546,9 +546,7 @@ func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.
 		<-s.done
 		return
 	}
-	// status and trailers can be updated here without any synchronization because the stream goroutine will
-	// only read it after it sees an io.EOF error from read or write and we'll write those errors
-	// only after updating this.
+	// status and trailers should be updated here with synchronization because Trailer() function may be called concurrently
 	s.status = st
 	if len(mdata) > 0 {
 		s.cliTlrMu.Lock()

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -551,7 +551,9 @@ func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.
 	// only after updating this.
 	s.status = st
 	if len(mdata) > 0 {
+		s.cliTlrMu.Lock()
 		s.trailer = mdata
+		s.cliTlrMu.Unlock()
 	}
 	if err != nil {
 		// This will unblock reads eventually.

--- a/pkg/remote/trans/nphttp2/grpc/http2_client_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client_test.go
@@ -21,11 +21,12 @@ import (
 	"math"
 	"testing"
 
+	"golang.org/x/net/http2"
+
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
-	"golang.org/x/net/http2"
 )
 
 func TestHttp2ClientTrailerRace(t *testing.T) {

--- a/pkg/remote/trans/nphttp2/grpc/http2_client_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client_test.go
@@ -1,14 +1,31 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package grpc
 
 import (
 	"context"
+	"math"
+	"testing"
+
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"golang.org/x/net/http2"
-	"math"
-	"testing"
 )
 
 func TestHttp2ClientTrailerRace(t *testing.T) {

--- a/pkg/remote/trans/nphttp2/grpc/http2_client_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client_test.go
@@ -1,0 +1,26 @@
+package grpc
+
+import (
+	"context"
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+	"golang.org/x/net/http2"
+	"math"
+	"testing"
+)
+
+func TestHttp2ClientTrailerRace(t *testing.T) {
+	_, ct := setUp(t, 0, math.MaxUint32, normal)
+	s, err := ct.NewStream(context.Background(), &CallHdr{})
+	test.Assert(t, err == nil, err)
+
+	go func() {
+		s.Trailer()
+	}()
+	go func() {
+		mdata := metadata.Pairs("k", "v")
+		ct.closeStream(s, nil, false, http2.ErrCodeNo, status.New(codes.OK, ""), mdata, true)
+	}()
+}

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -260,6 +260,9 @@ type Stream struct {
 
 	// hdrMu protects header and trailer metadata on the server-side.
 	hdrMu sync.Mutex
+	// cliTlrMu protects trailer metadata on the client-side
+	cliTlrMu sync.RWMutex
+
 	// On client side, header keeps the received header metadata.
 	//
 	// On server side, header keeps the header set by SetHeader(). The complete
@@ -388,7 +391,9 @@ func (s *Stream) TrailersOnly() bool {
 // It can be safely read only after stream has ended that is either read
 // or write have returned io.EOF.
 func (s *Stream) Trailer() metadata.MD {
+	s.cliTlrMu.RLock()
 	c := s.trailer.Copy()
+	s.cliTlrMu.RUnlock()
 	return c
 }
 


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
zh: fix(gRPC): 解决 gRPC client 侧 trailer 的 race 问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
http2Client 的 closeStream 内会设置 trailer，与暴露给外部使用的 Trailer api 存在 race 问题，加读写锁来解决，理论上不会有频繁调用 Trailer() 的情况，所以性能影响较小。

<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->