### PR TITLE
feat(ttstream): support WithRecvTimeout stream call option

### DIFF
--- a/client/callopt/options.go
+++ b/client/callopt/options.go
@@ -47,6 +47,7 @@ type CallOptions struct {
 	RetryPolicy    retry.Policy
 	Fallback       *fallback.Policy
 	CompressorName string
+	StreamOptions  client.StreamOptions
 }
 
 func newOptions() interface{} {

--- a/client/callopt/streamcall/call_options.go
+++ b/client/callopt/streamcall/call_options.go
@@ -17,6 +17,7 @@
 package streamcall
 
 import (
+	"strings"
 	"time"
 
 	"github.com/cloudwego/kitex/client/callopt"
@@ -44,4 +45,16 @@ func WithConnectTimeout(d time.Duration) Option {
 // WithTag sets the tags for service discovery for an RPC call.
 func WithTag(key, val string) Option {
 	return ConvertOptionFrom(callopt.WithTag(key, val))
+}
+
+// WithRecvTimeout add recv timeout for stream.Recv function.
+// NOTICE: ONLY effective for ttheader streaming protocol for now.
+func WithRecvTimeout(d time.Duration) Option {
+	return Option{f: func(o *callopt.CallOptions, di *strings.Builder) {
+		di.WriteString("WithRecvTimeout(")
+		di.WriteString(d.String())
+		di.WriteString(")")
+
+		o.StreamOptions.RecvTimeout = d
+	}}
 }

--- a/client/callopt/streamcall/call_options_test.go
+++ b/client/callopt/streamcall/call_options_test.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package streamcall
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/cloudwego/kitex/internal/test"
+)
+
+func TestWithRecvTimeout(t *testing.T) {
+	var sb strings.Builder
+	callOpts := callopt.CallOptions{}
+	testTimeout := 1 * time.Second
+	WithRecvTimeout(testTimeout).f(&callOpts, &sb)
+	test.Assert(t, callOpts.StreamOptions.RecvTimeout == testTimeout)
+	test.Assert(t, sb.String() == "WithRecvTimeout(1s)")
+}

--- a/client/client.go
+++ b/client/client.go
@@ -829,9 +829,14 @@ func initRPCInfo(ctx context.Context, method string, opt *client.Options, svcInf
 
 	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
 
-	if callOpts != nil && callOpts.CompressorName != "" {
-		// set send grpc compressor at client to tell how to server decode
-		remote.SetSendCompressor(ri, callOpts.CompressorName)
+	if callOpts != nil {
+		if callOpts.CompressorName != "" {
+			// set send grpc compressor at client to tell how to server decode
+			remote.SetSendCompressor(ri, callOpts.CompressorName)
+		}
+		if callOpts.StreamOptions.RecvTimeout != 0 {
+			cfg.SetStreamRecvTimeout(callOpts.StreamOptions.RecvTimeout)
+		}
 	}
 
 	return ctx, ri, callOpts


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(ttstream): 支持 WithRecvTimeout stream 调用 call option

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->