### PR TITLE
optimize(gRPC): return more detailed error when received invalid http2 frame

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader.go
@@ -380,9 +380,7 @@ func (fr *Framer) readAndCheckFrameHeader() (http2.FrameHeader, error) {
 		// valid:    true,
 	}
 	if fh.Length > fr.maxReadSize {
-		first4Bytes := binary.BigEndian.Uint32(buf[:4])
-		second4Bytes := binary.BigEndian.Uint32(buf[4:])
-		return http2.FrameHeader{}, fmt.Errorf("%s or invalid frame (first4Bytes=%#x, second4Bytes=%#x)", http2.ErrFrameTooLarge, first4Bytes, second4Bytes)
+		return http2.FrameHeader{}, fmt.Errorf("%s or invalid frame (first4Bytes=%#x, second4Bytes=%#x)", http2.ErrFrameTooLarge, buf[:4], buf[4:8])
 	}
 	return fh, nil
 }

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader_test.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpcframe
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/gopkg/protocol/thrift"
+	"github.com/cloudwego/netpoll"
+	"golang.org/x/net/http2"
+
+	"github.com/cloudwego/kitex/internal/test"
+)
+
+type mockNetpollReader struct {
+	netpoll.Reader
+	buf []byte
+}
+
+func (r *mockNetpollReader) Next(n int) (p []byte, err error) {
+	return r.buf[:n], nil
+}
+
+func getThriftApplicationExceptionBytes() []byte {
+	ex := thrift.NewApplicationException(1, "test thrift ApplicationException")
+	buf, _ := thrift.MarshalFastMsg("test", thrift.EXCEPTION, 1, ex)
+	return buf
+}
+
+func getHTTP2FrameHeaderBytes() []byte {
+	fh := http2.FrameHeader{
+		Length: 1,
+		Type:   http2.FrameData,
+	}
+	buf := make([]byte, frameHeaderLen)
+	buf[0] = byte(fh.Length >> 16)
+	buf[1] = byte(fh.Length >> 8)
+	buf[2] = byte(fh.Length)
+	buf[3] = byte(fh.Type)
+	buf[4] = byte(fh.Flags)
+	binary.BigEndian.PutUint32(buf[5:], fh.StreamID)
+	return buf
+}
+
+func Test_Framer_readAndCheckFrameHeader(t *testing.T) {
+	// mock netpoll.Reader
+	fr := &Framer{}
+	fr.SetMaxReadFrameSize(16384) //http2MaxFrameLen
+	testcases := []struct {
+		desc                   string
+		reader                 netpoll.Reader
+		checkFrameHeaderAndErr func(*testing.T, http2.FrameHeader, error)
+	}{
+		{
+			desc: "thrift ApplicationException",
+			reader: &mockNetpollReader{
+				buf: getThriftApplicationExceptionBytes(),
+			},
+			checkFrameHeaderAndErr: func(t *testing.T, header http2.FrameHeader, err error) {
+				test.Assert(t, err != nil, err)
+				t.Log(err)
+				test.Assert(t, strings.Contains(err.Error(), http2.ErrFrameTooLarge.Error()), err)
+				test.Assert(t, strings.Contains(err.Error(), "invalid frame"), err)
+			},
+		},
+		{
+			desc: "normal HTTP2 FrameHeader",
+			reader: &mockNetpollReader{
+				buf: getHTTP2FrameHeaderBytes(),
+			},
+			checkFrameHeaderAndErr: func(t *testing.T, header http2.FrameHeader, err error) {
+				test.Assert(t, err == nil, err)
+				test.Assert(t, header.Length == 1, header)
+				test.Assert(t, header.Type == http2.FrameData, header)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fr.reader = tc.reader
+			fh, err := fr.readAndCheckFrameHeader()
+			tc.checkFrameHeaderAndErr(t, fh, err)
+		})
+	}
+}

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader_test.go
@@ -61,7 +61,8 @@ func getHTTP2FrameHeaderBytes() []byte {
 func Test_Framer_readAndCheckFrameHeader(t *testing.T) {
 	// mock netpoll.Reader
 	fr := &Framer{}
-	fr.SetMaxReadFrameSize(16384) //http2MaxFrameLen
+	http2MaxFrameLen := uint32(16384)
+	fr.SetMaxReadFrameSize(http2MaxFrameLen)
 	testcases := []struct {
 		desc                   string
 		reader                 netpoll.Reader


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
optimize(gRPC): 收到无效的 http2 帧时返回更详细的错误

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
When a non-HTTP2 Frame is received, the original```http2: frame too large```error is somewhat misleading, print out the first 8 bytes to better troubleshoot the problem 
zh(optional): 
当收到非 HTTP2 Frame 时，原本的```http2: frame too large```错误会带来一定误导，为了更好地排查问题打印出前 8 个字节

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->