### PR TITLE
fix(prutal): fix the issue of incorrect handling of proto file path by prutal on Windows

### DIFF
--- a/tool/cmd/kitex/main.go
+++ b/tool/cmd/kitex/main.go
@@ -135,7 +135,6 @@ func main() {
 			}
 		}
 		log.Warn(err)
-
 		os.Exit(1)
 	}
 NormalExit:

--- a/tool/cmd/kitex/main.go
+++ b/tool/cmd/kitex/main.go
@@ -18,9 +18,12 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/cloudwego/kitex/tool/cmd/kitex/utils"
 
@@ -135,6 +138,47 @@ func main() {
 			}
 		}
 		log.Warn(err)
+
+		// Check for specific protoc plugin path error on Windows due to non-ASCII paths
+		if args.IsProtobuf() && runtime.GOOS == "windows" {
+			errorOutput := out.String()
+
+			isPluginNotFoundError := strings.Contains(errorOutput, "protoc-gen-kitex") &&
+				strings.Contains(errorOutput, "The system cannot find the path specified")
+
+			if isPluginNotFoundError {
+				kitexExecutablePath, execErr := os.Executable()
+				containsNonASCII := false
+				for _, r := range kitexExecutablePath {
+					if r > unicode.MaxASCII {
+						containsNonASCII = true
+						break
+					}
+				}
+
+				if execErr == nil && containsNonASCII {
+					hintMessage := fmt.Sprintf(
+						`[Hint] Failed to execute protoc plugin 'protoc-gen-kitex'.
+Cause Analysis:
+- In the current mode, Kitex calls the external 'protoc.exe' tool.
+- 'protoc.exe' was instructed to use the Kitex executable itself (located at '%s') as the 'protoc-gen-kitex' plugin.
+- This path appears to contain non-ASCII characters.
+- 'protoc.exe' on Windows is known to have problems executing plugins located at paths with non-ASCII characters.
+(See: https://github.com/protocolbuffers/protobuf/issues/9875 for related issues).
+											
+SOLUTION:
+- Please ensure the installation path of the Kitex tool (where kitex.exe resides, often determined by GOPATH/bin) and potentially your project path contain ONLY standard ASCII characters.
+- You may need to rename folders (e.g., remove Chinese characters) in the installation path or move your Go workspace (GOPATH) to an ASCII-only location.
+- After changing the path, ensure relevant environment variables ('GOPATH', 'Path') are updated.
+- You may need to restart your terminal/command prompt or IDE, or potentially even your computer, for these environment variable changes to take full effect.`, kitexExecutablePath)
+
+					log.Warnf(hintMessage)
+				} else if execErr != nil {
+					log.Warnf("[Hint] Could not determine Kitex executable path to check for non-ASCII characters: %v", execErr)
+				}
+			}
+		}
+
 		os.Exit(1)
 	}
 NormalExit:

--- a/tool/internal_pkg/prutal/prutal.go
+++ b/tool/internal_pkg/prutal/prutal.go
@@ -278,7 +278,9 @@ func genStructsAndKitexInterfaces(f *prutalgen.Proto, c *generator.Config, dir s
 	// interfaces used by kitex
 	genKitexServiceInterface(f, w, c.StreamX)
 
-	fn := strings.TrimSuffix(path.Base(f.ProtoFile), ".proto") + ".pb.go"
+	baseFilename := filepath.Base(f.ProtoFile)
+	fn := strings.TrimSuffix(baseFilename, ".proto") + ".pb.go"
+
 	out := filepath.Join(dir, fn)
 	f.Infof("generating %s", out)
 	writeFile(out, w.Bytes())


### PR DESCRIPTION
关联 Issue: #1772

此PR修复了Kitex命令行工具在Windows操作系统上处理.proto文件时使用Kitex内置Prutal模式时遇到的与文件路径相关的问题，这个问题在Issue #1772中有详细描述。

## 问题及修复
 **问题:** 当设置KITEX_TOOL_USE_PROTOC=0使用Kitex内置Prutal模式时，internal_pkg/prutal/prutal.go中因使用path.Base而无法正确处理Windows 的`\`路径分隔符，导致代码生成失败。
    **修复:** 将internal_pkg/prutal/prutal.go中相关的path.Base调用替换为filepath.Base。



## 测试 (Testing)

* 相关验证已在Issue #1772中有详细描述。



