### PR TITLE
perf(retry): minimum obj alloc for context

### DIFF
--- a/pkg/retry/retryer_test.go
+++ b/pkg/retry/retryer_test.go
@@ -707,3 +707,27 @@ func TestNewRetryContainerWithCB(t *testing.T) {
 	test.Assertf(t, rc.cbContainer.cbStat == false, "cb_stat not false")
 	rc.Close()
 }
+
+func TestPrepareRetryContext(t *testing.T) {
+	ctx := PrepareRetryContext(context.Background())
+
+	test.Assert(t, *ctx.Value(CtxReqOp).(*int32) == OpNo)
+	test.Assert(t, *ctx.Value(CtxRespOp).(*int32) == OpNo)
+	*ctx.Value(CtxReqOp).(*int32) = OpDone
+	*ctx.Value(CtxRespOp).(*int32) = OpDone
+
+	test.Assert(t, *ctx.Value(CtxReqOp).(*int32) == OpDone)
+	test.Assert(t, *ctx.Value(CtxRespOp).(*int32) == OpDone)
+}
+
+var gctx context.Context // make sure the return value of PrepareRetryContext escapes
+
+func BenchmarkPrepareRetryContext(b *testing.B) {
+	var ctx context.Context
+	for i := 0; i < b.N; i++ {
+		ctx = PrepareRetryContext(context.Background())
+		_ = ctx.Value(CtxReqOp)
+		_ = ctx.Value(CtxRespOp)
+	}
+	gctx = ctx
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/kitex/pkg/retry
                       │  ./old.txt  │             ./new.txt              │
                       │   sec/op    │   sec/op     vs base               │
PrepareRetryContext-12   68.97n ± 1%   28.52n ± 2%  -58.64% (p=0.002 n=6)

                       │  ./old.txt  │             ./new.txt             │
                       │    B/op     │    B/op     vs base               │
PrepareRetryContext-12   104.00 ± 0%   24.00 ± 0%  -76.92% (p=0.002 n=6)

                       │ ./old.txt  │             ./new.txt             │
                       │ allocs/op  │ allocs/op   vs base               │
PrepareRetryContext-12   4.000 ± 0%   1.000 ± 0%  -75.00% (p=0.002 n=6)
```

#### What type of PR is this?
perf

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->