### PR TITLE
perf(circuitbreak): no allocation for MW

### DIFF
--- a/pkg/circuitbreak/cbsuite_test.go
+++ b/pkg/circuitbreak/cbsuite_test.go
@@ -48,7 +48,7 @@ func TestNewCBSuite(t *testing.T) {
 	cb := NewCBSuite(RPCInfo2Key)
 	test.Assert(t, cb.servicePanel == nil)
 	test.Assert(t, cb.instancePanel == nil)
-	test.Assert(t, cb.instanceCBConfig.CBConfig == defaultCBConfig)
+	test.Assert(t, cb.instanceCBConfig.CBConfig == GetDefaultCBConfig())
 	test.Assert(t, sameFuncPointer(cb.genServiceCBKey, RPCInfo2Key))
 	test.Assert(t, sameFuncPointer(cb.config.instanceGetErrorTypeFunc, ErrorTypeOnInstanceLevel))
 	test.Assert(t, sameFuncPointer(cb.config.serviceGetErrorTypeFunc, ErrorTypeOnServiceLevel))
@@ -659,5 +659,16 @@ func TestCBConfig_Equals(t *testing.T) {
 				t.Errorf("Equals() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkCBSuiteMW(b *testing.B) {
+	ctx := prepareCtx()
+	p := NewCBSuite(func(ri rpcinfo.RPCInfo) string { return "BenchmarkCBSuite" })
+	smw := p.ServiceCBMW()
+	noop := func(ctx context.Context, req, resp interface{}) (err error) { return nil }
+	ep := smw(noop)
+	for i := 0; i < b.N; i++ {
+		ep(ctx, b, b)
 	}
 }


### PR DESCRIPTION
```
s.serviceCBConfig.LoadOrStore(serviceCBKey, defaultCBConfig)
```

`serviceCBKey` escapes due to any parameter
`defaultCBConfig` escapes due to passing struct to any parameter

```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/kitex/pkg/circuitbreak
             │  ./old.txt  │             ./new.txt              │
             │   sec/op    │   sec/op     vs base               │
CBSuiteMW-12   95.53n ± 4%   70.98n ± 7%  -25.69% (p=0.002 n=6)

             │ ./old.txt  │             ./new.txt             │
             │    B/op    │   B/op     vs base                │
CBSuiteMW-12   40.00 ± 0%   0.00 ± 0%  -100.00% (p=0.002 n=6)

             │ ./old.txt  │             ./new.txt              │
             │ allocs/op  │ allocs/op   vs base                │
CBSuiteMW-12   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
```

#### What type of PR is this?
perf

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
perf(circuitbreak): 无对象分配

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->