### PR TITLE
fix: protect bizErr and extra field of ri.Invocation by lock

### DIFF
--- a/pkg/rpcinfo/copy.go
+++ b/pkg/rpcinfo/copy.go
@@ -83,16 +83,17 @@ func copyInvocation(i Invocation) Invocation {
 		return nil
 	}
 	ink := i.(*invocation)
-	return &invocation{
+	nink := &invocation{
 		packageName:   ink.PackageName(),
 		serviceName:   ink.ServiceName(),
 		methodName:    ink.MethodName(),
 		methodInfo:    ink.MethodInfo(),
 		streamingMode: ink.StreamingMode(),
 		seqID:         ink.SeqID(),
-		bizErr:        ink.BizStatusErr(),
 		// ignore extra info to users
 	}
+	nink.SetBizStatusErr(ink.BizStatusErr())
+	return nink
 }
 
 func copyRPCConfig(cfg RPCConfig) RPCConfig {

--- a/pkg/rpcinfo/invocation.go
+++ b/pkg/rpcinfo/invocation.go
@@ -19,6 +19,7 @@ package rpcinfo
 import (
 	"sync"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
@@ -53,14 +54,17 @@ type InvocationSetter interface {
 	Reset()
 }
 type invocation struct {
+	sync.Mutex
 	packageName   string
 	serviceName   string
 	methodInfo    serviceinfo.MethodInfo
 	methodName    string
 	streamingMode serviceinfo.StreamingMode
 	seqID         int32
-	bizErr        kerrors.BizStatusErrorIface
-	extra         map[string]interface{}
+	// bizErr and extra should be protected by lock or atomic operation, because they might be read by the client calling goroutine,
+	// but at the same time, written by the real rpc goroutine which is started by timeout middleware.
+	bizErr unsafe.Pointer // of type *kerrors.BizStatusErrorIface
+	extra  map[string]interface{}
 }
 
 // NewInvocation creates a new Invocation with the given service, method and optional package.
@@ -153,15 +157,25 @@ func (i *invocation) SetStreamingMode(mode serviceinfo.StreamingMode) {
 
 // BizStatusErr implements the Invocation interface.
 func (i *invocation) BizStatusErr() kerrors.BizStatusErrorIface {
-	return i.bizErr
+	bizErr := (*kerrors.BizStatusErrorIface)(atomic.LoadPointer(&i.bizErr))
+	if bizErr == nil {
+		return nil
+	}
+	return *bizErr
 }
 
 // SetBizStatusErr implements the InvocationSetter interface.
 func (i *invocation) SetBizStatusErr(err kerrors.BizStatusErrorIface) {
-	i.bizErr = err
+	if err == nil {
+		atomic.StorePointer(&i.bizErr, nil)
+		return
+	}
+	atomic.StorePointer(&i.bizErr, unsafe.Pointer(&err))
 }
 
 func (i *invocation) SetExtra(key string, value interface{}) {
+	i.Lock()
+	defer i.Unlock()
 	if i.extra == nil {
 		i.extra = map[string]interface{}{}
 	}
@@ -169,6 +183,8 @@ func (i *invocation) SetExtra(key string, value interface{}) {
 }
 
 func (i *invocation) Extra(key string) interface{} {
+	i.Lock()
+	defer i.Unlock()
 	if i.extra == nil {
 		return nil
 	}
@@ -192,7 +208,9 @@ func (i *invocation) zero() {
 	i.serviceName = ""
 	i.methodName = ""
 	i.methodInfo = nil
-	i.bizErr = nil
+	atomic.StorePointer(&i.bizErr, nil)
+	i.Lock()
+	defer i.Unlock()
 	for key := range i.extra {
 		delete(i.extra, key)
 	}

--- a/pkg/transmeta/ttheader.go
+++ b/pkg/transmeta/ttheader.go
@@ -79,8 +79,7 @@ func (ch *clientTTHeaderHandler) WriteMeta(ctx context.Context, msg remote.Messa
 		hd[transmeta.ConnectTimeout] = strconv.Itoa(int(ri.Config().ConnectTimeout().Milliseconds()))
 	}
 	transInfo.PutTransIntInfo(hd)
-	svcInfo, _ := ri.Invocation().Extra(rpcinfo.InvocationServiceInfoKey).(*serviceinfo.ServiceInfo)
-	if idlSvcName := getIDLSvcName(svcInfo, ri); idlSvcName != "" {
+	if idlSvcName := getIDLSvcName(ri); idlSvcName != "" {
 		if strInfo := transInfo.TransStrInfo(); strInfo != nil {
 			strInfo[transmeta.HeaderIDLServiceName] = idlSvcName
 		} else {
@@ -90,7 +89,8 @@ func (ch *clientTTHeaderHandler) WriteMeta(ctx context.Context, msg remote.Messa
 	return ctx, nil
 }
 
-func getIDLSvcName(svcInfo *serviceinfo.ServiceInfo, ri rpcinfo.RPCInfo) string {
+func getIDLSvcName(ri rpcinfo.RPCInfo) string {
+	svcInfo, _ := ri.Invocation().Extra(rpcinfo.InvocationServiceInfoKey).(*serviceinfo.ServiceInfo)
 	idlSvcName := ri.Invocation().ServiceName()
 	// for combine service, idlSvcName may not be the same as server's service name
 	var isCombineService bool


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat: 使用锁保护 ri.Invacation 内的 bizErr 和 extra 字段

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->