### PR TITLE
fix(tool): remove redundant dependency for streamx generation code

### DIFF
--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -546,9 +546,14 @@ func (g *generator) setImports(name string, pkg *PackageInfo) {
 	switch name {
 	case ClientFileName:
 		pkg.AddImports("client")
-		if !g.StreamX && pkg.HasStreaming {
-			pkg.AddImport("streaming", "github.com/cloudwego/kitex/pkg/streaming")
-			pkg.AddImport("transport", "github.com/cloudwego/kitex/transport")
+		if pkg.HasStreaming {
+			if !g.StreamX {
+				pkg.AddImport("streaming", "github.com/cloudwego/kitex/pkg/streaming")
+				pkg.AddImport("transport", "github.com/cloudwego/kitex/transport")
+			} else {
+				pkg.AddImports("github.com/cloudwego/kitex/client/streamxclient/streamxcallopt")
+				pkg.AddImports("github.com/cloudwego/kitex/pkg/streamx")
+			}
 		}
 		if len(pkg.AllMethods()) > 0 {
 			if needCallOpt(pkg) {

--- a/tool/internal_pkg/tpl/client.go
+++ b/tool/internal_pkg/tpl/client.go
@@ -28,14 +28,9 @@ import (
 			{{- end}}
 		{{- end}}
 	{{- end}}
-	{{- if .HasStreaming}}
-	{{- if not .StreamX}}
+	{{- if and .HasStreaming (not .StreamX) }}
 	"github.com/cloudwego/kitex/client/streamclient"
 	"github.com/cloudwego/kitex/client/callopt/streamcall"
-	{{- else}}
-	"github.com/cloudwego/kitex/client/streamxclient/streamxcallopt"
-	"github.com/cloudwego/kitex/pkg/streamx"
-	{{- end}}{{- /* if not .StreamX end */}}
 	{{- end}}
 )
 // Client is designed to provide IDL-compatible methods with call-option parameter for kitex framework.


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(工具): 移除 streamx 生成代码中的冗余依赖

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
When generating streamx code with ```-thrift no_fmt```, ```github.com/cloudwego/kitex/pkg/streamx``` is referenced twice:
```
"github.com/cloudwego/kitex/pkg/streamx"
"github.com/cloudwego/kitex/client/streamxclient/streamxcallopt"
"github.com/cloudwego/kitex/pkg/streamx"
```
Need to remove ```github.com/cloudwego/kitex/pkg/stream``` from the template since it is duplicated in the setImports.
zh(optional): 
当使用`-thrift no_fmt`生成 streamx 代码时，```github.com/cloudwego/kitex/pkg/streamx```会被重复引用：
```
"github.com/cloudwego/kitex/pkg/streamx"
"github.com/cloudwego/kitex/client/streamxclient/streamxcallopt"
"github.com/cloudwego/kitex/pkg/streamx"
```
需要将模版中的```github.com/cloudwego/kitex/pkg/stream```移除，和 setImports 中添加的依赖重复了。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->