### PR TITLE
feat: add context-based sequence ID preservation for RPC proxy servers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -794,10 +794,19 @@ func initRPCInfo(ctx context.Context, method string, opt *client.Options, svcInf
 	}
 
 	// Export read-only views to external users.
+	// Create invocation with context awareness
+	invocation := rpcinfo.NewInvocation(svcInfo.ServiceName, method, svcInfo.GetPackageName())
+
+	// Check if we have a custom sequence ID in the context
+	if seqID, ok := ctx.Value(rpcinfo.CtxKeySequenceID).(int32); ok && seqID > 0 {
+		// invocation is *invocation which implements InvocationSetter
+		invocation.SetSeqID(seqID)
+	}
+
 	ri := rpcinfo.NewRPCInfo(
 		rpcinfo.FromBasicInfo(opt.Cli),
 		rmt.ImmutableView(),
-		rpcinfo.NewInvocation(svcInfo.ServiceName, method, svcInfo.GetPackageName()),
+		invocation,
 		cfg.ImmutableView(),
 		rpcStats.ImmutableView(),
 	)

--- a/client/client_seqid_test.go
+++ b/client/client_seqid_test.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/kitex/internal/mocks"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/transport"
+)
+
+// TestClientSequenceIDPreservation tests that custom sequence IDs are preserved through client calls
+func TestClientSequenceIDPreservation(t *testing.T) {
+	t.Run("sequence ID preservation in client", func(t *testing.T) {
+		// This test verifies that if we create a client and make a call with
+		// a custom sequence ID in context, it gets preserved
+
+		svcInfo := mocks.ServiceInfo()
+
+		// Create a client
+		cli, err := NewClient(svcInfo, WithDestService("test-service"))
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+
+		// Create a context with custom sequence ID
+		customSeqID := int32(12345)
+		ctx := rpcinfo.WithSequenceID(context.Background(), customSeqID)
+
+		// We can't easily test the full flow without a server, but we can
+		// at least verify that the context propagation works
+		retrievedSeqID, ok := rpcinfo.GetSequenceID(ctx)
+		if !ok {
+			t.Fatal("Failed to retrieve sequence ID from context")
+		}
+
+		if retrievedSeqID != customSeqID {
+			t.Errorf("Sequence ID mismatch: got %d, want %d", retrievedSeqID, customSeqID)
+		}
+
+		// Verify the client was created successfully
+		if cli == nil {
+			t.Fatal("Client is nil")
+		}
+	})
+}
+
+// TestSequenceIDContextPropagation tests that sequence IDs propagate correctly through context
+func TestSequenceIDContextPropagation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		seqID    int32
+		expected int32
+		shouldOK bool
+	}{
+		{"positive sequence ID", 12345, 12345, true},
+		{"zero sequence ID", 0, 0, true},
+		{"negative sequence ID", -123, -123, true},
+		{"max int32", 2147483647, 2147483647, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := rpcinfo.WithSequenceID(context.Background(), tc.seqID)
+
+			retrievedSeqID, ok := rpcinfo.GetSequenceID(ctx)
+			if ok != tc.shouldOK {
+				t.Errorf("GetSequenceID returned %v, expected %v", ok, tc.shouldOK)
+			}
+
+			if retrievedSeqID != tc.expected {
+				t.Errorf("Sequence ID mismatch: got %d, want %d", retrievedSeqID, tc.expected)
+			}
+		})
+	}
+}
+
+// TestStreamingWithSequenceID tests sequence ID with streaming transport
+func TestStreamingWithSequenceID(t *testing.T) {
+	svcInfo := mocks.ServiceInfo()
+
+	// Create a streaming client
+	cli, err := NewClient(svcInfo,
+		WithDestService("test-service"),
+		WithTransportProtocol(transport.TTHeaderStreaming))
+	if err != nil {
+		t.Fatalf("Failed to create streaming client: %v", err)
+	}
+
+	// Create a context with custom sequence ID
+	customSeqID := int32(54321)
+	ctx := rpcinfo.WithSequenceID(context.Background(), customSeqID)
+
+	// Verify context has the sequence ID
+	retrievedSeqID, ok := rpcinfo.GetSequenceID(ctx)
+	if !ok {
+		t.Fatal("Failed to retrieve sequence ID from context")
+	}
+
+	if retrievedSeqID != customSeqID {
+		t.Errorf("Sequence ID mismatch: got %d, want %d", retrievedSeqID, customSeqID)
+	}
+
+	// Verify the client was created successfully
+	if cli == nil {
+		t.Fatal("Client is nil")
+	}
+}

