### PR TITLE
ci: prepare for Windows X64 hosts

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: crate-ci/typos@v1.13.14
 
   golangci-lint:
-    runs-on: [ self-hosted, X64 ]
+    runs-on: [ Linux, X64 ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   unit-scenario-test:
-    runs-on: [ self-hosted, X64 ]
+    runs-on: [ Linux, X64 ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -34,12 +34,26 @@ jobs:
         # setting benchtime=100ms is saving our time...
         run: go test -bench=. -benchmem -run=none ./... -benchtime=100ms
 
-  compatibility-test:
+  compatibility-test-x64:
     strategy:
       matrix:
         go: [ "1.18", "1.19", "1.20", "1.21", "1.22", "1.23" ]
-        os: [ X64, ARM64 ]
-    runs-on: ${{ matrix.os }}
+    runs-on: [ Linux, X64 ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache: false # don't use cache for self-hosted runners
+      - name: Unit Test
+        run: go test -race ./...
+
+  compatibility-test-arm:
+    strategy:
+      matrix:
+        go: [ "1.18", "1.19", "1.20", "1.21", "1.22", "1.23" ]
+    runs-on: [ ARM64 ] # It's OK under Linux or macOS
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -80,15 +94,13 @@ jobs:
           bash ./codegen_run.sh        
 
   windows-test:
-    runs-on: windows-latest
-    env: # Fixes https://github.com/actions/setup-go/issues/240
-      GOMODCACHE: 'D:\go\pkg\mod'
-      GOCACHE: 'D:\go\go-build'
+    runs-on: [ Windows ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: stable
+          cache: false # don't use cache for self-hosted runners
       - name: Windows compatibility test
         run: go test -run=^$ ./...


### PR DESCRIPTION
#### What type of PR is this?
ci

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->