### PR TITLE
fix(serviceinline): fix the issue of missing CtxEventBusKey and CtxEventQueueKey during server initialization in the service inline scenario

### DIFF
--- a/client/service_inline.go
+++ b/client/service_inline.go
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Service inline is a service deployment form of ByteDance's internal applications.
+// Different Kitex services are merged together during the compilation period through the tool chain, and this capability is not yet opensource.
 package client
 
 import (

--- a/server/service_inline.go
+++ b/server/service_inline.go
@@ -128,8 +128,9 @@ func (s *server) BuildServiceInlineInvokeChain() endpoint.Endpoint {
 			return
 		}
 	}
+	ctx := fillContext(s.opt)
 	mws := []endpoint.Middleware{mw}
-	smws := s.buildMiddlewares(context.Background())
+	smws := s.buildMiddlewares(ctx)
 	mws = append(mws, smws...)
 	return endpoint.Chain(mws...)(innerHandlerEp)
 }

--- a/server/service_inline.go
+++ b/server/service_inline.go
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Service inline is a service deployment form of ByteDance's internal applications.
+// Different Kitex services are merged together during the compilation period through the tool chain, and this capability is not yet opensource.
 package server
 
 import (
@@ -128,6 +130,11 @@ func (s *server) BuildServiceInlineInvokeChain() endpoint.Endpoint {
 			return
 		}
 	}
+
+	// In the internal service inline scenario, if the merged service does not detect the RPC Ingress Mesh being enabled
+	// (for example, if the main service is an API service, the RPC Ingress Mesh will not be enabled),
+	// the CtxEventQueueKey will be used to monitor configuration changes for debugging during server initialization.
+	// If this key is not injected, it will lead to a panic during initialization.
 	ctx := fillContext(s.opt)
 	mws := []endpoint.Middleware{mw}
 	smws := s.buildMiddlewares(ctx)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复service inline场景下server初始化缺失CtxEventBusKey，CtxEventQueueKey问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Note that this fix has no impact on open-source users. Service inline is a service deployment form of Bytedance internal applications. Different Kitex services are merged together during the compilation period through the tool chain, and this capability is not yet open to the outside world. 
zh(optional): 注意，该修复对开源用户无影响，service inline 是字节内部应用的一种服务部署形态，通过工具链将不同的 Kitex 服务在编译期合并到一起，该能力暂未对外开放，
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->