--- a/pkg/rpcinfo/invocation.go
+++ b/pkg/rpcinfo/invocation.go
@@ -17,12 +17,27 @@
 package rpcinfo
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
+
+// CtxKeySequenceID is the context key for passing custom sequence IDs
+const CtxKeySequenceID = "kitex_sequence_id"
+
+// WithSequenceID returns a new context with the given sequence ID
+func WithSequenceID(ctx context.Context, seqID int32) context.Context {
+	return context.WithValue(ctx, CtxKeySequenceID, seqID)
+}
+
+// GetSequenceID retrieves the sequence ID from the context
+func GetSequenceID(ctx context.Context) (int32, bool) {
+	seqID, ok := ctx.Value(CtxKeySequenceID).(int32)
+	return seqID, ok
+}
 
 var (
 	_              Invocation       = (*invocation)(nil)

--- a/pkg/rpcinfo/invocation_seqid_test.go
+++ b/pkg/rpcinfo/invocation_seqid_test.go
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2024 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpcinfo
+
+import (
+	"context"
+	"testing"
+)
+
+// TestWithSequenceID tests the WithSequenceID helper function
+func TestWithSequenceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		seqID    int32
+		expected int32
+	}{
+		{"positive sequence ID", 12345, 12345},
+		{"max int32", 2147483647, 2147483647},
+		{"sequence ID 1", 1, 1},
+		{"large sequence ID", 999999, 999999},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithSequenceID(context.Background(), tt.seqID)
+
+			// Verify the sequence ID is stored correctly
+			value := ctx.Value(CtxKeySequenceID)
+			if value == nil {
+				t.Fatal("sequence ID not found in context")
+			}
+
+			storedSeqID, ok := value.(int32)
+			if !ok {
+				t.Fatalf("sequence ID has wrong type: %T", value)
+			}
+
+			if storedSeqID != tt.expected {
+				t.Errorf("sequence ID mismatch: got %d, want %d", storedSeqID, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetSequenceID tests the GetSequenceID helper function
+func TestGetSequenceID(t *testing.T) {
+	t.Run("sequence ID exists", func(t *testing.T) {
+		expectedSeqID := int32(54321)
+		ctx := WithSequenceID(context.Background(), expectedSeqID)
+
+		seqID, ok := GetSequenceID(ctx)
+		if !ok {
+			t.Fatal("GetSequenceID returned false when sequence ID exists")
+		}
+
+		if seqID != expectedSeqID {
+			t.Errorf("GetSequenceID returned wrong value: got %d, want %d", seqID, expectedSeqID)
+		}
+	})
+
+	t.Run("sequence ID does not exist", func(t *testing.T) {
+		ctx := context.Background()
+
+		seqID, ok := GetSequenceID(ctx)
+		if ok {
+			t.Error("GetSequenceID returned true when sequence ID does not exist")
+		}
+
+		if seqID != 0 {
+			t.Errorf("GetSequenceID returned non-zero value when not set: %d", seqID)
+		}
+	})
+
+	t.Run("wrong type in context", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), CtxKeySequenceID, "not an int32")
+
+		seqID, ok := GetSequenceID(ctx)
+		if ok {
+			t.Error("GetSequenceID returned true when value has wrong type")
+		}
+
+		if seqID != 0 {
+			t.Errorf("GetSequenceID returned non-zero value when type is wrong: %d", seqID)
+		}
+	})
+}
+
+// TestSequenceIDPreservation tests that sequence IDs can be preserved through context
+func TestSequenceIDPreservation(t *testing.T) {
+	// This test simulates the relay scenario where we want to preserve sequence IDs
+
+	// Step 1: Create an invocation with auto-generated sequence ID
+	inv1 := NewInvocation("service1", "method1")
+	autoSeqID := inv1.SeqID()
+	if autoSeqID == 0 {
+		t.Fatal("auto-generated sequence ID should not be 0")
+	}
+	t.Logf("Auto-generated sequence ID: %d", autoSeqID)
+
+	// Step 2: Store this sequence ID in context (simulating relay extraction)
+	ctx := WithSequenceID(context.Background(), autoSeqID)
+
+	// Step 3: In the actual implementation, the client would use this context
+	// and the initRPCInfo function would check for the sequence ID
+	retrievedSeqID, ok := GetSequenceID(ctx)
+	if !ok {
+		t.Fatal("Failed to retrieve sequence ID from context")
+	}
+
+	if retrievedSeqID != autoSeqID {
+		t.Errorf("Retrieved sequence ID mismatch: got %d, want %d", retrievedSeqID, autoSeqID)
+	}
+
+	// Step 4: Verify we can create a new invocation and set its sequence ID
+	inv2 := NewInvocation("service2", "method2")
+	// *invocation implements InvocationSetter, so we can call SetSeqID directly
+	inv2.SetSeqID(retrievedSeqID)
+
+	if inv2.SeqID() != autoSeqID {
+		t.Errorf("Failed to preserve sequence ID: got %d, want %d", inv2.SeqID(), autoSeqID)
+	}
+}
+
+// TestContextChaining tests that sequence IDs work with context chaining
+func TestContextChaining(t *testing.T) {
+	// Start with a base context
+	ctx := context.Background()
+
+	// Add sequence ID
+	seqID := int32(11111)
+	ctx = WithSequenceID(ctx, seqID)
+
+	// Add other values to context (simulating real usage)
+	type ctxKey string
+	ctx = context.WithValue(ctx, ctxKey("other"), "value")
+	ctx = context.WithValue(ctx, ctxKey("another"), 123)
+
+	// Verify sequence ID is still retrievable
+	retrievedSeqID, ok := GetSequenceID(ctx)
+	if !ok {
+		t.Fatal("Failed to retrieve sequence ID after context chaining")
+	}
+
+	if retrievedSeqID != seqID {
+		t.Errorf("Sequence ID changed after context chaining: got %d, want %d", retrievedSeqID, seqID)
+	}
+}
+
+// TestZeroSequenceID tests behavior with zero sequence ID
+func TestZeroSequenceID(t *testing.T) {
+	// Zero sequence ID should be treated as "not set"
+	ctx := WithSequenceID(context.Background(), 0)
+
+	// The context will still have the value
+	seqID, ok := GetSequenceID(ctx)
+	if !ok {
+		t.Error("GetSequenceID returned false even though value was set")
+	}
+
+	if seqID != 0 {
+		t.Errorf("Expected zero sequence ID, got %d", seqID)
+	}
+}
+
+// TestNegativeSequenceID tests behavior with negative sequence ID
+func TestNegativeSequenceID(t *testing.T) {
+	// Negative sequence IDs might be used for special purposes
+	negSeqID := int32(-1)
+	ctx := WithSequenceID(context.Background(), negSeqID)
+
+	seqID, ok := GetSequenceID(ctx)
+	if !ok {
+		t.Fatal("Failed to store negative sequence ID")
+	}
+
+	if seqID != negSeqID {
+		t.Errorf("Negative sequence ID not preserved: got %d, want %d", seqID, negSeqID)
+	}
+}
+
+// BenchmarkWithSequenceID benchmarks the WithSequenceID function
+func BenchmarkWithSequenceID(b *testing.B) {
+	ctx := context.Background()
+	seqID := int32(12345)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = WithSequenceID(ctx, seqID)
+	}
+}
+
+// BenchmarkGetSequenceID benchmarks the GetSequenceID function
+func BenchmarkGetSequenceID(b *testing.B) {
+	ctx := WithSequenceID(context.Background(), 12345)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = GetSequenceID(ctx)
+	}
+}


