### PR TITLE
Introducing Kitex Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ English | [中文](README_cn.md)
 [![ClosedIssue](https://img.shields.io/github/issues-closed/cloudwego/kitex)](https://github.com/cloudwego/kitex/issues?q=is%3Aissue+is%3Aclosed)
 ![Stars](https://img.shields.io/github/stars/cloudwego/kitex)
 ![Forks](https://img.shields.io/github/forks/cloudwego/kitex)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Kitex%20Guru-006BFF)](https://gurubase.io/g/kitex)
 
 Kitex [kaɪt'eks] is a **high-performance** and **strong-extensibility** Go RPC framework that helps developers build microservices. If the performance and extensibility are the main concerns when you develop microservices, Kitex can be a good choice.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Kitex Guru](https://gurubase.io/g/kitex) to Gurubase. Kitex Guru uses the data from this repo and data from the [docs](https://www.cloudwego.io/docs/kitex/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Kitex Guru", which highlights that Kitex now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Kitex Guru in Gurubase, just let me know that's totally fine.
