### PR TITLE
optimize: remove useless TargetSvcInfo field

### DIFF
--- a/pkg/remote/option.go
+++ b/pkg/remote/option.go
@@ -70,8 +70,6 @@ func (o *Option) AppendBoundHandler(h BoundHandler) {
 
 // ServerOption contains option that is used to init the remote server.
 type ServerOption struct {
-	TargetSvcInfo *serviceinfo.ServiceInfo
-
 	SvcSearcher ServiceSearcher
 
 	TransServerFactory TransServerFactory

--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -29,18 +29,16 @@ import (
 	"github.com/cloudwego/kitex/pkg/klog"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
-	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
 )
 
 // NewDefaultSvrTransHandler to provide default impl of svrTransHandler, it can be reused in netpoll, shm-ipc, framework-sdk extensions
 func NewDefaultSvrTransHandler(opt *remote.ServerOption, ext Extension) (remote.ServerTransHandler, error) {
 	svrHdlr := &svrTransHandler{
-		opt:           opt,
-		codec:         opt.Codec,
-		svcSearcher:   opt.SvcSearcher,
-		targetSvcInfo: opt.TargetSvcInfo,
-		ext:           ext,
+		opt:         opt,
+		codec:       opt.Codec,
+		svcSearcher: opt.SvcSearcher,
+		ext:         ext,
 	}
 	if svrHdlr.opt.TracerCtl == nil {
 		// init TraceCtl when it is nil, or it will lead some unit tests panic
@@ -52,7 +50,6 @@ func NewDefaultSvrTransHandler(opt *remote.ServerOption, ext Extension) (remote.
 type svrTransHandler struct {
 	opt                *remote.ServerOption
 	svcSearcher        remote.ServiceSearcher
-	targetSvcInfo      *serviceinfo.ServiceInfo
 	inkHdlFunc         endpoint.Endpoint
 	codec              remote.Codec
 	transPipe          *remote.TransPipeline

--- a/pkg/remote/trans/default_server_handler_test.go
+++ b/pkg/remote/trans/default_server_handler_test.go
@@ -65,8 +65,7 @@ func TestDefaultSvrTransHandler(t *testing.T) {
 				return nil
 			},
 		},
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
+		SvcSearcher: svcSearcher,
 	}
 
 	handler, err := NewDefaultSvrTransHandler(opt, ext)
@@ -128,9 +127,8 @@ func TestSvrTransHandlerBizError(t *testing.T) {
 				return nil
 			},
 		},
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
-		TracerCtl:     tracerCtl,
+		SvcSearcher: svcSearcher,
+		TracerCtl:   tracerCtl,
 		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(addr)
 			return ri
@@ -186,9 +184,8 @@ func TestSvrTransHandlerReadErr(t *testing.T) {
 				return mockErr
 			},
 		},
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
-		TracerCtl:     tracerCtl,
+		SvcSearcher: svcSearcher,
+		TracerCtl:   tracerCtl,
 		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(addr)
 			return ri
@@ -239,9 +236,8 @@ func TestSvrTransHandlerReadPanic(t *testing.T) {
 				panic("mock")
 			},
 		},
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
-		TracerCtl:     tracerCtl,
+		SvcSearcher: svcSearcher,
+		TracerCtl:   tracerCtl,
 		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(addr)
 			return ri
@@ -296,9 +292,8 @@ func TestSvrTransHandlerOnReadHeartbeat(t *testing.T) {
 				return nil
 			},
 		},
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
-		TracerCtl:     tracerCtl,
+		SvcSearcher: svcSearcher,
+		TracerCtl:   tracerCtl,
 		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			rpcinfo.AsMutableEndpointInfo(ri.From()).SetAddress(addr)
 			return ri

