### PR TITLE
fix(ttstream): pingpong method refers to server interface defined in Kitex generation code when streamx is enabled and there are other streaming methods

### DIFF
--- a/tool/internal_pkg/tpl/service.go
+++ b/tool/internal_pkg/tpl/service.go
@@ -144,6 +144,7 @@ func newServiceInfo(hasStreaming bool, keepStreamingMethods bool, keepNonStreami
 	return svcInfo
 }
 
+{{- $referToKitexServerInterface := and .StreamX .HasStreaming}}
 {{range .AllMethods}}
 {{- $isStreaming := or .ClientStreaming .ServerStreaming}}
 {{- $streamingUnary := (eq .StreamingMode "unary")}}
@@ -153,6 +154,10 @@ func newServiceInfo(hasStreaming bool, keepStreamingMethods bool, keepNonStreami
 {{- $bidiSide := and .ClientStreaming .ServerStreaming}}
 {{- $arg := ""}}
 {{- $handlerFunc := ""}}
+{{- $serverInterfaceName := printf "%s.%s" .PkgRefName .ServiceName }}
+	{{- if $referToKitexServerInterface}}
+	{{- $serverInterfaceName = .ServiceName}}{{/* when streamx is enabled and there are streaming methods, refer to Server Interface defined in service/server.go */}}
+	{{- end}}
 {{- $mode := ""}}
     {{- if $streamingUnary -}} {{- $mode = "serviceinfo.StreamingUnary" }} {{- $handlerFunc = "InvokeUnaryHandler" }}
     {{- else if $serverSide -}} {{- $mode = "serviceinfo.StreamingServer" }} {{- $handlerFunc = "InvokeServerStreamHandler" }}
@@ -228,8 +233,8 @@ func {{LowerFirst .Name}}Handler(ctx context.Context, handler interface{}, arg, 
 	{{- end}}
 	{{if gt .ArgsLength 0}}realArg := {{else}}_ = {{end}}arg.(*{{if not .GenArgResultStruct}}{{.PkgRefName}}.{{end}}{{.ArgStructName}})
 	{{if or (not .Void) .Exceptions}}realResult := result.(*{{if not .GenArgResultStruct}}{{.PkgRefName}}.{{end}}{{.ResStructName}}){{end}}
-	{{if .Void}}err := handler.({{.PkgRefName}}.{{.ServiceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
-	{{else}}success, err := handler.({{.PkgRefName}}.{{.ServiceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
+	{{if .Void}}err := handler.({{$serverInterfaceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
+	{{else}}success, err := handler.({{$serverInterfaceName}}).{{.Name}}(ctx{{range .Args}}, realArg.{{.Name}}{{end}})
 	{{end -}}
 	if err != nil {
 	{{- if $HandlerReturnKeepResp }}


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(ttstream): 当开启 StreamX 并且存在 Streaming 方法时，Ping-Pong 方法引用 Kitex 生成代码中的服务接口定义

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
When StreamX is enabled, if both Streaming method and Ping-Pong method exist in the service, the Streaming method references the Service Interface Definition in the Kitex generated code, while the Ping-Pong method references the Service Interface Definition in the thriftgo generated code, which is not consistent.
After fixing, the Ping-Pong method also references the service interface definition in the Kitex generated code.
zh(optional): 
当开启 StreamX 时，若服务中同时存在 Streaming 方法和 Ping-Pong 方法，Streaming 方法会引用 Kitex 生成代码中的服务接口定义，而 Ping-Pong 方法会引用 thriftgo 生成代码中的服务接口定义，两者并不统一。
修复后，Ping-Pong 方法也会引用 Kitex 生成代码中的服务接口定义。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->