### PR TITLE
fix(gRPC): retrieve status or biz error for non-ServerStreaming

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   unit-scenario-test:
     strategy:
       matrix:
-        go: [ "1.18", "1.25" ]
+        go: [ "1.19", "1.25" ]
     runs-on: [ Linux, X64 ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   unit-scenario-test:
     strategy:
       matrix:
-        go: [ "1.19", "1.25" ]
+        go: [ "1.18", "1.25" ]
     runs-on: [ Linux, X64 ]
     steps:
       - uses: actions/checkout@v4

--- a/pkg/remote/codec/grpc/grpc_test.go
+++ b/pkg/remote/codec/grpc/grpc_test.go
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpc
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	mocksremote "github.com/cloudwego/kitex/internal/mocks/remote"
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/kerrors"
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/rpcinfo/remoteinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
+)
+
+func Test_grpcCodec_Decode(t *testing.T) {
+	codec := NewGRPCCodec()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testcases := []struct {
+		desc              string
+		role              remote.RPCRole
+		mode              serviceinfo.StreamingMode
+		getByteBufferFunc func() remote.ByteBuffer
+		expectErr         error
+	}{
+		{
+			desc: "client-side ClientStreaming decodes first grpc frame failed",
+			role: remote.Client,
+			mode: serviceinfo.StreamingClient,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return(nil, status.Err(codes.Internal, "test")).Times(1)
+				return mockIn
+			},
+			expectErr: status.Err(codes.Internal, "test"),
+		},
+		{
+			desc: "client-side ClientStreaming decodes second grpc frame successfully => wrong gRPC protocol implementation on the server side",
+			role: remote.Client,
+			mode: serviceinfo.StreamingClient,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				return mockIn
+			},
+			expectErr: errWrongGRPCImplementation,
+		},
+		{
+			desc: "client-side ClientStreaming decodes second grpc frame getting io.EOF => normal exit on the server side",
+			role: remote.Client,
+			mode: serviceinfo.StreamingClient,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, io.EOF).Times(1)
+				return mockIn
+			},
+			expectErr: ErrInvalidPayload,
+		},
+		{
+			desc: "client-side ClientStreaming decodes second grpc frame getting gRPC errors",
+			role: remote.Client,
+			mode: serviceinfo.StreamingClient,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, status.Err(codes.Internal, "gRPC errors")).Times(1)
+				return mockIn
+			},
+			expectErr: status.Err(codes.Internal, "gRPC errors"),
+		},
+		{
+			desc: "client-side ClientStreaming decodes second grpc frame getting biz error",
+			role: remote.Client,
+			mode: serviceinfo.StreamingClient,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, kerrors.NewGRPCBizStatusError(10000, "test")).Times(1)
+				return mockIn
+			},
+			expectErr: kerrors.NewGRPCBizStatusError(10000, "test"),
+		},
+		{
+			desc: "client-side Unary decodes second grpc frame getting io.EOF => normal exit on the server side",
+			role: remote.Client,
+			mode: serviceinfo.StreamingUnary,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, io.EOF).Times(1)
+				return mockIn
+			},
+			expectErr: ErrInvalidPayload,
+		},
+		{
+			desc: "client-side Unary decodes second grpc frame getting biz error",
+			role: remote.Client,
+			mode: serviceinfo.StreamingUnary,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, kerrors.NewGRPCBizStatusError(10000, "test")).Times(1)
+				return mockIn
+			},
+			expectErr: kerrors.NewGRPCBizStatusError(10000, "test"),
+		},
+		{
+			desc: "client-side None decodes second grpc frame getting io.EOF => normal exit on the server side",
+			role: remote.Client,
+			mode: serviceinfo.StreamingUnary,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, io.EOF).Times(1)
+				return mockIn
+			},
+			expectErr: ErrInvalidPayload,
+		},
+		{
+			desc: "client-side None decodes second grpc frame getting biz error",
+			role: remote.Client,
+			mode: serviceinfo.StreamingNone,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				mockIn.EXPECT().Next(5).Return(nil, kerrors.NewGRPCBizStatusError(10000, "test")).Times(1)
+				return mockIn
+			},
+			expectErr: kerrors.NewGRPCBizStatusError(10000, "test"),
+		},
+		{
+			desc: "client-side ServerStreaming decodes",
+			role: remote.Client,
+			mode: serviceinfo.StreamingServer,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				return mockIn
+			},
+			expectErr: ErrInvalidPayload,
+		},
+		{
+			desc: "client-side BidiStreaming decodes",
+			role: remote.Client,
+			mode: serviceinfo.StreamingBidirectional,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				return mockIn
+			},
+			expectErr: ErrInvalidPayload,
+		},
+		{
+			desc: "server-side decodes",
+			role: remote.Server,
+			getByteBufferFunc: func() remote.ByteBuffer {
+				mockIn := mocksremote.NewMockByteBuffer(ctrl)
+				mockIn.EXPECT().Next(5).Return([]byte{0, 0, 0, 0, 1}, nil).Times(1)
+				mockIn.EXPECT().Next(1).Return([]byte{1}, nil).Times(1)
+				return mockIn
+			},
+			expectErr: ErrInvalidPayload,
+		},
+	}
+	mockServiceName := "grpcService"
+	mockMethod := "InvokeClientStreaming"
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			inv := rpcinfo.NewInvocation(mockServiceName, mockMethod)
+			inv.SetStreamingMode(tc.mode)
+			cfg := rpcinfo.NewRPCConfig()
+			// avoid unmarshal
+			rpcinfo.AsMutableRPCConfig(cfg).SetPayloadCodec(serviceinfo.PayloadCodec(-1))
+			ri := rpcinfo.NewRPCInfo(
+				rpcinfo.EmptyEndpointInfo(),
+				remoteinfo.NewRemoteInfo(&rpcinfo.EndpointBasicInfo{ServiceName: mockServiceName}, mockMethod).ImmutableView(),
+				inv, cfg, rpcinfo.NewRPCStats())
+			ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+			mockMsg := remote.NewMessage(nil, ri, remote.Stream, tc.role)
+			mockIn := tc.getByteBufferFunc()
+			err := codec.Decode(ctx, mockMsg, mockIn)
+			test.DeepEqual(t, err, tc.expectErr)
+		})
+	}
+}
+
+func Test_isNonServerStreaming(t *testing.T) {
+	testcases := []struct {
+		mode      serviceinfo.StreamingMode
+		expectRes bool
+	}{
+		{
+			mode:      serviceinfo.StreamingNone,
+			expectRes: true,
+		},
+		{
+			mode:      serviceinfo.StreamingUnary,
+			expectRes: true,
+		},
+		{
+			mode:      serviceinfo.StreamingClient,
+			expectRes: true,
+		},
+		{
+			mode:      serviceinfo.StreamingServer,
+			expectRes: false,
+		},
+		{
+			mode:      serviceinfo.StreamingBidirectional,
+			expectRes: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		test.Assert(t, isNonServerStreaming(tc.mode) == tc.expectRes)
+	}
+}

--- a/pkg/remote/trans/nphttp2/server_handler_test.go
+++ b/pkg/remote/trans/nphttp2/server_handler_test.go
@@ -88,6 +88,9 @@ func TestServerHandler(t *testing.T) {
 	msg.RPCInfoFunc = func() rpcinfo.RPCInfo {
 		return ri
 	}
+	msg.RPCRoleFunc = func() remote.RPCRole {
+		return remote.Server
+	}
 	npConn := newMockNpConn(mockAddr0)
 	npConn.mockSettingFrame()
 	tr, err := newMockServerTransport(npConn)

--- a/pkg/remote/trans/nphttp2/stream.go
+++ b/pkg/remote/trans/nphttp2/stream.go
@@ -121,7 +121,7 @@ func (s *serverStream) SetTrailer(tl streaming.Trailer) error {
 func (s *serverStream) RecvMsg(ctx context.Context, m interface{}) error {
 	ri := s.rpcInfo
 
-	msg := remote.NewMessage(m, ri, remote.Stream, remote.Client)
+	msg := remote.NewMessage(m, ri, remote.Stream, remote.Server)
 	defer msg.Recycle()
 
 	_, err := s.handler.Read(s.ctx, s.conn, msg)
@@ -133,7 +133,7 @@ func (s *serverStream) RecvMsg(ctx context.Context, m interface{}) error {
 func (s *serverStream) SendMsg(ctx context.Context, m interface{}) error {
 	ri := s.rpcInfo
 
-	msg := remote.NewMessage(m, ri, remote.Stream, remote.Client)
+	msg := remote.NewMessage(m, ri, remote.Stream, remote.Server)
 	defer msg.Recycle()
 
 	_, err := s.handler.Write(s.ctx, s.conn, msg)


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
ClientStreaming 场景下，server 侧调用```SendAndClose```后，可能还会 return 一个 err，例如：
```
stream.SendAndClose(resp)
return status.Err(codes.Internal, "some err")
```
在当前的 client 侧，调用```CloseAndRecv```后，只能拿到```resp```，但拿不到这个 err。然而在官方 gRPC 中是可以拿到这个 err 的。
根本原因在于当前 Kitex 每次 Read 都只能解析一个 Frame，但实际上在 ClientStreaming 场景，这次 Read 不仅需要读 Data Frame，还需要读 Trailer Frame。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->