--- a/pkg/remote/trans/detection/server_handler_test.go
+++ b/pkg/remote/trans/detection/server_handler_test.go
@@ -54,8 +54,7 @@ var (
 
 func TestServerHandlerCall(t *testing.T) {
 	transHdler, _ := NewSvrTransHandlerFactory(netpoll.NewSvrTransHandlerFactory(), nphttp2.NewSvrTransHandlerFactory()).NewTransHandler(&remote.ServerOption{
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
+		SvcSearcher: svcSearcher,
 	})
 
 	ctrl := gomock.NewController(t)
@@ -124,8 +123,7 @@ func TestOnError(t *testing.T) {
 		ctrl.Finish()
 	}()
 	transHdler, err := NewSvrTransHandlerFactory(netpoll.NewSvrTransHandlerFactory(), nphttp2.NewSvrTransHandlerFactory()).NewTransHandler(&remote.ServerOption{
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
+		SvcSearcher: svcSearcher,
 	})
 	test.Assert(t, err == nil)
 
@@ -154,8 +152,7 @@ func TestOnError(t *testing.T) {
 // TestOnInactive covers onInactive() codes to check panic
 func TestOnInactive(t *testing.T) {
 	transHdler, err := NewSvrTransHandlerFactory(netpoll.NewSvrTransHandlerFactory(), nphttp2.NewSvrTransHandlerFactory()).NewTransHandler(&remote.ServerOption{
-		SvcSearcher:   svcSearcher,
-		TargetSvcInfo: svcInfo,
+		SvcSearcher: svcSearcher,
 	})
 	test.Assert(t, err == nil)
 

--- a/pkg/remote/trans/gonet/trans_server_test.go
+++ b/pkg/remote/trans/gonet/trans_server_test.go
@@ -57,7 +57,6 @@ func (m *MockGonetConn) Do() bool {
 }
 
 func TestMain(m *testing.M) {
-	svcInfo := mocks.ServiceInfo()
 	svrOpt = &remote.ServerOption{
 		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
 			fromInfo := rpcinfo.EmptyEndpointInfo()
@@ -78,9 +77,8 @@ func TestMain(m *testing.M) {
 				return codec.SetOrCheckMethodName(mocks.MockMethod, msg)
 			},
 		},
-		SvcSearcher:   mocksremote.NewDefaultSvcSearcher(),
-		TargetSvcInfo: svcInfo,
-		TracerCtl:     &rpcinfo.TraceController{},
+		SvcSearcher: mocksremote.NewDefaultSvcSearcher(),
+		TracerCtl:   &rpcinfo.TraceController{},
 	}
 	svrTransHdlr, _ = newSvrTransHandler(svrOpt)
 	transSvr = NewTransServerFactory().NewTransServer(svrOpt, remote.NewTransPipeline(svrTransHdlr)).(*transServer)

--- a/pkg/remote/trans/netpoll/trans_server_test.go
+++ b/pkg/remote/trans/netpoll/trans_server_test.go
@@ -73,9 +73,8 @@ func TestMain(m *testing.M) {
 				return nil
 			},
 		},
-		SvcSearcher:   mocksremote.NewDefaultSvcSearcher(),
-		TargetSvcInfo: svcInfo,
-		TracerCtl:     &rpcinfo.TraceController{},
+		SvcSearcher: mocksremote.NewDefaultSvcSearcher(),
+		TracerCtl:   &rpcinfo.TraceController{},
 	}
 	svrTransHdlr, _ = newSvrTransHandler(svrOpt)
 	transSvr = NewTransServerFactory().NewTransServer(svrOpt, svrTransHdlr).(*transServer)

--- a/pkg/remote/trans/netpollmux/server_handler.go
+++ b/pkg/remote/trans/netpollmux/server_handler.go
@@ -63,11 +63,10 @@ func (f *svrTransHandlerFactory) NewTransHandler(opt *remote.ServerOption) (remo
 
 func newSvrTransHandler(opt *remote.ServerOption) (*svrTransHandler, error) {
 	svrHdlr := &svrTransHandler{
-		opt:           opt,
-		codec:         opt.Codec,
-		svcSearcher:   opt.SvcSearcher,
-		targetSvcInfo: opt.TargetSvcInfo,
-		ext:           np.NewNetpollConnExtension(),
+		opt:         opt,
+		codec:       opt.Codec,
+		svcSearcher: opt.SvcSearcher,
+		ext:         np.NewNetpollConnExtension(),
 	}
 	if svrHdlr.opt.TracerCtl == nil {
 		// init TraceCtl when it is nil, or it will lead some unit tests panic
@@ -83,16 +82,15 @@ func newSvrTransHandler(opt *remote.ServerOption) (*svrTransHandler, error) {
 var _ remote.ServerTransHandler = &svrTransHandler{}
 
 type svrTransHandler struct {
-	opt           *remote.ServerOption
-	svcSearcher   remote.ServiceSearcher
-	targetSvcInfo *serviceinfo.ServiceInfo
-	inkHdlFunc    endpoint.Endpoint
-	codec         remote.Codec
-	transPipe     *remote.TransPipeline
-	ext           trans.Extension
-	funcPool      sync.Pool
-	conns         sync.Map
-	tasks         sync.WaitGroup
+	opt         *remote.ServerOption
+	svcSearcher remote.ServiceSearcher
+	inkHdlFunc  endpoint.Endpoint
+	codec       remote.Codec
+	transPipe   *remote.TransPipeline
+	ext         trans.Extension
+	funcPool    sync.Pool
+	conns       sync.Map
+	tasks       sync.WaitGroup
 }
 
 // Write implements the remote.ServerTransHandler interface.

--- a/server/server.go
+++ b/server/server.go
@@ -59,9 +59,8 @@ type Server interface {
 }
 
 type server struct {
-	opt           *internal_server.Options
-	svcs          *services
-	targetSvcInfo *serviceinfo.ServiceInfo
+	opt  *internal_server.Options
+	svcs *services
 
 	// actual rpc service implement of biz
 	eps     endpoint.Endpoint
@@ -217,7 +216,6 @@ func (s *server) Run() (err error) {
 	if err = s.check(); err != nil {
 		return err
 	}
-	s.findAndSetDefaultService()
 	diagnosis.RegisterProbeFunc(s.opt.DebugService, diagnosis.ServiceInfosKey, diagnosis.WrapAsProbeFunc(s.svcs.getSvcInfoMap()))
 	if s.svcs.fallbackSvc != nil {
 		diagnosis.RegisterProbeFunc(s.opt.DebugService, diagnosis.FallbackServiceKey, diagnosis.WrapAsProbeFunc(s.svcs.fallbackSvc.svcInfo.ServiceName))
@@ -448,7 +446,6 @@ func (s *server) streamHandleEndpoint() sep.StreamEndpoint {
 
 func (s *server) initBasicRemoteOption() {
 	remoteOpt := s.opt.RemoteOpt
-	remoteOpt.TargetSvcInfo = s.targetSvcInfo
 	remoteOpt.SvcSearcher = s.svcs
 	remoteOpt.InitOrResetRPCInfoFunc = s.initOrResetRPCInfoFunc()
 	remoteOpt.TracerCtl = s.opt.TracerCtl
@@ -631,12 +628,6 @@ func (s *server) waitExit(errCh chan error) error {
 			}
 			s.Unlock()
 		}
-	}
-}
-
-func (s *server) findAndSetDefaultService() {
-	if len(s.svcs.svcMap) == 1 {
-		s.targetSvcInfo = getDefaultSvcInfo(s.svcs)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
`TargetServiceInfo` was added to avoid service searching in single service scenario, but we've already integrated it into the service searching logic, and it's now useless and can be safely deleted. 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->