### PR TITLE
fix(wpool): no allocation and correct ctx

### DIFF
--- a/internal/wpool/pool_test.go
+++ b/internal/wpool/pool_test.go
@@ -17,6 +17,7 @@
 package wpool
 
 import (
+	"context"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -54,4 +55,16 @@ func TestWPool(t *testing.T) {
 		time.Sleep(maxIdleTime)
 	}
 	test.Assert(t, p.Size() == 0)
+}
+
+func BenchmarkWPool(b *testing.B) {
+	maxIdleWorkers := runtime.GOMAXPROCS(0)
+	ctx := context.Background()
+	p := New(maxIdleWorkers, 10*time.Millisecond)
+	for i := 0; i < b.N; i++ {
+		p.GoCtx(ctx, func() {})
+		for int(p.Size()) > maxIdleWorkers {
+			runtime.Gosched()
+		}
+	}
 }

--- a/pkg/profiler/profiler.go
+++ b/pkg/profiler/profiler.go
@@ -106,6 +106,12 @@ func Tag(ctx context.Context) {
 	}
 }
 
+// IsEnabled returns true if profiler is enabled
+// This func is short enough can be inlined, and likely it returns false
+func IsEnabled(ctx context.Context) bool {
+	return ctx.Value(profilerContextKey{}) != nil
+}
+
 // Untag current goroutine with tagged ctx
 // it's used for reuse goroutine scenario
 func Untag(ctx context.Context) {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/kitex/internal/wpool
         │  ./old.txt   │             ./new.txt              │
         │    sec/op    │   sec/op     vs base               │
WPool-12   562.7n ± 18%   542.2n ± 5%  -3.64% (p=0.029 n=10)

         │  ./old.txt  │             ./new.txt              │
         │    B/op     │    B/op     vs base                │
WPool-12   12.000 ± 8%   7.000 ± 0%  -41.67% (p=0.000 n=10)

         │ ./old.txt  │              ./new.txt              │
         │ allocs/op  │ allocs/op   vs base                 │
WPool-12   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

#### What type of PR is this?
fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复了 wpool 对象分配的问题，同时解决不正确ctx可能导致profiler误差。 

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->