### PR TITLE
fix(generic): Package information in idl missing when using protobuf generic streaming

### DIFF
--- a/client/genericclient/generic_stream_service.go
+++ b/client/genericclient/generic_stream_service.go
@@ -104,6 +104,9 @@ func newClientStreamingServiceInfo(g generic.Generic) *serviceinfo.ServiceInfo {
 		if extra.GetExtra(generic.CombineServiceKey) == "true" {
 			svcInfo.Extra["combine_service"] = true
 		}
+		if pkg := extra.GetExtra("PackageName"); pkg != "" {
+			svcInfo.Extra["PackageName"] = pkg
+		}
 	}
 	return svcInfo
 }

--- a/client/genericclient/generic_stream_service_test.go
+++ b/client/genericclient/generic_stream_service_test.go
@@ -36,6 +36,7 @@ func TestGenericStreamService(t *testing.T) {
 	svcInfo := newClientStreamingServiceInfo(g)
 	test.Assert(t, svcInfo.Extra["generic"] == true)
 	test.Assert(t, svcInfo.Extra["combine_service"] == nil)
+	test.Assert(t, svcInfo.Extra["PackageName"] == "pbapi")
 	svcInfo.GenericMethod = func(name string) serviceinfo.MethodInfo {
 		return svcInfo.Methods[name]
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytedance/gopkg v0.1.1
 	github.com/bytedance/sonic v1.12.5
 	github.com/cloudwego/configmanager v0.2.2
-	github.com/cloudwego/dynamicgo v0.4.6
+	github.com/cloudwego/dynamicgo v0.4.7-0.20241220085612-55704ea4ca8f
 	github.com/cloudwego/fastpb v0.0.5
 	github.com/cloudwego/frugal v0.2.3
 	github.com/cloudwego/gopkg v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/configmanager v0.2.2 h1:sVrJB8gWYTlPV2OS3wcgJSO9F2/9Zbkmcm1Z7jempOU=
 github.com/cloudwego/configmanager v0.2.2/go.mod h1:ppiyU+5TPLonE8qMVi/pFQk2eL3Q4P7d4hbiNJn6jwI=
-github.com/cloudwego/dynamicgo v0.4.6 h1:raRdvLN1WsGl5WsNd2Ul86s8PFQPu8soF4ALSJ9MdC4=
-github.com/cloudwego/dynamicgo v0.4.6/go.mod h1:DknfxjIMuGvXow409bS/AWycXONdc02HECBL0qpNqTY=
+github.com/cloudwego/dynamicgo v0.4.7-0.20241220085612-55704ea4ca8f h1:IERXjxDg3Pbatb5z/dR8Qr8XUA1FpDVa73BnwbeQ76U=
+github.com/cloudwego/dynamicgo v0.4.7-0.20241220085612-55704ea4ca8f/go.mod h1:DknfxjIMuGvXow409bS/AWycXONdc02HECBL0qpNqTY=
 github.com/cloudwego/fastpb v0.0.5 h1:vYnBPsfbAtU5TVz5+f9UTlmSCixG9F9vRwaqE0mZPZU=
 github.com/cloudwego/fastpb v0.0.5/go.mod h1:Bho7aAKBUtT9RPD2cNVkTdx4yQumfSv3If7wYnm1izk=
 github.com/cloudwego/frugal v0.2.3 h1:t1hhhAi8lXcx7Ncs4PR1pSZ90vlDU1cy5K2btDMFpoA=

--- a/pkg/generic/generic.go
+++ b/pkg/generic/generic.go
@@ -59,7 +59,10 @@ type ExtraProvider interface {
 	GetExtra(key string) string
 }
 
-const CombineServiceKey = "combine_service"
+const (
+	CombineServiceKey = "combine_service"
+	packageNameKey    = "PackageName"
+)
 
 // BinaryThriftGeneric raw thrift binary Generic
 func BinaryThriftGeneric() Generic {

--- a/pkg/generic/grpcjsonpb_test/generic_init.go
+++ b/pkg/generic/grpcjsonpb_test/generic_init.go
@@ -33,11 +33,9 @@ import (
 	"github.com/cloudwego/kitex/transport"
 )
 
-func newGenericClient(g generic.Generic, targetIPPort string) genericclient.Client {
-	cli, err := genericclient.NewStreamingClient("destService", g,
-		client.WithTransportProtocol(transport.GRPC),
-		client.WithHostPorts(targetIPPort),
-	)
+func newGenericClient(g generic.Generic, targetIPPort string, cliOpts ...client.Option) genericclient.Client {
+	cliOpts = append(cliOpts, client.WithTransportProtocol(transport.GRPC), client.WithHostPorts(targetIPPort))
+	cli, err := genericclient.NewStreamingClient("destService", g, cliOpts...)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/generic/grpcjsonpb_test/generic_test.go
+++ b/pkg/generic/grpcjsonpb_test/generic_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	dproto "github.com/cloudwego/dynamicgo/proto"
 	"github.com/tidwall/gjson"
@@ -54,7 +53,6 @@ func TestClientStreaming(t *testing.T) {
 		req := fmt.Sprintf(`{"message": "grpc client streaming generic %dth request"}`, i)
 		err = streamCli.Send(req)
 		test.Assert(t, err == nil)
-		time.Sleep(100 * time.Millisecond)
 	}
 	resp, err := streamCli.CloseAndRecv()
 	test.Assert(t, err == nil)
@@ -87,7 +85,6 @@ func TestServerStreaming(t *testing.T) {
 			fmt.Printf("serverStreaming message received: %s\n", strResp)
 			test.Assert(t, strings.Contains(strResp, "grpc server streaming generic request ->"))
 		}
-		time.Sleep(100 * time.Millisecond)
 	}
 }
 
@@ -130,7 +127,6 @@ func TestBidirectionalStreaming(t *testing.T) {
 				fmt.Printf("bidirectionalStreaming message received: %s\n", strResp)
 				test.Assert(t, strings.Contains(strResp, "th response"))
 			}
-			time.Sleep(100 * time.Millisecond)
 		}
 	}()
 	wg.Wait()

--- a/pkg/generic/jsonpb_codec.go
+++ b/pkg/generic/jsonpb_codec.go
@@ -56,6 +56,7 @@ func newJsonPbCodec(p PbDescriptorProviderDynamicGo, opts *Options) *jsonPbCodec
 	convOpts := opts.dynamicgoConvOpts
 	c.convOpts = convOpts
 	c.setCombinedServices(svc.IsCombinedServices())
+	c.setPackageName(svc.PackageName())
 
 	c.svcDsc.Store(svc)
 	go c.update()
@@ -80,6 +81,10 @@ func (c *jsonPbCodec) setCombinedServices(isCombinedServices bool) {
 	} else {
 		c.extra[CombineServiceKey] = "false"
 	}
+}
+
+func (c *jsonPbCodec) setPackageName(pkg string) {
+	c.extra[packageNameKey] = pkg
 }
 
 func (c *jsonPbCodec) getMessageReaderWriter() interface{} {

--- a/pkg/generic/jsonpb_codec_test.go
+++ b/pkg/generic/jsonpb_codec_test.go
@@ -53,6 +53,7 @@ func TestJsonPbCodec(t *testing.T) {
 	test.Assert(t, method.StreamingMode == serviceinfo.StreamingNone)
 	test.Assert(t, jpc.svcName == "Echo")
 	test.Assert(t, jpc.extra[CombineServiceKey] == "false")
+	test.Assert(t, jpc.extra[packageNameKey] == "test")
 
 	rw := jpc.getMessageReaderWriter()
 	_, ok := rw.(gproto.MessageWriter)


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(generic): 使用 protobuf 流式泛化调用时，idl 中的 Package 信息丢失

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Take the following pb idl as an example:
```
syntax = "proto3";

package a.b.c;

option go_package = "grpc_official_demo/official";

message Request {
  string message = 1;
}

message Response {
  string message = 1;
}

service GRPCEchoService {
  rpc EchoUnary(Request) returns (Response) {}
  rpc EchoClient(stream Request) returns (Response) {}
  rpc EchoServer(Request) returns (stream Response) {}
  rpc EchoBidi(stream Request) returns (stream Response) {}
}
```
To request EchoServer, for a standard gRPC request, “:path” is filled with “/a.b.c.GRPCEchoService/EchoServer” Where “a.b.c” is the Package of the pb idl.
The current Kitex Json2Pb Streaming generic call using dynamicgo does not resolve to the pb idl's Package, the ":path" is filled with "/GRPCEchoService/EchoServer", and there is problem to  access to other official gRPC libraries such as gRPC-python.

zh(optional): 
以下列 pb idl 为例：
```
syntax = "proto3";

package a.b.c;

option go_package = "grpc_official_demo/official";

message Request {
  string message = 1;
}

message Response {
  string message = 1;
}

service GRPCEchoService {
  rpc EchoUnary(Request) returns (Response) {}
  rpc EchoClient(stream Request) returns (Response) {}
  rpc EchoServer(Request) returns (stream Response) {}
  rpc EchoBidi(stream Request) returns (stream Response) {}
}
```
要请求 EchoServer，对于一个标准的 gRPC 请求，":path" 填入的值为 "/a.b.c.GRPCEchoService/EchoServer"。
其中 "a.b.c" 为 pb idl 的 Package。
当前 Kitex Json2Pb Streaming 泛化调用利用 dynamicgo 无法解析到 pb idl 的 Package，":path" 填入的值为 "/GRPCEchoService/EchoServer"，无法访问 gRPC-python 等其他官方 gRPC 库。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->