### PR TITLE
test: fix gRPC TestClientMix data race

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -312,7 +312,6 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 	}
 	s.port = p
 	s.conns = make(map[ServerTransport]bool)
-	s.startedErr <- nil
 
 	// handle: 连接读数据和处理逻辑
 	var onConnect netpoll.OnConnect = func(ctx context.Context, connection netpoll.Connection) context.Context {
@@ -400,6 +399,7 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 	if err != nil {
 		panic("create netpoll event-loop fail")
 	}
+	s.startedErr <- nil
 
 	// 运行 Server
 	err = s.eventLoop.Serve(s.lis)


### PR DESCRIPTION
#### What type of PR is this?
test
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
test: 修复 gRPC ```TestClientMix``` 数据竞争问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
When server.start and server.stop are executed concurrently, it is possible to cause concurrent reads and writes to the eventloop field.
The eventloop field is assigned a value before execution is allowed to continue.
Unit Test context: https://github.com/cloudwego/kitex/actions/runs/11010654292/job/30573068741?pr=1559
zh(optional): 
当 server.start 与 server.stop 并发执行时，有可能造成 eventloop 字段的并发读写。
eventloop 字段赋值后才允许继续执行。
单测错误上下文：https://github.com/cloudwego/kitex/actions/runs/11010654292/job/30573068741?pr=1559

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->