### PR DESCRIPTION
### feat: add context-based sequence ID preservation for RPC proxy servers

  Check the PR title.

  - This PR title match the format: type(optional scope): description
  - The description of this PR title is user-oriented and clear enough for others to
  understand.
  - Attach the PR updating the user documentation if the current PR requires user
  awareness at the usage level. https://github.com/cloudwego/cloudwego.github.io

###  (Optional) Translate the PR title into Chinese.

  feat: 为 RPC 代理服务器添加基于上下文的序列 ID 保留功能

###  (Optional) More detailed description for this PR(en: English/zh: Chinese).

  en:
  This PR introduces context-based sequence ID preservation for building RPC proxy
  servers with Kitex. Currently, when building a security/privacy RPC proxy using Kitex's
  generic server/client, the framework automatically generates new sequence IDs for
  outgoing requests, breaking request correlation across the proxy chain.

####  Problem:
  - Client sends request with sequence ID 1 → Proxy receives ID 1 → Proxy forwards with
  new ID 2 → Target receives ID 2
  - This makes it impossible to trace requests across service boundaries

####  Solution:
  - Added WithSequenceID(ctx, seqID) and GetSequenceID(ctx) helper functions to the
  rpcinfo package
  - Modified the client initialization to check context for custom sequence IDs before
  auto-generating
  - If a custom sequence ID exists in context, it will be used instead of generating a
  new one

####
  Benefits:
  - Enables building security/privacy RPC proxies that preserve request identity
  - Backward compatible - services not using custom sequence IDs are unaffected

####  Usage Example:
```go
  // In proxy server
  incomingSeqID := rpcInfo.Invocation().SeqID()
  ctx = rpcinfo.WithSequenceID(ctx, incomingSeqID)
  // Forward request with preserved sequence ID
  response, err := client.GenericCall(ctx, method, request)
```

  zh(optional):
  本 PR 为使用 Kitex 构建 RPC 代理服务器引入了基于上下文的序列 ID 保留功能。目前，当使用
   Kitex 的泛化服务器/客户端构建透明 RPC 代理时，框架会自动为出站请求生成新的序列
  ID，导致无法在代理链中追踪请求。

  该功能允许代理服务器保留原始客户端的序列
  ID，实现端到端的请求追踪，对于服务网格架构和分布式系统调试至关重要。

  (Optional) Which issue(s) this PR fixes:

[1823](https://github.com/cloudwego/kitex/issues/1823)

  (optional) The PR that updates user documentation:

  TODO: Will submit a documentation PR if this feature is accepted