### PR TITLE
feat(codec/thrift): use fastcodec/frugal if apache codec not available

### DIFF
--- a/pkg/remote/codec/thrift/codec_frugal_test.go
+++ b/pkg/remote/codec/thrift/codec_frugal_test.go
@@ -179,9 +179,9 @@ func TestMarshalThriftDataFrugal(t *testing.T) {
 		test.Assert(t, reflect.DeepEqual(buf, mockReqThrift), buf)
 	}
 
-	// Basic can be used for disabling frugal
+	// CodecType=Basic and failback to frugal
 	_, err := MarshalThriftData(context.Background(), NewThriftCodecWithConfig(Basic), mockReqFrugal)
-	test.Assert(t, err != nil, err)
+	test.Assert(t, err == nil, err)
 }
 
 func TestUnmarshalThriftDataFrugal(t *testing.T) {
@@ -203,9 +203,9 @@ func TestUnmarshalThriftDataFrugal(t *testing.T) {
 
 	}
 
-	// Basic can be used for disabling frugal
+	// CodecType=Basic and failback to frugal
 	err := UnmarshalThriftData(context.Background(), NewThriftCodecWithConfig(Basic), "mock", mockReqThrift, req)
-	test.Assert(t, err != nil, err)
+	test.Assert(t, err == nil, err)
 }
 
 func TestThriftCodec_unmarshalThriftDataFrugal(t *testing.T) {

--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -154,15 +154,12 @@ func (c thriftCodec) Marshal(ctx context.Context, message remote.Message, out re
 		return apacheMarshal(out, ctx, methodName, msgType, seqID, data)
 	}
 
-	// if user only wants to use Basic we never try fallback to frugal or fastcodec
-	if c.CodecType != Basic {
-		// try FrugalWrite < - > FastWrite fallback
-		if typecodec.FastCodec {
-			return fastMarshal(out, methodName, msgType, seqID, data.(thrift.FastCodec))
-		}
-		if typecodec.Frugal {
-			return frugalMarshal(out, methodName, msgType, seqID, data)
-		}
+	// try fallback to fastcodec or frugal even though CodecType=Basic
+	if typecodec.FastCodec {
+		return fastMarshal(out, methodName, msgType, seqID, data.(thrift.FastCodec))
+	}
+	if typecodec.Frugal {
+		return frugalMarshal(out, methodName, msgType, seqID, data)
 	}
 	return errEncodeMismatchMsgType
 }

--- a/pkg/remote/codec/thrift/thrift_data.go
+++ b/pkg/remote/codec/thrift/thrift_data.go
@@ -63,16 +63,12 @@ func (c thriftCodec) marshalThriftData(ctx context.Context, data interface{}) ([
 	if typecodec.Apache {
 		return apacheMarshalData(data)
 	}
-	if c.CodecType != Basic {
-		// try fallback to frugal or fastcodec
-		// case: typecodec.Frugal=false but typecodec.FastCodec=true
-		if typecodec.FastCodec {
-			return fastMarshalData(data)
-		}
-		// case: typecodec.FastCodec=false but typecodec.Frugal=true
-		if typecodec.Frugal {
-			return frugalMarshalData(data)
-		}
+	// try fallback to fastcodec or frugal even though CodecType=Basic
+	if typecodec.FastCodec {
+		return fastMarshalData(data)
+	}
+	if typecodec.Frugal {
+		return frugalMarshalData(data)
 	}
 	return nil, errEncodeMismatchMsgType
 }
@@ -118,16 +114,12 @@ func (c thriftCodec) unmarshalThriftData(trans bufiox.Reader, data interface{}, 
 	if typecodec.Apache {
 		return apacheUnmarshal(trans, data)
 	}
-	if dataLenOK && c.CodecType != Basic {
-		// try fallback to frugal or fastcodec
-		// case: typecodec.Frugal=false but typecodec.FastCodec=true
-		if typecodec.FastCodec {
-			return fastUnmarshal(trans, data, dataLen)
-		}
-		// case: typecodec.FastCodec=false but typecodec.Frugal=true
-		if typecodec.Frugal {
-			return frugalUnmarshal(trans, data, dataLen)
-		}
+	// try fallback to fastcodec or frugal even though CodecType=Basic or EnableSkipDecoder not set
+	if typecodec.FastCodec {
+		return fastUnmarshal(trans, data, dataLen)
+	}
+	if typecodec.Frugal {
+		return frugalUnmarshal(trans, data, dataLen)
 	}
 	return errDecodeMismatchMsgType
 }

--- a/pkg/remote/codec/thrift/thrift_data_test.go
+++ b/pkg/remote/codec/thrift/thrift_data_test.go
@@ -53,10 +53,8 @@ func TestMarshalThriftData(t *testing.T) {
 	})
 	t.Run("BasicCodec", func(t *testing.T) {
 		_, err := MarshalThriftData(context.Background(), NewThriftCodecWithConfig(Basic), mockReq)
-		test.Assert(t, err != nil, err)
-		// test.Assert(t, reflect.DeepEqual(buf, mockReqThrift), buf)
+		test.Assert(t, err == nil, err)
 	})
-	// FrugalCodec: in thrift_frugal_amd64_test.go: TestMarshalThriftDataFrugal
 }
 
 func checkDecodeResult(t *testing.T, err error, req *mocks.MockReq) {
@@ -81,9 +79,8 @@ func TestUnmarshalThriftData(t *testing.T) {
 	t.Run("BasicCodec", func(t *testing.T) {
 		req := &mocks.MockReq{}
 		err := UnmarshalThriftData(context.Background(), NewThriftCodecWithConfig(Basic), "mock", mockReqThrift, req)
-		test.Assert(t, err != nil, err)
+		test.Assert(t, err == nil, err)
 	})
-	// FrugalCodec: in thrift_frugal_amd64_test.go: TestUnmarshalThriftDataFrugal
 }
 
 func TestThriftCodec_unmarshalThriftData(t *testing.T) {

--- a/pkg/remote/codec/thrift/thrift_test.go
+++ b/pkg/remote/codec/thrift/thrift_test.go
@@ -291,23 +291,22 @@ func TestSkipDecoder(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			desc:     "Disable SkipDecoder, fallback to Apache Thrift Codec for Buffer Protocol",
+			desc:     "SkipDecoder=false|PurePayload",
 			codec:    NewThriftCodec(),
 			protocol: transport.PurePayload,
-			wantErr:  true,
 		},
 		{
-			desc:     "Disable SkipDecoder, using FastCodec for TTHeader Protocol",
+			desc:     "SkipDecoder=false|TTHeader",
 			codec:    NewThriftCodec(),
 			protocol: transport.TTHeader,
 		},
 		{
-			desc:     "Enable SkipDecoder, using FastCodec for Buffer Protocol",
+			desc:     "SkipDecoder=true|PurePayload",
 			codec:    NewThriftCodecWithConfig(FastRead | FastWrite | EnableSkipDecoder),
 			protocol: transport.PurePayload,
 		},
 		{
-			desc:     "Enable SkipDecoder, using FastCodec for TTHeader Protocol",
+			desc:     "SkipDecoder=true|TTHeader",
 			codec:    NewThriftCodecWithConfig(FastRead | FastWrite | EnableSkipDecoder),
 			protocol: transport.TTHeader,
 		},


### PR DESCRIPTION
#### What type of PR is this?
feat

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
如果 apache codec 不可用，使用 fastcodec/frugal

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
* This change will use skipdecoder regardless it's enabled or not when apache codec not available.
* Even though codec set to Basic, we will still fail back to use fastcodec or frugal.

zh(optional): 
* 这个修改会当apache codec 不可用时自动启使用 skipdecoder，无需要主动启用。
* 哪怕是 Thrift codec 设置为 Basic，我们仍会使用 fastcodec 或 frugal

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->