### PR TITLE
fix: descriptor.HTTPRequest.GetParam nil pointer exception

### DIFF
--- a/pkg/generic/descriptor/http.go
+++ b/pkg/generic/descriptor/http.go
@@ -105,6 +105,9 @@ func (req *HTTPRequest) GetHost() string {
 
 // GetParam implements http.RequestGetter of dynamicgo
 func (req *HTTPRequest) GetParam(key string) string {
+	if req.Params == nil {
+		return ""
+	}
 	return req.Params.ByName(key)
 }
 

--- a/pkg/generic/descriptor/http_mapping.go
+++ b/pkg/generic/descriptor/http_mapping.go
@@ -87,6 +87,9 @@ var NewAPIPath NewHTTPMapping = func(value string) HTTPMapping {
 }
 
 func (m *apiPath) Request(ctx context.Context, req *HTTPRequest, field *FieldDescriptor) (interface{}, bool, error) {
+	if req.Params == nil {
+		return nil, false, nil
+	}
 	val := req.Params.ByName(m.value)
 	return val, val != "", nil
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

```
stack=goroutine 54043 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/cloudwego/kitex/pkg/rpcinfo.ClientPanicToErr({0x74fdaf0, 0xc00d878f30}, {0x64006a0, 0xbd59080}, {0x7501d60, 0xc00eb4adc0}, 0x0)
	/opt/tiger/compile_path/pkg/mod/github.com/cloudwego/kitex@v0.13.1/pkg/rpcinfo/stats_util.go:55 +0xa5
github.com/cloudwego/kitex/client.(*kClient).Call.func1()
	/opt/tiger/compile_path/pkg/mod/github.com/cloudwego/kitex@v0.13.1/client/client.go:379 +0x98
panic({0x64006a0?, 0xbd59080?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/cloudwego/kitex/pkg/generic/descriptor.(*Params).ByName(...)
	/opt/tiger/compile_path/pkg/mod/github.com/cloudwego/kitex@v0.13.1/pkg/generic/descriptor/http.go:261
github.com/cloudwego/kitex/pkg/generic/descriptor.(*HTTPRequest).GetParam(0x6?, {0xc00e77be90, 0xd})
	/opt/tiger/compile_path/pkg/mod/github.com/cloudwego/kitex@v0.13.1/pkg/generic/descriptor/http.go:108 +0x1f
github.com/cloudwego/dynamicgo/conv/j2t.tryGetValueFromHttp({0x7faec83b2ef8, 0xc002a80e70}, {0xc00e77be90, 0xd})
	/opt/tiger/compile_path/pkg/mod/github.com/cloudwego/dynamicgo@v0.6.2/conv/j2t/impl.go:177 +0x4d
github.com/cloudwego/dynamicgo/conv/j2t.(*BinaryConv).do.func1(0xc00f014380)
```

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->