### PR TITLE
optimize(tool): use os.UserHomeDir to allow modify os env to set the git-cache dir

### DIFF
--- a/tool/internal_pkg/util/util.go
+++ b/tool/internal_pkg/util/util.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -160,11 +159,11 @@ func SearchGoMod(cwd string) (moduleName, path string, found bool) {
 }
 
 func RunGitCommand(gitLink string) (string, string, error) {
-	u, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", "Failed to get home dir", err
 	}
-	cachePath := JoinPath(u.HomeDir, ".kitex", "cache")
+	cachePath := JoinPath(homeDir, ".kitex", "cache")
 
 	branch := ""
 	if strings.Contains(gitLink, ".git@") {


### PR DESCRIPTION
#### What type of PR is this?

optimize: A new optimization to allow modify os env, like $HOME, to set the git-cache dir.

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

通过使用os.UserHomeDir方法，允许用户通过指定环境变量的方式修改git的cache路径

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en: user.Current() read the system file to find the UserHomeDir, it can not be affected by env value. While the os.UserHomeDir() directly read the env.
zh(optional): 原本代码使用user.Current()获取用户的HOME目录，但是该方法直接读取了系统文件，无法通过修改环境变量来改变。改成os.UserHomeDir()则是直接从环境变量获取HOME目录。
