### PR TITLE
fix(ttstream): cancelFunc panic when server-side stream receiving Rst and then returning handler with customized error

### DIFF
--- a/pkg/remote/trans/ttstream/exception.go
+++ b/pkg/remote/trans/ttstream/exception.go
@@ -34,10 +34,12 @@ var (
 
 	errBizCancel = newException("user code invoking stream RPC with context processed by context.WithCancel or context.WithTimeout, then invoking cancel() actively",
 		kerrors.ErrStreamingCanceled, 12007)
-	errBizCancelWithCause = newException("user code canceled with cancelCause(error)", kerrors.ErrStreamingCanceled, 12008)
-	errDownstreamCancel   = newException("canceled by downstream", kerrors.ErrStreamingCanceled, 12009)
-	errUpstreamCancel     = newException("canceled by upstream", kerrors.ErrStreamingCanceled, 12010)
-	errInternalCancel     = newException("internal canceled", kerrors.ErrStreamingCanceled, 12011)
+	errBizCancelWithCause     = newException("user code canceled with cancelCause(error)", kerrors.ErrStreamingCanceled, 12008)
+	errDownstreamCancel       = newException("canceled by downstream", kerrors.ErrStreamingCanceled, 12009)
+	errUpstreamCancel         = newException("canceled by upstream", kerrors.ErrStreamingCanceled, 12010)
+	errInternalCancel         = newException("internal canceled", kerrors.ErrStreamingCanceled, 12011)
+	errBizHandlerReturnCancel = newException("canceled by business handler returning", kerrors.ErrStreamingCanceled, 12012)
+	errConnectionClosedCancel = newException("canceled by connection closed", kerrors.ErrStreamingCanceled, 12013)
 )
 
 const (
@@ -103,8 +105,10 @@ func (e *Exception) Error() string {
 }
 
 func (e *Exception) withCause(cause error) *Exception {
-	e.cause = cause
-	e.bitSet |= setCause
+	if cause != nil {
+		e.cause = cause
+		e.bitSet |= setCause
+	}
 	return e
 }
 

--- a/pkg/remote/trans/ttstream/exception_test.go
+++ b/pkg/remote/trans/ttstream/exception_test.go
@@ -39,6 +39,10 @@ func TestErrors(t *testing.T) {
 	test.Assert(t, errors.Is(appErr, errApplicationException), appErr)
 	test.Assert(t, !errors.Is(appErr, kerrors.ErrStreamingProtocol), appErr)
 	test.Assert(t, strings.Contains(appErr.Error(), causeErr.Error()))
+
+	newExWithNilErr := errIllegalFrame.newBuilder().withCause(nil)
+	test.Assert(t, !newExWithNilErr.isCauseSet(), newExWithNilErr)
+	test.Assert(t, newExWithNilErr.cause == nil, newExWithNilErr)
 }
 
 func TestCommonParentKerror(t *testing.T) {

--- a/pkg/remote/trans/ttstream/stream_server_test.go
+++ b/pkg/remote/trans/ttstream/stream_server_test.go
@@ -39,8 +39,8 @@ func newTestServerStream() *serverStream {
 func Test_serverStreamStateChange(t *testing.T) {
 	t.Run("serverStream close, then RecvMsg/SendMsg returning exception", func(t *testing.T) {
 		srvSt := newTestServerStream()
-		testException := errors.New("test")
-		err := srvSt.close(testException, false)
+		testException := errInternalCancel.newBuilder().withCause(errors.New("test"))
+		err := srvSt.close(testException)
 		test.Assert(t, err == nil, err)
 		rErr := srvSt.RecvMsg(srvSt.ctx, nil)
 		test.Assert(t, rErr == testException, rErr)
@@ -49,11 +49,11 @@ func Test_serverStreamStateChange(t *testing.T) {
 	})
 	t.Run("serverStream close twice with different exception, RecvMsg/SendMsg returning the first time exception", func(t *testing.T) {
 		srvSt := newTestServerStream()
-		testException1 := errors.New("test1")
-		err := srvSt.close(testException1, false)
+		testException1 := errInternalCancel.newBuilder().withCause(errors.New("test1"))
+		err := srvSt.close(testException1)
 		test.Assert(t, err == nil, err)
-		testException2 := errors.New("test2")
-		err = srvSt.close(testException2, false)
+		testException2 := errInternalCancel.newBuilder().withCause(errors.New("test2"))
+		err = srvSt.close(testException2)
 		test.Assert(t, err == nil, err)
 
 		rErr := srvSt.RecvMsg(srvSt.ctx, nil)
@@ -65,10 +65,10 @@ func Test_serverStreamStateChange(t *testing.T) {
 		srvSt := newTestServerStream()
 		var wg sync.WaitGroup
 		wg.Add(2)
-		testException := errors.New("test")
+		testException := errInternalCancel.newBuilder().withCause(errors.New("test1"))
 		go func() {
 			time.Sleep(100 * time.Millisecond)
-			err := srvSt.close(testException, false)
+			err := srvSt.close(testException)
 			test.Assert(t, err == nil, err)
 		}()
 		go func() {

--- a/pkg/remote/trans/ttstream/transport_client.go
+++ b/pkg/remote/trans/ttstream/transport_client.go
@@ -172,7 +172,7 @@ func (t *clientTransport) readFrame(reader bufiox.Reader) error {
 	var ok bool
 	s, ok = t.loadStream(fr.sid)
 	if !ok {
-		klog.Errorf("transport[%s] read a unknown stream: frame[%s]", t.Addr(), fr)
+		klog.Debugf("transport[%s] read a unknown stream: frame[%s]", t.Addr(), fr)
 		// ignore unknown stream error
 		err = nil
 	} else {


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(ttstream): 当 server 侧 stream 收到 rst 并且 handler 返回了自定义错误，cancelFunc 会 panic

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
- bug 触发条件：
1. Kitex-Client 或其它支持 TTHeader Streaming 的 client 发送 rst Frame(使用 cancel 功能)
2. Kitex-Server 处理完 rst Frame 后，handler 并没有返回 ttstream 包下的```Exception```类型错误，而是返回了其它 error
本质是 rst Frame 和 handler return 的处理路径都会使用```serverStream.close```，在确认流状态前会调用```cancelFunc```，其中使用 atomic.Value 存放了用于 ctx 的 err，如果类型不同就会 panic。

- bug 引入 pr：
https://github.com/cloudwego/kitex/pull/1821

- bug 引入版本：
尚未发版
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->