### PR TITLE
Revert "fix(ttstream): pingpong method refers to server interface defined in Kitex generation code when streamx is enabled and there are other streaming methods"

### DIFF
--- a/tool/internal_pkg/tpl/service.go
+++ b/tool/internal_pkg/tpl/service.go
@@ -144,7 +144,6 @@ func newServiceInfo(hasStreaming bool, keepStreamingMethods bool, keepNonStreami
 	return svcInfo
 }
 
-{{- $referToKitexServerInterface := and .StreamX .HasStreaming}}
 {{range .AllMethods}}
 {{- $isStreaming := or .ClientStreaming .ServerStreaming}}
 {{- $streamingUnary := (eq .StreamingMode "unary")}}
@@ -154,10 +153,6 @@ func newServiceInfo(hasStreaming bool, keepStreamingMethods bool, keepNonStreami
 {{- $bidiSide := and .ClientStreaming .ServerStreaming}}
 {{- $arg := ""}}
 {{- $handlerFunc := ""}}
-{{- $serverInterfaceName := printf "%s.%s" .PkgRefName .ServiceName }}
-	{{- if $referToKitexServerInterface}}
-	{{- $serverInterfaceName = .ServiceName}}{{/* when streamx is enabled and there are streaming methods, refer to Server Interface defined in service/server.go */}}
-	{{- end}}
 {{- $mode := ""}}
     {{- if $streamingUnary -}} {{- $mode = "serviceinfo.StreamingUnary" }} {{- $handlerFunc = "InvokeUnaryHandler" }}
     {{- else if $serverSide -}} {{- $mode = "serviceinfo.StreamingServer" }} {{- $handlerFunc = "InvokeServerStreamHandler" }}
@@ -233,8 +228,8 @@ func {{LowerFirst .Name}}Handler(ctx context.Context, handler interface{}, arg, 
 	{{- end}}
 	{{if gt .ArgsLength 0}}realArg := {{else}}_ = {{end}}arg.(*{{if not .GenArgResultStruct}}{{.PkgRefName}}.{{end}}{{.ArgStructName}})
 	{{if or (not .Void) .Exceptions}}realResult := result.(*{{if not .GenArgResultStruct}}{{.PkgRefName}}.{{end}}{{.ResStructName}}){{end}}
-	{{if .Void}}err := handler.({{$serverInterfaceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
-	{{else}}success, err := handler.({{$serverInterfaceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
+	{{if .Void}}err := handler.({{.PkgRefName}}.{{.ServiceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
+	{{else}}success, err := handler.({{.PkgRefName}}.{{.ServiceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
 	{{end -}}
 	if err != nil {
 	{{- if $HandlerReturnKeepResp }}


### PR DESCRIPTION
Reverts cloudwego/kitex#1698