### PR TITLE
[WIP] feat(generic): fail on nil value for required field

### DIFF
--- a/pkg/generic/option.go
+++ b/pkg/generic/option.go
@@ -41,6 +41,8 @@ type Options struct {
 	dynamicgoConvOpts conv.Options
 	// flag to set whether to store http resp body into HTTPResponse.RawBody
 	useRawBodyForHTTPResp bool
+	// will return error when field is required but input value is nil
+	failOnNilValueForRequiredField bool
 }
 
 type Option struct {
@@ -66,5 +68,12 @@ func WithCustomDynamicGoConvOpts(opts *conv.Options) Option {
 func UseRawBodyForHTTPResp(enable bool) Option {
 	return Option{F: func(opt *Options) {
 		opt.useRawBodyForHTTPResp = enable
+	}}
+}
+
+// will return error when field is required but input value is nil
+func WithFailOnNilValueForRequiredField(enable bool) Option {
+	return Option{F: func(opt *Options) {
+		opt.failOnNilValueForRequiredField = enable
 	}}
 }

--- a/pkg/generic/thrift/http.go
+++ b/pkg/generic/thrift/http.go
@@ -43,11 +43,12 @@ func NewHTTPReaderWriter(svc *descriptor.ServiceDescriptor) *HTTPReaderWriter {
 
 // WriteHTTPRequest implement of MessageWriter
 type WriteHTTPRequest struct {
-	svc                    *descriptor.ServiceDescriptor
-	binaryWithBase64       bool
-	convOpts               conv.Options // used for dynamicgo conversion
-	convOptsWithThriftBase conv.Options // used for dynamicgo conversion with EnableThriftBase turned on
-	dynamicgoEnabled       bool
+	svc                            *descriptor.ServiceDescriptor
+	binaryWithBase64               bool
+	convOpts                       conv.Options // used for dynamicgo conversion
+	convOptsWithThriftBase         conv.Options // used for dynamicgo conversion with EnableThriftBase turned on
+	dynamicgoEnabled               bool
+	failOnNilValueForRequiredField bool // will return error when field is required but input value is nil
 }
 
 var (
@@ -69,6 +70,10 @@ func NewWriteHTTPRequest(svc *descriptor.ServiceDescriptor) *WriteHTTPRequest {
 // Note that this method is not concurrent-safe.
 func (w *WriteHTTPRequest) SetBinaryWithBase64(enable bool) {
 	w.binaryWithBase64 = enable
+}
+
+func (w *WriteHTTPRequest) SetFailOnNilValueForRequiredField(enable bool) {
+	w.failOnNilValueForRequiredField = enable
 }
 
 // SetDynamicGo ...
@@ -94,7 +99,7 @@ func (w *WriteHTTPRequest) originalWrite(ctx context.Context, out bufiox.Writer,
 		requestBase = nil
 	}
 	bw := thrift.NewBufferWriter(out)
-	err = wrapStructWriter(ctx, req, bw, fn.Request, &writerOption{requestBase: requestBase, binaryWithBase64: w.binaryWithBase64})
+	err = wrapStructWriter(ctx, req, bw, fn.Request, &writerOption{requestBase: requestBase, binaryWithBase64: w.binaryWithBase64, failOnNilValueForRequiredField: w.failOnNilValueForRequiredField})
 	bw.Recycle()
 	return err
 }

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -35,6 +35,8 @@ type writerOption struct {
 	requestBase *base.Base // request base from metahandler
 	// decoding Base64 to binary
 	binaryWithBase64 bool
+	// will return error when field is required but input value is nil
+	failOnNilValueForRequiredField bool
 }
 
 type writer func(ctx context.Context, val interface{}, out *thrift.BufferWriter, t *descriptor.TypeDescriptor, opt *writerOption) error
@@ -778,6 +780,9 @@ func writeHTTPRequest(ctx context.Context, val interface{}, out *thrift.BufferWr
 
 		if v == nil {
 			if !field.Optional {
+				if opt != nil && opt.failOnNilValueForRequiredField {
+					return fmt.Errorf("value of field [%s] is nil", name)
+				}
 				if err := out.WriteFieldBegin(field.Type.Type.ToThriftTType(), int16(field.ID)); err != nil {
 					return err
 				}

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -1358,6 +1358,36 @@ func Test_writeHTTPRequest(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"writeStructRequiredFail",
+			args{
+				val: &descriptor.HTTPRequest{
+					Body: map[string]interface{}{"hello": nil},
+				},
+
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.STRUCT,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Struct: &descriptor.StructDescriptor{
+						Name: "Demo",
+						FieldsByName: map[string]*descriptor.FieldDescriptor{
+							"hello": {
+								Name:        "hello",
+								ID:          1,
+								Required:    true,
+								Type:        &descriptor.TypeDescriptor{Type: descriptor.STRING},
+								HTTPMapping: descriptor.DefaultNewMapping("hello"),
+							},
+						},
+					},
+				},
+				opt: &writerOption{
+					failOnNilValueForRequiredField: true,
+				},
+			},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1434,7 +1464,7 @@ func getReqPbBody() (proto.Message, error) {
 	path := "main.proto"
 	content := `
 	package kitex.test.server;
-	
+
 	message BizReq {
 		optional int32 user_id = 1;
 		optional string user_name = 2;


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

feat: Currently, generic HTTP calls in Thrift automatically fill in default zero values for fields missing in the HTTP request. This PR introduces an option that allows users to control whether to trigger an early error and reject the request when a required field is empty, intercepting the request in advance.

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
目前 generic http call thrift 默认会给 http 请求中不存在的值填零值。这个 PR 增加一个选项，让用户可以控制，当 required field 为空的时候，报错返回，提前拦截请求。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->