### PR TITLE
fix(client): rpctimeout would cause ctx panic

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -125,7 +125,12 @@ func rpcTimeoutMW(mwCtx context.Context) endpoint.Middleware {
 			}
 			start := time.Now()
 			ctx, err := workerPool.RunTask(ctx, tm, request, response, backgroundEP)
-			if ctx.Err() != nil { // context.Canceled or context.DeadlineExceeded?
+			if err == nil {
+				return nil
+			}
+			if err == ctx.Err() {
+				// err is from ctx.Err()
+				// either parent is cancelled by user, or timeout
 				return makeTimeoutErr(ctx, start, tm)
 			}
 			return err

--- a/client/rpctimeout_pool_test.go
+++ b/client/rpctimeout_pool_test.go
@@ -49,7 +49,7 @@ func TestTimeoutPool(t *testing.T) {
 					atomic.AddInt32(&sum, 1)
 					return nil
 				})
-			test.Assert(t, err == nil && ctx.Err() == nil)
+			test.Assert(t, err == nil && ctx.Err() == context.Canceled, err, ctx.Err())
 		}()
 	}
 	wg.Wait()
@@ -89,7 +89,7 @@ func TestTask(t *testing.T) {
 		go p.Run()
 		ctx, err := p.Wait()
 		test.Assert(t, returnErr == err, err)
-		test.Assert(t, ctx.Err() == nil, ctx.Err())
+		test.Assert(t, ctx.Err() == context.Canceled, ctx.Err())
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
@@ -144,6 +144,6 @@ func TestTask(t *testing.T) {
 		go p.Run()
 		ctx, err := p.Wait()
 		test.Assert(t, err != nil && strings.Contains(err.Error(), "testpanic"), err)
-		test.Assert(t, ctx.Err() == nil)
+		test.Assert(t, ctx.Err() == context.Canceled, ctx.Err())
 	})
 }

--- a/client/rpctimeout_test.go
+++ b/client/rpctimeout_test.go
@@ -98,7 +98,7 @@ func TestNewRPCTimeoutMW(t *testing.T) {
 	mw1 = rpctimeout.MiddlewareBuilder(0)(mwCtx)
 	mw2 = rpcTimeoutMW(mwCtx)
 	err = mw1(mw2(panicEp))(ctx, nil, nil)
-	test.Assert(t, strings.Contains(err.Error(), panicMsg))
+	test.Assert(t, strings.Contains(err.Error(), panicMsg), err)
 
 	// 6. panic without timeout, panic won't be recovered in timeout mw, but it will be recoverd in client.Call
 	m.SetRPCTimeout(0)


### PR DESCRIPTION
#### What type of PR is this?
fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
This issue is introduced by #1581 

zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->