### PR TITLE
perf(rpcinfo): rm lock for rpcStats

### DIFF
--- a/pkg/rpcinfo/stats_util.go
+++ b/pkg/rpcinfo/stats_util.go
@@ -27,13 +27,17 @@ import (
 
 // Record records the event to RPCStats.
 func Record(ctx context.Context, ri RPCInfo, event stats.Event, err error) {
-	if ctx == nil || ri.Stats() == nil {
+	if ctx == nil {
+		return
+	}
+	st := ri.Stats()
+	if st == nil {
 		return
 	}
 	if err != nil {
-		ri.Stats().Record(ctx, event, stats.StatusError, err.Error())
+		st.Record(ctx, event, stats.StatusError, err.Error())
 	} else {
-		ri.Stats().Record(ctx, event, stats.StatusInfo, "")
+		st.Record(ctx, event, stats.StatusInfo, "")
 	}
 }
 


### PR DESCRIPTION
* use atomic for updating and retrieving events
* use embedded events. No pool needed for rpcStats

#### What type of PR is this?
perf

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
优化rpcinfo 中的 rpcStats，去掉锁。 

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->