### PR TITLE
fix(tool): 更新服务名称生成逻辑(https://github.com/cloudwego/kitex/issues/1358)

### DIFF
--- a/tool/internal_pkg/generator/custom_template.go
+++ b/tool/internal_pkg/generator/custom_template.go
@@ -175,7 +175,7 @@ func (g *generator) GenerateCustomPackage(pkg *PackageInfo) (fs []*File, err err
 		return nil, err
 	}
 	for _, tpl := range t {
-		if tpl.LoopService && g.CombineService {
+		if g.CombineService {
 			svrInfo, cs := pkg.ServiceInfo, pkg.CombineServices
 
 			for i := range cs {

--- a/tool/internal_pkg/generator/generator.go
+++ b/tool/internal_pkg/generator/generator.go
@@ -462,6 +462,7 @@ func (g *generator) GenerateService(pkg *PackageInfo) ([]*File, error) {
 	output := util.JoinPath(g.OutputPath, util.CombineOutputPath(g.GenPath, pkg.Namespace))
 	svcPkg := strings.ToLower(pkg.ServiceName)
 	output = util.JoinPath(output, svcPkg)
+	g.ServiceName = pkg.Namespace
 	ext := g.tmplExt
 	if ext == nil {
 		ext = new(TemplateExtension)


### PR DESCRIPTION
自定义模板服务名为空，需要给值，现在使用namespace的值。

#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->