### PR TITLE
fix(tool): disable fast api for protobuf

### DIFF
--- a/tool/cmd/kitex/main.go
+++ b/tool/cmd/kitex/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/cloudwego/kitex/tool/cmd/kitex/utils"
+	"github.com/cloudwego/kitex/tool/internal_pkg/util/env"
 
 	"github.com/cloudwego/kitex/tool/cmd/kitex/sdk"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/cloudwego/kitex/tool/internal_pkg/pluginmode/protoc"
 	"github.com/cloudwego/kitex/tool/internal_pkg/pluginmode/thriftgo"
 	"github.com/cloudwego/kitex/tool/internal_pkg/prutal"
-	"github.com/cloudwego/kitex/tool/internal_pkg/util/env"
 )
 
 var args kargs.Arguments
@@ -97,13 +97,17 @@ func main() {
 			os.Exit(versions.CompatibilityCheckExitCode)
 		}
 	}
-	if args.IsProtobuf() && !env.UseProtoc() {
-		g := prutal.NewPrutalGen(args.Config)
-		if err := g.Process(); err != nil {
-			log.Errorf("%s", err)
-			os.Exit(1)
+	if args.IsProtobuf() {
+		// Whether using protoc or prutal, no longer generate the fast api for protobuf
+		args.Config.NoFastAPI = true
+		if !env.UseProtoc() {
+			g := prutal.NewPrutalGen(args.Config)
+			if err := g.Process(); err != nil {
+				log.Errorf("%s", err)
+				os.Exit(1)
+			}
+			return
 		}
-		return
 	}
 
 	out := new(bytes.Buffer)


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(tool): 不再为 protobuf 生成 fast api 相关代码

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
从 v0.14.0 开始，Kitex 将不会生成 fastpb 的编解码代码，但 kitex 生成的结构体代码中依然会生成 FastWrite 和 FastRead 等函数引用 fastpb 的编解码接口，导致编译报错。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->