### PR TITLE
fix(ttstream): inject K_METHOD in server-side ctx to add FROM_METHOD information

### DIFF
--- a/pkg/remote/trans/ttstream/server_handler.go
+++ b/pkg/remote/trans/ttstream/server_handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cloudwego/netpoll"
 
 	igeneric "github.com/cloudwego/kitex/internal/generic"
+	"github.com/cloudwego/kitex/pkg/consts"
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/gofunc"
 	"github.com/cloudwego/kitex/pkg/kerrors"
@@ -196,6 +197,11 @@ func (t *svrTransHandler) OnStream(ctx context.Context, conn net.Conn, st *serve
 	ink.SetStreamingMode(minfo.StreamingMode())
 	if mutableTo := rpcinfo.AsMutableEndpointInfo(ri.To()); mutableTo != nil {
 		_ = mutableTo.SetMethod(st.Method())
+		// this method name will be used as from method if a new RPC call is invoked in this handler.
+		// ping-pong relies on transMetaHandler.OnMessage to inject but streaming does not trigger.
+		//
+		//nolint:staticcheck // SA1029: consts.CtxKeyMethod has been used and we just follow it
+		stCtx = context.WithValue(stCtx, consts.CtxKeyMethod, st.Method())
 	}
 	rpcinfo.AsMutableRPCConfig(ri.Config()).SetTransportProtocol(st.TransportProtocol())
 

--- a/pkg/remote/trans/ttstream/transport_client.go
+++ b/pkg/remote/trans/ttstream/transport_client.go
@@ -234,7 +234,7 @@ func (t *clientTransport) loopWrite() error {
 			recycleFrame(fr)
 		}
 		if err = writer.Flush(); err != nil {
-			return err
+			return errTransport.newBuilder().withCause(err)
 		}
 	}
 }

--- a/pkg/remote/trans/ttstream/transport_test.go
+++ b/pkg/remote/trans/ttstream/transport_test.go
@@ -288,14 +288,14 @@ func TestTransportClose(t *testing.T) {
 			req.B = "hello"
 			sErr := cs.SendMsg(context.Background(), req)
 			if sErr != nil {
-				test.Assert(t, errors.Is(sErr, errIllegalFrame), sErr)
+				test.Assert(t, errors.Is(sErr, errIllegalFrame) || errors.Is(sErr, errTransport), sErr)
 				return
 			}
 
 			res := new(testResponse)
 			rErr := cs.RecvMsg(context.Background(), res)
 			if rErr != nil {
-				test.Assert(t, errors.Is(rErr, errIllegalFrame), rErr)
+				test.Assert(t, errors.Is(rErr, errIllegalFrame) || errors.Is(rErr, errTransport), rErr)
 				return
 			}
 			test.DeepEqual(t, req.B, res.B)


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(ttstream): 在服务端侧的 ctx 中注入 K_METHOD 以补全 FROM_METHOD 信息

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
在进行 RPC 调用时，client 会尝试从 ctx 中提取当前所处的 handler 对应的 method，从而知道是从哪个 handler 中发起的:
```
if fromMethod := ctx.Value(consts.CtxKeyMethod); fromMethod != nil {
    rpcinfo.AsMutableEndpointInfo(ri.From()).SetMethod(fromMethod.(string))
}
```
对于 Ping-Pong，FROM_METHOD 的注入在`transmetaHandler.OnMessage`中完成：
```
func (h *transMetaHandler) OnMessage(ctx context.Context, args, result remote.Message) (context.Context, error) {
        // ...
	if isServer && result.MessageType() != remote.Exception {
		// Pass through method name using ctx, the method name will be used as from method in the client.
		ctx = context.WithValue(ctx, consts.CtxKeyMethod, msg.RPCInfo().To().Method())
		// ...
	}
	return ctx, nil
}
```
gRPC 在 #1792 中补全，这次补全 TTHeader Streaming

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->