### PR TITLE
optimize(tool): optimize fastcodec->frugal replacement

### DIFF
--- a/tool/cmd/kitex/args/args.go
+++ b/tool/cmd/kitex/args/args.go
@@ -131,8 +131,7 @@ func (a *Arguments) buildFlags(version string) *flag.FlagSet {
 		"Generate streaming code with streamx interface",
 	)
 
-	f.BoolVar(&a.GenFrugal, "gen-frugal", false, `Gen frugal codec for those structs with (go.codec="frugal")`)
-	f.Var(&a.FrugalStruct, "frugal-struct", "Gen frugal codec for given struct")
+	f.Var(&a.FrugalStruct, "frugal-struct", "Replace fastCodec code to frugal. Use `-frugal-struct @all` for all, `-frugal-struct @auto` for annotated structs (go.codec=\"frugal\"), or specify multiple structs (e.g., `-frugal-struct A -frugal-struct B`).")
 
 	f.BoolVar(&a.NoRecurse, "no-recurse", false, `Don't generate thrift files recursively, just generate the given file.'`)
 

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -148,7 +148,6 @@ type Config struct {
 	Rapid             bool
 	LocalThriftgo     bool
 
-	GenFrugal    bool
 	FrugalStruct util.StringSlice
 	NoRecurse    bool
 

--- a/tool/internal_pkg/generator/generator_test.go
+++ b/tool/internal_pkg/generator/generator_test.go
@@ -67,7 +67,7 @@ func TestConfig_Pack(t *testing.T) {
 		{
 			name:    "some",
 			fields:  fields{Features: []feature{feature(999)}, ThriftPluginTimeLimit: 30 * time.Second},
-			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false", "LocalThriftgo=false", "GenFrugal=false", "FrugalStruct=", "NoRecurse=false", "BuiltinTpl=", "StreamX=false"},
+			wantRes: []string{"Verbose=false", "GenerateMain=false", "GenerateInvoker=false", "Version=", "NoFastAPI=false", "ModuleName=", "ServiceName=", "Use=", "IDLType=", "Includes=", "ThriftOptions=", "ProtobufOptions=", "Hessian2Options=", "IDL=", "OutputPath=", "PackagePrefix=", "CombineService=false", "CopyIDL=false", "ProtobufPlugins=", "Features=999", "FrugalPretouch=false", "ThriftPluginTimeLimit=30s", "CompilerPath=", "ExtensionFile=", "Record=false", "RecordCmd=", "TemplateDir=", "GenPath=", "DeepCopyAPI=false", "Protocol=", "HandlerReturnKeepResp=false", "NoDependencyCheck=false", "Rapid=false", "LocalThriftgo=false", "FrugalStruct=", "NoRecurse=false", "BuiltinTpl=", "StreamX=false"},
 		},
 	}
 	for _, tt := range tests {

--- a/tool/internal_pkg/pluginmode/thriftgo/plugin.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/plugin.go
@@ -147,7 +147,6 @@ func HandleRequest(req *plugin.Request) *plugin.Response {
 		deepCopyAPI:           conv.Config.DeepCopyAPI,
 		protocol:              conv.Config.Protocol,
 		handlerReturnKeepResp: conv.Config.HandlerReturnKeepResp,
-		genFrugal:             conv.Config.GenFrugal,
 		frugalStruct:          conv.Config.FrugalStruct,
 	}
 	// for cmd without setting -module

--- a/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
@@ -150,6 +150,7 @@ RequiredFieldNotSetError:
 
 const StructLikeFastReadField = `
 {{define "StructLikeFastReadField"}}
+{{- if not (UseFrugalForStruct .) }}
 {{- $TypeName := .GoName}}
 {{- range .Fields}}
 {{$FieldName := .GoName}}
@@ -177,6 +178,7 @@ func (p *{{$TypeName}}) FastReadField{{Str .ID}}(buf []byte) (int, error) {
 	return offset, nil
 }
 {{- end}}{{/* range .Fields */}}
+{{- end}}{{/* if not (UseFrugalForStruct .) */}}
 {{- end}}{{/* define "StructLikeFastReadField" */}}
 `
 
@@ -265,6 +267,10 @@ const StructLikeLength = `
 {{define "StructLikeLength"}}
 {{- $TypeName := .GoName}}
 func (p *{{$TypeName}}) BLength() int {
+{{- if UseFrugalForStruct .}}
+	{{- UseLib "github.com/cloudwego/frugal" "frugal"}}
+	return frugal.EncodedSize(p)
+{{- else}}
 	l := 0
 	{{- if eq .Category "union"}}
 	var c int
@@ -289,12 +295,14 @@ func (p *{{$TypeName}}) BLength() int {
 CountSetFieldsError:
 	panic(fmt.Errorf("%T write union: exactly one field must be set (%d set).", p, c))
 {{- end}}
+{{- end}}{{/* frugal */}}
 }
 {{- end}}{{/* define "StructLikeLength" */}}
 `
 
 const StructLikeFastWriteField = `
 {{define "StructLikeFastWriteField"}}
+{{- if not (UseFrugalForStruct .) }}
 {{- $TypeName := .GoName}}
 {{- range .Fields}}
 {{- $FieldName := .GoName}}
@@ -333,11 +341,13 @@ func (p *{{$TypeName}}) fastWriteField{{Str .ID}}(buf []byte, w thrift.NocopyWri
 	return offset
 }
 {{end}}{{/* range .Fields */}}
+{{- end}}{{/* if not (UseFrugalForStruct .) */}}
 {{- end}}{{/* define "StructLikeFastWriteField" */}}
 `
 
 const StructLikeFieldLength = `
 {{define "StructLikeFieldLength"}}
+{{- if not (UseFrugalForStruct .) }}
 {{- $TypeName := .GoName}}
 {{- range .Fields}}
 {{- $FieldName := .GoName}}
@@ -376,6 +386,7 @@ func (p *{{$TypeName}}) field{{Str .ID}}Length() int {
 	return l
 }
 {{end}}{{/* range .Fields */}}
+{{- end}}{{/* if not (UseFrugalForStruct .) */}}
 {{- end}}{{/* define "StructLikeFieldLength" */}}
 `
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
optimize(tool): 优化了生成工具关于 frugal 替换参数的实现逻辑

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
Previously: gen-frugal was used to decide whether to replace the implementation of structs with frugal based on annotations, and -frugal-struct xxx was used to pass the struct name when executing a command.

Now: Only the -frugal-struct parameter is retained, with different inputs achieving different effects:
1. -frugal-struct @all: Replaces all structs named fastCodec with frugal implementation.
2. -frugal-struct @auto: Replaces structs with annotations (equivalent to the previous gen-frugal parameter).
3. -frugal-struct xxxname: Specifies a specific struct, can be specified multiple times.

And also some template optimizations:
- implement BLength() by frugal EncodedSize.
- remove fastReadField, fastWriteField, fieldLength function because it's no longer used after frugal replacement.

zh(optional): 
把 -gen-frugal 和 -frugal-struct 合并了

之前：有 gen-frugal 来决定是否根据注解给结构体替换 frugal 实现，也有 -frugal-struct xxx 执行命令行时传入结构体名来替换
现在：只保留 -frugal-struct 参数，不同输入达到不同效果：
1. -frugal-struct @all：给所有结构体 fastCodec 都替换为 frugal 实现
2. -frugal-struct @auto: 给有注解的结构体替换（相当于之前的gen-frugal参数）
3. -frugal-struct xxxname: 指定具体结构体，可以多次指定，和之前一样

模板上也有一些改动：
1. BLength 也改为用 frugal EncodedSize 来替换实现了
2. 开启 frugal 替换后，不再生成  fastReadField, fastWriteField, fieldLength，因为用不到了

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->