### PR TITLE
feat(gRPC): support dump MaxConcurrentStreams of HTTP2 Client

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -1638,9 +1638,11 @@ func TestGetClientStat(t *testing.T) {
 	test.Assert(t, md != nil)
 	test.Assert(t, ok)
 	test.Assert(t, s.getHeaderValid())
-	// send quota
-	w := cli.getOutFlowWindow()
+	// send quota and max concurrent streams
+	w, m := cli.getOutFlowWindowAndMaxConcurrentStreams()
 	test.Assert(t, uint32(w) == cli.loopy.sendQuota)
+	// there is no limit on the number of streams by default
+	test.Assert(t, m == math.MaxUint32)
 
 	// Dump
 	d := cli.Dump()
@@ -1649,7 +1651,8 @@ func TestGetClientStat(t *testing.T) {
 	test.Assert(t, td.State == reachable)
 	cli.mu.Lock()
 	remoteAddr := cli.remoteAddr.String()
-	test.Assert(t, len(td.ActiveStreams) == len(cli.activeStreams))
+	// When the Dump ends, it's possible streams that were active at that moment have already ended
+	test.Assert(t, len(td.ActiveStreams) >= len(cli.activeStreams))
 	cli.mu.Unlock()
 
 	if len(td.ActiveStreams) != 0 {


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(gRPC): 支持查看 HTTP2 Client 的最大并发流数量

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
Client 在创建 Stream 时受 HTTP2 Settings MaxConcurrentStreams 制约，若当前连接上的并发流超过这个限制，则 NewStream 会被阻塞。
支持查看当前状态的 MaxConcurrentStreams 以更好地排查问题。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->