### PR TITLE
feat(gRPC): add monitor closeStreamTask for cancelled gRPC client stream

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
           cache: false
       - name: Scenario Tests
         run: |
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
       - name: Benchmark
         # we only use this CI to verify bench code works
         # setting benchtime=100ms is saving our time...
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
       - name: Prepare
         run: |  
           go install github.com/cloudwego/thriftgo@main
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
           cache: false # don't use cache for self-hosted runners
       - name: Windows compatibility test
         run: go test -run=^$ ./...

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -46,7 +46,13 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/peer"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+	"github.com/cloudwego/kitex/pkg/utils"
 )
+
+// ticker is used to manage closeStreamTask.
+// it triggers and cleans up actively cancelled streams every 5s.
+// Streaming QPS is generally not too high, if there is a requirement for timeliness, then consider making it configurable.
+var ticker = utils.NewSharedTicker(5 * time.Second)
 
 // http2Client implements the ClientTransport interface with HTTP2.
 type http2Client struct {
@@ -200,6 +206,13 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 		}
 	}
 	t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst)
+	task := &closeStreamTask{t: t}
+	t.onClose = func() {
+		onClose()
+		// when http2Client has been closed, remove this task
+		ticker.Delete(task)
+	}
+	ticker.Add(task)
 
 	// Start the reader goroutine for incoming message. Each transport has
 	// a dedicated goroutine which reads HTTP2 frame from network. Then it
@@ -270,6 +283,34 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 	}, gofunc.NewBasicInfo(remoteService, conn.RemoteAddr().String()))
 
 	return t, nil
