### PR TITLE
feat(gRPC): optimize gRPC error prompt and metrics

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/http2_server.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_server.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/cloudwego/kitex/pkg/remote/codec/protobuf/encoding"
+	"github.com/cloudwego/kitex/pkg/remote/transmeta"
 
 	"github.com/cloudwego/netpoll"
 	"golang.org/x/net/http2"
@@ -58,21 +59,21 @@ const (
 var (
 	// ErrIllegalHeaderWrite indicates that setting header is illegal because of
 	// the stream's state.
-	ErrIllegalHeaderWrite = errors.New("transport: the stream is done or WriteHeader was already called")
+	ErrIllegalHeaderWrite       = errors.New("transport: the stream is done or WriteHeader was already called")
+	errStatusIllegalHeaderWrite = status.Err(codes.Internal, ErrIllegalHeaderWrite.Error()+triggeredByHandlerSideSuffix)
 
 	// ErrHeaderListSizeLimitViolation indicates that the header list size is larger
 	// than the limit set by peer.
 	ErrHeaderListSizeLimitViolation       = errors.New("transport: trying to send header list size larger than the limit set by peer")
-	errStatusHeaderListSizeLimitViolation = status.Err(codes.Internal, ErrHeaderListSizeLimitViolation.Error())
+	errStatusHeaderListSizeLimitViolation = status.Err(codes.Internal, ErrHeaderListSizeLimitViolation.Error()+triggeredByHandlerSideSuffix)
 
 	// errors used for cancelling stream.
 	// the code should be codes.Canceled coz it's NOT returned from remote
-	errConnectionEOF      = status.New(codes.Canceled, "transport: connection EOF").Err()
-	errStreamClosing      = status.New(codes.Canceled, "transport: stream is closing").Err()
-	errMaxStreamsExceeded = status.New(codes.Canceled, "transport: max streams exceeded").Err()
-	errNotReachable       = status.New(codes.Canceled, "transport: server not reachable").Err()
-	errMaxAgeClosing      = status.New(codes.Canceled, "transport: closing server transport due to maximum connection age").Err()
-	errIdleClosing        = status.New(codes.Canceled, "transport: closing server transport due to idleness").Err()
+	errConnectionEOF      = status.Err(codes.Canceled, "transport: connection EOF"+triggeredByRemoteServiceSuffix)
+	errMaxStreamsExceeded = status.Err(codes.Canceled, "transport: max streams exceeded"+triggeredByRemoteServiceSuffix)
+	errNotReachable       = status.Err(codes.Canceled, "transport: server not reachable"+triggeredByRemoteServiceSuffix)
+	errMaxAgeClosing      = status.Err(codes.Canceled, "transport: closing server transport due to maximum connection age"+triggeredByRemoteServiceSuffix)
+	errIdleClosing        = status.Err(codes.Canceled, "transport: closing server transport due to idleness"+triggeredByRemoteServiceSuffix)
 
 	errGracefulShutdown = status.Err(codes.Unavailable, gracefulShutdownMsg)
 )
@@ -187,14 +188,14 @@ func newHTTP2Server(ctx context.Context, conn net.Conn, config *ServerConfig) (_
 	}
 
 	if err := framer.WriteSettings(isettings...); err != nil {
-		return nil, connectionErrorf(false, err, "transport: %v", err)
+		return nil, status.Errorf(codes.Unavailable, "transport: %v", err)
 	}
 
 	// Adjust the connection flow control window if needed.
 	if icwz > defaultWindowSize {
 		if delta := icwz - defaultWindowSize; delta > 0 {
 			if err := framer.WriteWindowUpdate(0, delta); err != nil {
-				return nil, connectionErrorf(false, err, "transport: %v", err)
+				return nil, status.Errorf(codes.Unavailable, "transport: %v", err)
 			}
 		}
 	}
@@ -266,23 +267,23 @@ func newHTTP2Server(ctx context.Context, conn net.Conn, config *ServerConfig) (_
 		if err == io.EOF {
 			return nil, io.EOF
 		}
-		return nil, connectionErrorf(false, err, "transport: http2Server.HandleStreams failed to receive the preface from client: %v", err)
+		return nil, status.Errorf(codes.Unavailable, "transport: http2Server.HandleStreams failed to receive the preface from client: %v", err)
 	}
 	if !bytes.Equal(preface, ClientPreface) {
-		return nil, connectionErrorf(false, nil, "transport: http2Server.HandleStreams received bogus greeting from client: %q", preface)
+		return nil, status.Errorf(codes.Unavailable, "transport: http2Server.HandleStreams received bogus greeting from client: %q", preface)
 	}
 
 	frame, err := t.framer.ReadFrame()
 	if err == io.EOF || err == io.ErrUnexpectedEOF {
-		return nil, err
+		return nil, status.Errorf(codes.Unavailable, "transport: connection EOF: %v", err)
 	}
 	if err != nil {
-		return nil, connectionErrorf(false, err, "transport: http2Server.HandleStreams failed to read initial settings frame: %v", err)
+		return nil, status.Errorf(codes.Unavailable, "transport: http2Server.HandleStreams failed to read initial settings frame: %v", err)
 	}
 	atomic.StoreInt64(&t.lastRead, time.Now().UnixNano())
 	sf, ok := frame.(*grpcframe.SettingsFrame)
 	if !ok {
-		return nil, connectionErrorf(false, nil, "transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
+		return nil, status.Errorf(codes.Unavailable, "transport: http2Server.HandleStreams saw invalid preface type %T from client", frame)
 	}
 	t.handleSettings(sf)
 
@@ -310,10 +311,12 @@ func (t *http2Server) operateHeaders(frame *grpcframe.MetaHeadersFrame, handle f
 	}
 	if err := state.decodeHeader(frame); err != nil {
 		if se, ok := status.FromError(err); ok {
+			rstCode := statusCodeConvTab[se.Code()]
+			klog.CtxInfof(t.ctx, "KITEX: http2Server.operateHeaders failed to decode header frame, err=%v, rstCode: %d"+sendRSTStreamFrameSuffix, err, rstCode)
 			t.controlBuf.put(&cleanupStream{
 				streamID: streamID,
 				rst:      true,
-				rstCode:  statusCodeConvTab[se.Code()],
+				rstCode:  rstCode,
 				onWrite:  func() {},
 			})
 		}
@@ -345,6 +348,11 @@ func (t *http2Server) operateHeaders(frame *grpcframe.MetaHeadersFrame, handle f
 	// Attach the received metadata to the context.
 	if len(state.data.mdata) > 0 {
 		s.ctx = metadata.NewIncomingContext(s.ctx, state.data.mdata)
+		// retrieve source service from metadata
+		vals := state.data.mdata[transmeta.HTTPSourceService]
+		if len(vals) > 0 {
+			s.sourceService = vals[0]
+		}
 	}
 
 	t.mu.Lock()
@@ -355,6 +363,7 @@ func (t *http2Server) operateHeaders(frame *grpcframe.MetaHeadersFrame, handle f
 	}
 	if uint32(len(t.activeStreams)) >= t.maxStreams {
 		t.mu.Unlock()
+		klog.CtxInfof(t.ctx, "KITEX: http2Server.operateHeaders failed to create stream, rstCode: %d"+sendRSTStreamFrameSuffix, http2.ErrCodeRefusedStream)
 		t.controlBuf.put(&cleanupStream{
 			streamID: streamID,
 			rst:      true,
@@ -416,11 +425,10 @@ func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.
 				s := t.activeStreams[se.StreamID]
 				t.mu.Unlock()
 				if s != nil {
-					// it will be codes.Internal error for GRPC
-					// TODO: map http2.StreamError to status.Error?
-					s.cancel(err)
-					t.closeStream(s, status.Errorf(codes.Canceled, "transport: ReadFrame encountered http2.StreamError: %v", err), true, se.Code, false)
+					klog.CtxInfof(s.ctx, "KITEX: http2Server.HandleStreams encountered http2.StreamError, err=%v, rstCode: %d"+sendRSTStreamFrameSuffix, err, se.Code)
+					t.closeStream(s, status.Errorf(codes.Canceled, "transport: ReadFrame encountered http2.StreamError: %v [triggered by %s]", err, s.sourceService), true, se.Code, false)
 				} else {
+					klog.CtxInfof(t.ctx, "KITEX: http2Server.HandleStreams failed to ReadFrame, err=%v, rstCode: %d"+sendRSTStreamFrameSuffix, err, se.Code)
 					t.controlBuf.put(&cleanupStream{
 						streamID: se.StreamID,
 						rst:      true,
@@ -435,7 +443,7 @@ func (t *http2Server) HandleStreams(handle func(*Stream), traceCtx func(context.
 				return
 			}
 			klog.CtxWarnf(t.ctx, "transport: http2Server.HandleStreams failed to read frame: %v", err)
-			t.closeWithErr(err)
+			t.closeWithErr(status.Errorf(codes.Canceled, "transport: ReadFrame encountered err: %v"+triggeredByRemoteServiceSuffix, err))
 			return
 		}
 		switch frame := frame.(type) {
@@ -562,7 +570,8 @@ func (t *http2Server) handleData(f *grpcframe.DataFrame) {
 	}
 	if size > 0 {
 		if err := s.fc.onData(size); err != nil {
-			t.closeStream(s, status.Errorf(codes.Canceled, "transport: inflow control err: %v", err), true, http2.ErrCodeFlowControl, false)
+			klog.CtxInfof(s.ctx, "KITEX: http2Server.handleData inflow control err: %v, rstCode: %d"+sendRSTStreamFrameSuffix, err, http2.ErrCodeFlowControl)
+			t.closeStream(s, status.Errorf(codes.Canceled, "transport: inflow control err: %v [triggered by %s]", err, s.sourceService), true, http2.ErrCodeFlowControl, false)
 			return
 		}
 		if f.Header().Flags.Has(http2.FlagDataPadded) {
@@ -593,7 +602,7 @@ func (t *http2Server) handleRSTStream(f *http2.RSTStreamFrame) {
 		if f.ErrCode == gracefulShutdownCode {
 			t.closeStream(s, errGracefulShutdown, false, 0, false)
 		} else {
-			t.closeStream(s, status.Errorf(codes.Canceled, "transport: RSTStream Frame received with error code: %v", f.ErrCode), false, 0, false)
+			t.closeStream(s, status.Errorf(codes.Canceled, "transport: RSTStream Frame received with error code: %v [triggered by %s]", f.ErrCode, s.sourceService), false, 0, false)
 		}
 		return
 	}
@@ -730,8 +739,11 @@ func (t *http2Server) checkForHeaderListSize(it interface{}) bool {
 
 // WriteHeader sends the header metadata md back to the client.
 func (t *http2Server) WriteHeader(s *Stream, md metadata.MD) error {
-	if s.updateHeaderSent() || s.getState() == streamDone {
-		return ErrIllegalHeaderWrite
+	if s.updateHeaderSent() {
+		return errStatusIllegalHeaderWrite
+	}
+	if s.getState() == streamDone {
+		return ContextErr(s.ctx.Err())
 	}
 	s.hdrMu.Lock()
 	if md.Len() > 0 {
@@ -775,8 +787,9 @@ func (t *http2Server) writeHeaderLocked(s *Stream) error {
 		if err != nil {
 			return err
 		}
+		klog.CtxInfof(s.ctx, "KITEX: http2Server.writeHeaderLocked checkForHeaderListSize failed, rstCode: %d"+sendRSTStreamFrameSuffix, http2.ErrCodeInternal)
 		t.closeStream(s, errStatusHeaderListSizeLimitViolation, true, http2.ErrCodeInternal, false)
-		return ErrHeaderListSizeLimitViolation
+		return errStatusHeaderListSizeLimitViolation
 	}
 	return nil
 }
@@ -838,8 +851,9 @@ func (t *http2Server) WriteStatus(s *Stream, st *status.Status) error {
 		if err != nil {
 			return err
 		}
+		klog.CtxInfof(s.ctx, "KITEX: http2Server.WriteStatus checkForHeaderListSize failed, rstCode: %d"+sendRSTStreamFrameSuffix, http2.ErrCodeInternal)
 		t.closeStream(s, errStatusHeaderListSizeLimitViolation, true, http2.ErrCodeInternal, false)
-		return ErrHeaderListSizeLimitViolation
+		return errStatusHeaderListSizeLimitViolation
 	}
 	// Send a RST_STREAM after the trailers if the client has not already half-closed.
 	rst := s.getState() == streamActive
@@ -857,13 +871,6 @@ func (t *http2Server) Write(s *Stream, hdr, data []byte, opts *Options) error {
 	} else {
 		// Writing headers checks for this condition.
 		if s.getState() == streamDone {
-			// TODO(mmukhi, dfawley): Should the server write also return io.EOF?
-			s.cancel(errStreamClosing)
-			select {
-			case <-t.done:
-				return ErrConnClosing
-			default:
-			}
 			return ContextErr(s.ctx.Err())
 		}
 	}
@@ -875,11 +882,6 @@ func (t *http2Server) Write(s *Stream, hdr, data []byte, opts *Options) error {
 	df.originD = df.d
 	df.resetPingStrikes = &t.resetPingStrikes
 	if err := s.wq.get(int32(len(hdr) + len(data))); err != nil {
-		select {
-		case <-t.done:
-			return ErrConnClosing
-		default:
-		}
 		return ContextErr(s.ctx.Err())
 	}
 	return t.controlBuf.put(df)
@@ -1073,11 +1075,6 @@ func (t *http2Server) closeWithErr(reason error) error {
 
 // deleteStream deletes the stream s from transport's active streams.
 func (t *http2Server) deleteStream(s *Stream, eosReceived bool) {
-	// In case stream sending and receiving are invoked in separate
-	// goroutines (e.g., bi-directional streaming), cancel needs to be
-	// called to interrupt the potential blocking on other goroutines.
-	s.cancel(nil) // more details about the reason?
-
 	t.mu.Lock()
 	if _, ok := t.activeStreams[s.id]; ok {
 		delete(t.activeStreams, s.id)
@@ -1095,6 +1092,7 @@ func (t *http2Server) finishStream(s *Stream, rst bool, rstCode http2.ErrCode, h
 		// If the stream was already done, return.
 		return
 	}
+	s.cancel(nil)
 
 	hdr.cleanup = &cleanupStream{
 		streamID: s.id,

--- a/pkg/remote/trans/nphttp2/grpc/http_util_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/http_util_test.go
@@ -211,4 +211,6 @@ func TestConnectionError(t *testing.T) {
 	connectionError.err = context.Canceled
 	ori = connectionError.Origin()
 	test.Assert(t, ori == context.Canceled)
+
+	test.Assert(t, connectionError.Code() == 14)
 }

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -775,10 +775,15 @@ func (e ConnectionError) Origin() error {
 	return e.err
 }
 
+// Code returns the error code of this connection error to solve the metrics problem(no error code).
+// It always returns codes.Unavailable to be aligned with official gRPC-go.
+func (e ConnectionError) Code() int32 {
+	return int32(codes.Unavailable)
+}
+
 var (
 	// ErrConnClosing indicates that the transport is closing.
-	ErrConnClosing       = connectionErrorf(true, nil, "transport is closing")
-	errStatusConnClosing = status.Err(codes.Unavailable, "transport is closing")
+	ErrConnClosing = connectionErrorf(true, nil, "transport is closing")
 
 	// errStreamDone is returned from write at the client side to indicate application
 	// layer of an error.

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -942,9 +942,7 @@ func TestLargeMessageSuspension(t *testing.T) {
 	msg := make([]byte, initialWindowSize*8)
 	ct.Write(s, nil, msg, &Options{})
 	err = ct.Write(s, nil, msg, &Options{Last: true})
-	if err != errStreamDone {
-		t.Fatalf("write got %v, want io.EOF", err)
-	}
+	test.Assert(t, errors.Is(err, ContextErr(ctx.Err())), err)
 	expectedErr := status.Err(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
 	if _, err := s.Read(make([]byte, 8)); err.Error() != expectedErr.Error() {
 		t.Fatalf("Read got %v of type %T, want %v", err, err, expectedErr)


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(gRPC): 优化 gRPC 错误提示

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
zh: 
- Send 返回的 the stream is done 错误将变成流被关闭的真正原因，Recv 返回的 connection error 打点由 -1 变为 14，消除 -1 打点
- 增加发送 Rst Frame 的日志

en: 
- "the stream is done" error returned by Send would be replaced as the real reason causing stream closed, "connection error" metric returned by Recv would become 14 from -1, then eliminate -1 metric.
- Add logs for sending Rst Frame

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->