### PR TITLE
optimize: remove service middleware and SupportedTransportsFunc api

### DIFF
--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/codec/protobuf"
 	"github.com/cloudwego/kitex/pkg/remote/codec/thrift"
-	"github.com/cloudwego/kitex/pkg/remote/trans"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
@@ -158,8 +157,6 @@ type Options struct {
 	Bus    event.Bus
 	Events event.Queue
 
-	SupportedTransportsFunc func(option remote.ServerOption) []string
-
 	// DebugInfo should only contain objects that are suitable for json serialization.
 	DebugInfo    utils.Slice
 	DebugService diagnosis.Service
@@ -203,8 +200,6 @@ func NewOptions(opts []Option) *Options {
 		Bus:    event.NewEventBus(),
 		Events: event.NewQueue(event.MaxEventNum),
 
-		SupportedTransportsFunc: DefaultSupportedTransportsFunc,
-
 		TracerCtl: &rpcinfo.TraceController{},
 		Registry:  registry.NoopRegistry,
 	}
@@ -247,13 +242,4 @@ func SysExitSignal() chan os.Signal {
 	}
 	signal.Notify(signals, notifications...)
 	return signals
-}
-
-func DefaultSupportedTransportsFunc(option remote.ServerOption) []string {
-	if factory, ok := option.SvrHandlerFactory.(trans.MuxEnabledFlag); ok {
-		if factory.MuxEnabled() {
-			return []string{"ttheader_mux"}
-		}
-	}
-	return []string{"ttheader", "framed", "ttheader_framed", "grpc"}
 }

--- a/internal/server/register_option.go
+++ b/internal/server/register_option.go
@@ -16,10 +16,6 @@
 
 package server
 
-import (
-	"github.com/cloudwego/kitex/pkg/endpoint"
-)
-
 // RegisterOption is the only way to config service registration.
 type RegisterOption struct {
 	F func(o *RegisterOptions)
@@ -28,7 +24,6 @@ type RegisterOption struct {
 // RegisterOptions is used to config service registration.
 type RegisterOptions struct {
 	IsFallbackService bool
-	Middlewares       []endpoint.Middleware
 }
 
 // NewRegisterOptions creates a register options.

--- a/pkg/remote/trans/detection/server_handler.go
+++ b/pkg/remote/trans/detection/server_handler.go
@@ -50,10 +50,6 @@ type svrTransHandlerFactory struct {
 	detectableHandlerFactory []remote.ServerTransHandlerFactory
 }
 
-func (f *svrTransHandlerFactory) MuxEnabled() bool {
-	return false
-}
-
 func (f *svrTransHandlerFactory) NewTransHandler(opt *remote.ServerOption) (remote.ServerTransHandler, error) {
 	t := &svrTransHandler{}
 	var err error

--- a/server/option_advanced.go
+++ b/server/option_advanced.go
@@ -206,16 +206,6 @@ func WithReusePort(reuse bool) Option {
 	}}
 }
 
-// WithSupportedTransportsFunc sets a function which converts supported transports from server option.
-func WithSupportedTransportsFunc(f func(option remote.ServerOption) []string) Option {
-	return Option{
-		F: func(o *internal_server.Options, di *utils.Slice) {
-			di.Push("WithSupportedTransportsFunc()")
-			o.SupportedTransportsFunc = f
-		},
-	}
-}
-
 // WithProfiler set a profiler to server.
 func WithProfiler(pc profiler.Profiler) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {

--- a/server/option_advanced_test.go
+++ b/server/option_advanced_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/acl"
 	"github.com/cloudwego/kitex/pkg/generic"
-	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
 
@@ -199,54 +198,4 @@ func TestExitSignalOption(t *testing.T) {
 	})
 	err = svr.Run()
 	test.Assert(t, err == stopErr, err)
-}
-
-func TestWithSupportedTransportsFunc(t *testing.T) {
-	cases := []struct {
-		options        []Option
-		wantTransports []string
-	}{
-		{
-			options: []Option{
-				WithSupportedTransportsFunc(func(option remote.ServerOption) []string {
-					return []string{"mock1", "mock2"}
-				}),
-			},
-			wantTransports: []string{"mock1", "mock2"},
-		},
-		{
-			options: []Option{
-				WithSupportedTransportsFunc(func(option remote.ServerOption) []string {
-					return []string{}
-				}),
-			},
-			wantTransports: []string{},
-		},
-		{
-			wantTransports: []string{"ttheader", "framed", "ttheader_framed", "grpc"},
-		},
-		{
-			options: []Option{
-				WithMuxTransport(),
-			},
-			wantTransports: []string{"ttheader_mux"},
-		},
-	}
-	var svr Server
-	for _, tcase := range cases {
-		svr = NewServer(tcase.options...)
-		svcInfo := mocks.ServiceInfo()
-		svr.RegisterService(svcInfo, new(mockImpl))
-		svr.(*server).fillMoreServiceInfo(nil)
-		svcInfo = svr.(*server).svcs.SearchService(svcInfo.ServiceName, mocks.MockMethod, false)
-		test.DeepEqual(t, svcInfo.Extra["transports"], tcase.wantTransports)
-	}
-}
-
-// GenericServiceImpl ...
-type mockImpl struct{}
-
-// GenericCall ...
-func (g *mockImpl) GenericCall(ctx context.Context, method string, request interface{}) (response interface{}, err error) {
-	return nil, nil
 }

