### PR TITLE
perf(client): reduce obj alloc for RPCTimeoutMW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ testdata/
 # kitex binary
 tool/cmd/kitex/kitex
 
+# benchmark comparision
+old.txt
+new.txt
+
 # remote dump file
 *.json
 base1.go

--- a/client/rpctimeout_test.go
+++ b/client/rpctimeout_test.go
@@ -114,6 +114,20 @@ func TestNewRPCTimeoutMW(t *testing.T) {
 	test.Panic(t, func() { mw1(mw2(panicEp))(ctx, nil, nil) })
 }
 
+func BenchmarkRPCTimeoutMW(b *testing.B) {
+	s := rpcinfo.NewEndpointInfo("mockService", "mockMethod", nil, nil)
+	c := rpcinfo.NewRPCConfig()
+	r := rpcinfo.NewRPCInfo(nil, s, nil, c, rpcinfo.NewRPCStats())
+	m := rpcinfo.AsMutableRPCConfig(c)
+	m.SetRPCTimeout(20 * time.Millisecond)
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), r)
+	mw := rpcTimeoutMW(ctx)
+	ep := mw(func(ctx context.Context, req, resp interface{}) (err error) { return nil })
+	for i := 0; i < b.N; i++ {
+		ep(ctx, b, b)
+	}
+}
+
 func TestIsBusinessTimeout(t *testing.T) {
 	type args struct {
 		start        time.Time


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/kitex/client
                │  ./old.txt  │             ./new.txt              │
                │   sec/op    │   sec/op     vs base               │
RPCTimeoutMW-12   1.114µ ± 2%   1.064µ ± 1%  -4.45% (p=0.000 n=10)

                │ ./old.txt  │             ./new.txt             │
                │    B/op    │    B/op     vs base               │
RPCTimeoutMW-12   560.0 ± 0%   528.0 ± 0%  -5.71% (p=0.000 n=10)

                │ ./old.txt  │             ./new.txt              │
                │ allocs/op  │ allocs/op   vs base                │
RPCTimeoutMW-12   9.000 ± 0%   7.000 ± 0%  -22.22% (p=0.000 n=10)
```

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->