### PR TITLE
test(streamx): fix streamx Recv timeout unit test

### DIFF
--- a/pkg/streamx/streamx_user_test.go
+++ b/pkg/streamx/streamx_user_test.go
@@ -619,18 +619,20 @@ func TestStreamingException(t *testing.T) {
 					}
 				}),
 			)
-			octx := context.Background()
 
 			// assert circuitBreaker error
+			octx := context.Background()
 			atomic.StoreInt32(&circuitBreaker, 1)
 			_, _, err = cli.BidiStream(octx)
 			test.Assert(t, errors.Is(err, circuitBreakerErr), err)
 			atomic.StoreInt32(&circuitBreaker, 0)
 
 			// assert context deadline error
-			ctx, cancel := context.WithTimeout(octx, time.Millisecond)
-			ctx, bs, err := cli.BidiStream(ctx)
+			octx = context.Background()
+			ctx, bs, err := cli.BidiStream(octx)
 			test.Assert(t, err == nil, err)
+			// ctx timeout should be injected before invoking Recv and after creating stream
+			ctx, cancel := context.WithTimeout(ctx, time.Millisecond)
 			res, err := bs.Recv(ctx)
 			cancel()
 			test.Assert(t, res == nil && err != nil, res, err)


### PR DESCRIPTION
#### What type of PR is this?
test
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
test(stream): 修复 streamx Recv 超时的测试用例

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
error case: https://github.com/cloudwego/kitex/actions/runs/12766989287/job/35584452262?pr=1674
Injecting too short a timeout into the ctx before creating the stream can potentially time out when doing service discovery:
![image](https://github.com/user-attachments/assets/22afbc00-53b0-4349-bff5-b2d14f495fee)
zh(optional): 
报错 case: https://github.com/cloudwego/kitex/actions/runs/12766989287/job/35584452262?pr=1674
在创建 stream 前往 ctx 中注入过短的 timeout，有可能在进行服务发现时超时：
![image](https://github.com/user-attachments/assets/22afbc00-53b0-4349-bff5-b2d14f495fee)

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->