--- a/server/register_option.go
+++ b/server/register_option.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	internal_server "github.com/cloudwego/kitex/internal/server"
-	"github.com/cloudwego/kitex/pkg/endpoint"
 )
 
 // RegisterOption is the only way to config service registration.
@@ -26,17 +25,6 @@ type RegisterOption = internal_server.RegisterOption
 
 // RegisterOptions is used to config service registration.
 type RegisterOptions = internal_server.RegisterOptions
-
-// WithServiceMiddleware add middleware for a single service
-// The execution order of middlewares follows:
-// - server middlewares
-// - service middlewares
-// - service handler
-func WithServiceMiddleware(mw endpoint.Middleware) RegisterOption {
-	return RegisterOption{F: func(o *internal_server.RegisterOptions) {
-		o.Middlewares = append(o.Middlewares, mw)
-	}}
-}
 
 func WithFallbackService() RegisterOption {
 	return RegisterOption{F: func(o *internal_server.RegisterOptions) {

--- a/server/service.go
+++ b/server/service.go
@@ -20,22 +20,16 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
-
-type serviceMiddlewares struct {
-	MW endpoint.Middleware
-}
 
 type service struct {
 	svcInfo *serviceinfo.ServiceInfo
 	handler interface{}
-	serviceMiddlewares
 }
 
-func newService(svcInfo *serviceinfo.ServiceInfo, handler interface{}, smw serviceMiddlewares) *service {
-	return &service{svcInfo: svcInfo, handler: handler, serviceMiddlewares: smw}
+func newService(svcInfo *serviceinfo.ServiceInfo, handler interface{}) *service {
+	return &service{svcInfo: svcInfo, handler: handler}
 }
 
 type services struct {
@@ -57,13 +51,7 @@ func newServices() *services {
 }
 
 func (s *services) addService(svcInfo *serviceinfo.ServiceInfo, handler interface{}, registerOpts *RegisterOptions) error {
-	// prepare serviceMiddlewares
-	var serviceMWs serviceMiddlewares
-	if len(registerOpts.Middlewares) > 0 {
-		serviceMWs.MW = endpoint.Chain(registerOpts.Middlewares...)
-	}
-
-	svc := newService(svcInfo, handler, serviceMWs)
+	svc := newService(svcInfo, handler)
 	if registerOpts.IsFallbackService {
 		if s.fallbackSvc != nil {
 			return fmt.Errorf("multiple fallback services cannot be registered. [%s] is already registered as a fallback service", s.fallbackSvc.svcInfo.ServiceName)


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
1. Service Middleware was added by #1510 , but it has little practical use. Developers can determine `ri.Invocation.ServiceName()` within the middleware to inject middleware logic for specific services.
e.g.
```go
func ServiceMiddleware(svcmwMap map[string]endpoint.Middleware) endpoint.Middleware {
	return func(next endpoint.Endpoint) endpoint.Endpoint {
		endpointMap := make(map[string]endpoint.Endpoint)
		for svc, mw := range svcmwMap {
			endpointMap[svc] = mw(next)
		}
		return func(ctx context.Context, req, resp interface{}) error {
			ri := rpcinfo.GetRPCInfo(ctx)
			if next, ok := endpointMap[ri.Invocation().ServiceName()]; ok {
				return next(ctx, req, resp)
			}
			return next(ctx, req, resp)
		}
	}
}
```

2. `SupportedTransportsFunc` was introduced due to the early integration with the [opensergo](https://github.com/kitex-contrib/opensergo) service registration, but this extension library has not been maintained for a long time, and there is actually no dependency on this interface, so it can be removed.

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->