### PR TITLE
fix(gRPC): inject current method name to rpcinfo in server-side to fix FROM_METHOD missing 

### DIFF
--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cloudwego/netpoll"
 
+	"github.com/cloudwego/kitex/pkg/consts"
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/gofunc"
 	"github.com/cloudwego/kitex/pkg/kerrors"
@@ -174,6 +175,11 @@ func (t *svrTransHandler) handleFunc(s *grpcTransport.Stream, svrTrans *SvrTrans
 			_ = tr.WriteStatus(s, status.New(codes.Internal, errDesc))
 			return
 		}
+		// this method name will be used as from method if a new RPC call is invoked in this handler.
+		// ping-pong relies on transMetaHandler.OnMessage to inject but streaming does not trigger.
+		//
+		//nolint:staticcheck // SA1029: consts.CtxKeyMethod has been used and we just follow it
+		rCtx = context.WithValue(rCtx, consts.CtxKeyMethod, methodName)
 	}
 
 	var serviceName string

--- a/pkg/remote/trans/nphttp2/server_handler_test.go
+++ b/pkg/remote/trans/nphttp2/server_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cloudwego/kitex/internal/mocks"
+	"github.com/cloudwego/kitex/pkg/consts"
 
 	"github.com/golang/mock/gomock"
 
@@ -113,6 +114,9 @@ func TestServerHandler(t *testing.T) {
 	// test SetInvokeHandleFunc()
 	var calledInvoke int32
 	handler.(remote.InvokeHandleFuncSetter).SetInvokeHandleFunc(func(ctx context.Context, req, resp interface{}) (err error) {
+		fromMethod, ok := ctx.Value(consts.CtxKeyMethod).(string)
+		test.Assert(t, ok)
+		test.Assert(t, fromMethod == "SayHello", fromMethod)
 		atomic.StoreInt32(&calledInvoke, 1)
 		return nil
 	})


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
在进行 RPC 调用时，client 会尝试从 ctx 中提取当前所处的 handler 对应的 method，从而知道是从哪个 handler 中发起的:
```
if fromMethod := ctx.Value(consts.CtxKeyMethod); fromMethod != nil {
    rpcinfo.AsMutableEndpointInfo(ri.From()).SetMethod(fromMethod.(string))
}
```
对于 Ping-Pong，FROM_METHOD 的注入在`transmetaHandler.OnMessage`中完成：
```
func (h *transMetaHandler) OnMessage(ctx context.Context, args, result remote.Message) (context.Context, error) {
        // ...
	if isServer && result.MessageType() != remote.Exception {
		// Pass through method name using ctx, the method name will be used as from method in the client.
		ctx = context.WithValue(ctx, consts.CtxKeyMethod, msg.RPCInfo().To().Method())
		// ...
	}
	return ctx, nil
}
```
但 streaming 流程中不会触发 OnMessage，因此需要额外注入

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->