### PR TITLE
feat(tool): kitex tool support gen frugal codec for certain struct

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -132,6 +132,9 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"Use local thriftgo exec instead of kitex embedded thriftgo.")
 	f.Var(&a.BuiltinTpl, "tpl", "Specify kitex built-in template.")
 
+	f.BoolVar(&a.GenFrugal, "gen_frugal", false, `Gen frugal codec for those structs with (go.codec="frugal")`)
+	f.Var(&a.FrugalStruct, "frugal_struct", "Gen frugal codec for given struct")
+
 	a.RecordCmd = os.Args
 	a.Version = version
 	a.ThriftOptions = append(a.ThriftOptions,

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -146,6 +146,9 @@ type Config struct {
 	Rapid             bool
 	LocalThriftgo     bool
 
+	GenFrugal    bool
+	FrugalStruct util.StringSlice
+
 	BuiltinTpl util.StringSlice // specify the built-in template to use
 }
 

--- a/tool/internal_pkg/generator/generator_test.go
+++ b/tool/internal_pkg/generator/generator_test.go
@@ -69,7 +69,7 @@ func TestConfig_Pack(t *testing.T) {
 		{
 			name:    "some",
 			fields:  fields{Features: []feature{feature(999)}, ThriftPluginTimeLimit: 30 * time.Second},
-			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false", "LocalThriftgo=false", "BuiltinTpl="},
+			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false", "LocalThriftgo=false", "GenFrugal=false", "FrugalStruct=", "BuiltinTpl="},
 		},
 	}
 	for _, tt := range tests {

--- a/tool/internal_pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/patcher.go
@@ -61,12 +61,32 @@ type patcher struct {
 	protocol              string
 	handlerReturnKeepResp bool
 
+	genFrugal    bool
+	frugalStruct []string
+
 	fileTpl *template.Template
 	libs    map[string]string
 }
 
 func (p *patcher) UseFrugalForStruct(st *golang.StructLike) bool {
-	return strings.Contains(st.ReservedComments, "@UseFrugal")
+	if len(p.frugalStruct) > 0 {
+		for _, structName := range p.frugalStruct {
+			if st.GetName() == structName {
+				return true
+			}
+		}
+		return false
+	} else {
+		if !p.genFrugal {
+			return false
+		}
+		for _, anno := range st.Annotations {
+			if anno.GetKey() == "go.codec" && len(anno.GetValues()) > 0 && anno.GetValues()[0] == "frugal" {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 func (p *patcher) UseLib(path, alias string) string {

--- a/tool/internal_pkg/pluginmode/thriftgo/patcher.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/patcher.go
@@ -65,6 +65,10 @@ type patcher struct {
 	libs    map[string]string
 }
 
+func (p *patcher) UseFrugalForStruct(st *golang.StructLike) bool {
+	return strings.Contains(st.ReservedComments, "@UseFrugal")
+}
+
 func (p *patcher) UseLib(path, alias string) string {
 	if p.libs == nil {
 		p.libs = make(map[string]string)
@@ -77,6 +81,7 @@ func (p *patcher) buildTemplates() (err error) {
 	m := p.utils.BuildFuncMap()
 	m["PrintImports"] = util.PrintlImports
 	m["UseLib"] = p.UseLib
+	m["UseFrugalForStruct"] = p.UseFrugalForStruct
 	m["ZeroWriter"] = ZeroWriter
 	m["ZeroBLength"] = ZeroBLength
 	m["ReorderStructFields"] = p.reorderStructFields

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -147,6 +147,8 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 		deepCopyAPI:           conv.Config.DeepCopyAPI,
 		protocol:              conv.Config.Protocol,
 		handlerReturnKeepResp: conv.Config.HandlerReturnKeepResp,
+		genFrugal:             conv.Config.GenFrugal,
+		frugalStruct:          conv.Config.FrugalStruct,
 	}
 	// for cmd without setting -module
 	if p.module == "" {

--- a/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
@@ -226,7 +226,7 @@ const StructLikeFastWriteNocopy = `
 func (p *{{$TypeName}}) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 {{- if UseFrugalForStruct .}}
 	{{- UseLib "github.com/cloudwego/frugal" "frugal"}}
-	n, err := frugal.EncodeObject(buf, nil, p)
+	n, err := frugal.EncodeObject(buf, w, p)
 	if err != nil {
 		return -1
 	}

--- a/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
@@ -42,6 +42,11 @@ const StructLikeFastRead = `
 {{define "StructLikeFastRead"}}
 {{- $TypeName := .GoName}}
 func (p *{{$TypeName}}) FastRead(buf []byte) (int, error) {
+{{- if UseFrugalForStruct .}}
+	{{- UseLib "github.com/cloudwego/frugal" "frugal"}}
+	return frugal.DecodeObject(buf, p)
+{{- else}}
+
 	var err error
 	var offset int
 	var l int
@@ -138,6 +143,7 @@ SkipFieldError:
 RequiredFieldNotSetError:
 	return offset, thrift.NewProtocolException(thrift.INVALID_DATA, fmt.Sprintf("required field %s is not set", fieldIDToName_{{$TypeName}}[fieldId]))
 {{- end}}{{/* if $NeedRequiredFieldNotSetError */}}
+{{- end}}{{/* frugal */}}
 }
 {{- end}}{{/* define "StructLikeFastRead" */}}
 `
@@ -218,6 +224,14 @@ const StructLikeFastWriteNocopy = `
 {{define "StructLikeFastWriteNocopy"}}
 {{- $TypeName := .GoName}}
 func (p *{{$TypeName}}) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
+{{- if UseFrugalForStruct .}}
+	{{- UseLib "github.com/cloudwego/frugal" "frugal"}}
+	n, err := frugal.EncodeObject(buf, nil, p)
+	if err != nil {
+		return -1
+	}
+	return n
+{{- else}}
 	offset := 0
 	{{- if eq .Category "union"}}
 	var c int
@@ -242,6 +256,7 @@ func (p *{{$TypeName}}) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 CountSetFieldsError:
 	panic(fmt.Errorf("%T write union: exactly one field must be set (%d set).", p, c))
 {{- end}}
+{{- end}}{{/* frugal */}}
 }
 {{- end}}{{/* define "StructLikeFastWriteNocopy" */}}
 `


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(tool)：支持让部分结构体生成时采用 frugal 编解码

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
support 2 ways to gen frugal codec for certain struct
1. add annotation (go.codec="frugal") after struct, and use '-gen-frugal' option for kitex tool when generating code.
2. use '-frugal-struct $structName' option for kitex tool when generating code. You can use this option multi times to config more structs.
3. The priority of '-frugal-struct' is higer than '-gen-frugal', if '-frugal-struct' is used, then kitex tool wouldn't gen frugal for those with annotations.

zh(optional): 
新支持了两种方式来指定为个别结构体生成 Frugal 编解码
1. 为结构体添加 (go.codec='frugal') 的 annotation，生成代码时添加 -gen-frugal 参数，这些结构体就会生成 Frugal 编解码
2. 使用 -frugal-struct $structName 来在生成时指定结构体，可以多次追加该参数来指定多个结构体名字
3. 当使用 -frugal-struct 的方式时，优先级更高，就不再为 -gen-frugal 的注解场景生成 frugal 编解码了

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->