### PR TITLE
feat: add tail option to support for delayed initialization of some client options

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -576,3 +576,13 @@ func WithContextBackup(backupHandler func(prev, cur context.Context) (ctx contex
 		o.CtxBackupHandler = backupHandler
 	}}
 }
+
+// TailOption is used to covert an option to a tail option
+// which is executed after all options are applied.
+// NOTICE: no compatibility guarantee for this api,
+// just ignore it unless you clearly know what you are doing.
+func TailOption(opt Option) Option {
+	return Option{F: func(o *client.Options, di *utils.Slice) {
+		o.TailOptions = append(o.TailOptions, opt)
+	}}
+}

--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -202,29 +202,26 @@ type Options struct {
 	CtxBackupHandler backup.BackupHandler
 
 	Streaming stream.StreamingConfig // deprecated, use StreamOptions instead
+
+	// TailOptions is used to store options that are executed after all options are applied.
+	// just ignore it unless you clearly know what you are doing.
+	TailOptions []Option
 }
 
 // Apply applies all options.
 func (o *Options) Apply(opts []Option) {
-	reorderOpts := make([]Option, 0, len(opts))
-	finalOpts := make([]Option, 0, len(opts))
 	for _, op := range opts {
-		if op.finalOption {
-			finalOpts = append(finalOpts, op)
-		} else {
-			reorderOpts = append(reorderOpts, op)
-		}
-	}
-	reorderOpts = append(reorderOpts, finalOpts...)
-	for _, op := range reorderOpts {
 		op.F(o, &o.DebugInfo)
 	}
+	for _, op := range o.TailOptions {
+		op.F(o, &o.DebugInfo)
+	}
+	o.TailOptions = nil
 }
 
 // Option is the only way to config client.
 type Option struct {
-	F           func(o *Options, di *utils.Slice)
-	finalOption bool // just ignore it unless you clearly know what you are doing.
+	F func(o *Options, di *utils.Slice)
 }
 
 // NewOptions creates a new option.


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat: 添加 tail option 以支持部分client options的延迟执行


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
Client initialization logic in bytedance internal lib needs to perceive user configuration protocol information, and some options must be executed after all options are executed to get the protocol, so we add this api.

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->