### PR TITLE
fix(netpoll): timeout when calling Next

### DIFF
--- a/pkg/remote/trans/netpoll/bytebuf_test.go
+++ b/pkg/remote/trans/netpoll/bytebuf_test.go
@@ -55,6 +55,18 @@ func TestByteBuffer(t *testing.T) {
 	test.Assert(t, err == nil)
 }
 
+func TestByteBuffer_Read(t *testing.T) {
+	const teststr = "testing"
+	buf := &bytes.Buffer{}
+	buf.WriteString(teststr)
+	r := NewReaderByteBuffer(netpoll.NewReader(buf))
+	b := make([]byte, len(teststr)+1)
+	n, err := r.Read(b)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, n == len(teststr), n)
+	test.Assert(t, string(b[:n]) == teststr)
+}
+
 // TestWriterBuffer test writerbytebufferr return writedirect err
 func TestWriterBuffer(t *testing.T) {
 	// 1. prepare mock data


### PR DESCRIPTION
#### What type of PR is this?
fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复部分使用 remote.ByteBuffer Read方法引起的timeout

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->