+}
+
+// closeStreamTask is used to clean up streams that have been actively cancelled by users
+type closeStreamTask struct {
+	t              *http2Client
+	toCloseStreams []*Stream
+}
+
+func (task closeStreamTask) Tick() {
+	trans := task.t
+	trans.mu.Lock()
+	for _, stream := range trans.activeStreams {
+		select {
+		// judge whether stream has been canceled
+		case <-stream.Context().Done():
+			task.toCloseStreams = append(task.toCloseStreams, stream)
+		default:
+		}
+	}
+	trans.mu.Unlock()
+
+	for i, stream := range task.toCloseStreams {
+		// uniformly converted to status error
+		sErr := ContextErr(stream.Context().Err())
+		trans.closeStream(stream, sErr, true, http2.ErrCodeCancel, status.Convert(sErr), nil, false)
+		task.toCloseStreams[i] = nil
+	}
+	task.toCloseStreams = task.toCloseStreams[:0]
 }
 
 type preAllocatedStreamFields struct {

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -52,7 +52,8 @@ import (
 // ticker is used to manage closeStreamTask.
 // it triggers and cleans up actively cancelled streams every 5s.
 // Streaming QPS is generally not too high, if there is a requirement for timeliness, then consider making it configurable.
-var ticker = utils.NewSharedTicker(5 * time.Second)
+// To reduce the overhead of goroutines in a multi-connection scenario, use the Sync SharedTicker
+var ticker = utils.NewSyncSharedTicker(5 * time.Second)
 
 // http2Client implements the ClientTransport interface with HTTP2.
 type http2Client struct {

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/grpcframe"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc/testutils"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+	"github.com/cloudwego/kitex/pkg/utils"
 )
 
 type server struct {
@@ -99,6 +100,7 @@ const (
 	pingpong
 
 	gracefulShutdown
+	cancel
 )
 
 func (h *testStreamHandler) handleStreamAndNotify(s *Stream) {
@@ -317,6 +319,17 @@ func (h *testStreamHandler) gracefulShutdown(t *testing.T, s *Stream) {
 	test.Assert(t, st.Code() == codes.Unavailable, st)
 }
 
+func (h *testStreamHandler) handleStreamCancel(t *testing.T, s *Stream) {
+	header := make([]byte, 5)
+	_, err := s.Read(header)
+	test.Assert(t, err != nil, err)
+	st, ok := status.FromError(err)
+	test.Assert(t, ok)
+	test.Assert(t, st.Code() == codes.Canceled, st.Code())
+	test.Assert(t, strings.Contains(st.Message(), "transport: RSTStream Frame received with error code"), st.Message())
+	close(h.srv.srvReady)
+}
+
 // start starts server. Other goroutines should block on s.readyChan for further operations.
 func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hType) {
 	// 创建 listener
@@ -416,6 +429,12 @@ func (s *server) start(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 					}()
 				}, func(ctx context.Context, method string) context.Context { return ctx })
 			}()
+		case cancel:
+			go transport.HandleStreams(func(s *Stream) {
+				go h.handleStreamCancel(t, s)
+			}, func(ctx context.Context, method string) context.Context {
+				return ctx
+			})
 		default:
 			go func() {
 				transport.HandleStreams(func(s *Stream) {
@@ -2136,4 +2155,31 @@ func Test_isIgnorable(t *testing.T) {
 	test.Assert(t, !isIgnorable(err))
 
 	test.Assert(t, isIgnorable(ErrConnClosing))
+}
+
+func Test_closeStreamTask(t *testing.T) {
+	// replace ticker to reduce test time
+	ticker = utils.NewSharedTicker(10 * time.Millisecond)
+	server, ct := setUp(t, 0, math.MaxUint32, cancel)
+	callHdr := &CallHdr{
+		Host:   "localhost",
+		Method: "foo.Small",
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := ct.NewStream(ctx, callHdr)
+	if err != nil {
+		t.Fatalf("failed to open stream: %v", err)
+	}
+	cancel()
+	// wait for server receiving RstStream Frame
+	<-server.srvReady
+	state := stream.getState()
+	test.Assert(t, state == streamDone, state)
+	ct.mu.Lock()
+	streamNums := len(ct.activeStreams)
+	ct.mu.Unlock()
+	test.Assert(t, streamNums == 0, streamNums)
+
+	ct.Close(errSelfCloseForTest)
+	server.stop()
 }

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -1546,8 +1546,11 @@ func TestEncodingRequiredStatus(t *testing.T) {
 		return
 	}
 	opts := Options{Last: true}
-	if err := ct.Write(s, nil, expectedRequest, &opts); err != nil && err != errStreamDone {
-		t.Fatalf("Failed to write the request: %v", err)
+	if err := ct.Write(s, nil, expectedRequest, &opts); err != nil {
+		// in case server-side returns earlier, Write also returns a status error.
+		if err != errStatusStreamDone || !testutils.StatusErrEqual(s.Status().Err(), encodingTestStatus.Err()) {
+			t.Fatalf("Failed to write the request: %v", err)
+		}
 	}
 	p := make([]byte, http2MaxFrameLen)
 	if _, err := s.trReader.(*transportReader).Read(p); err != io.EOF {

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -2162,7 +2162,7 @@ func Test_isIgnorable(t *testing.T) {
 
 func Test_closeStreamTask(t *testing.T) {
 	// replace ticker to reduce test time
-	ticker = utils.NewSharedTicker(10 * time.Millisecond)
+	ticker = utils.NewSyncSharedTicker(10 * time.Millisecond)
 	server, ct := setUp(t, 0, math.MaxUint32, cancel)
 	callHdr := &CallHdr{
 		Host:   "localhost",


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(gRPC): 为已经被 cancel 的 gRPC client stream 添加一个监测 closeStreamTask

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
Currently either the user calls the```cancel```function, or the parent stream is cancelled:
- handler exits
- Parent stream received RstStream Frame
- ...
Users have to call```stream.Recv()```to detect if the ctx has been cancelled and close the stream, which is not intuitive.
Therefore, the closeStreamTask is introduced to periodically (currently 5s) detect streams that have been cancelled to avoid stream leakage.

zh(optional): 
当前无论是用户主动调用```cancel```函数，还是父 stream 被 cancel：
- handler 退出
- 父 stream 收到 RstStream Frame
-  ...
都需要用户主动调用```stream.Recv()```来检测 ctx 是否被 cancel，从而关闭流，这样很不符合直觉。
因此引入 closeStreamTask 周期性地(当前为 5s)检测已经被 cancel 的 stream，避免 stream 泄漏。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->