### PR TITLE
fix(ttstream): use consistent context of stream in ttstream.RecvMsg and fix nil message error of binary generic

### DIFF
--- a/pkg/generic/thrift/raw.go
+++ b/pkg/generic/thrift/raw.go
@@ -49,6 +49,14 @@ var _ MessageWriter = (*RawWriter)(nil)
 
 // Write returns the copy of data
 func (m *RawWriter) Write(ctx context.Context, out bufiox.Writer, msg interface{}, method string, isClient bool, requestBase *base.Base) error {
+	if msg == nil {
+		bw := thrift.NewBufferWriter(out)
+		defer bw.Recycle()
+		if err := bw.WriteFieldStop(); err != nil {
+			return err
+		}
+		return nil
+	}
 	buf, ok := msg.([]byte)
 	if !ok {
 		return fmt.Errorf("thrift binary generic msg is not []byte, method=%v", method)

--- a/pkg/generic/thrift/raw_test.go
+++ b/pkg/generic/thrift/raw_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/cloudwego/gopkg/bufiox"
 	"github.com/cloudwego/gopkg/protocol/thrift"
+
+	"github.com/cloudwego/kitex/internal/test"
 )
 
 func TestRawReader_Read(t *testing.T) {
@@ -45,4 +47,25 @@ func TestRawReader_Read(t *testing.T) {
 	if !reflect.DeepEqual(data, nb[:off]) {
 		t.Fatalf("expect %v, got %v", nb[:off], data)
 	}
+}
+
+func TestRawWriter_Write(t *testing.T) {
+	w := NewRawWriter()
+	var buf []byte
+	out := bufiox.NewBytesWriter(&buf)
+	// nil message
+	err := w.Write(context.Background(), out, nil, "method", true, nil)
+	test.Assert(t, err == nil)
+	err = out.Flush()
+	test.Assert(t, err == nil)
+	test.Assert(t, len(buf) == 1) // field stop
+	test.Assert(t, buf[0] == byte(thrift.STOP))
+
+	// normal message
+	buf = buf[:0]
+	err = w.Write(context.Background(), out, []byte("hello world"), "method", true, nil)
+	test.Assert(t, err == nil)
+	err = out.Flush()
+	test.Assert(t, err == nil)
+	test.Assert(t, len(buf) == len("hello world"))
 }

--- a/pkg/remote/trans/ttstream/stream.go
+++ b/pkg/remote/trans/ttstream/stream.go
@@ -125,16 +125,17 @@ func (s *stream) SendMsg(ctx context.Context, msg any) (err error) {
 }
 
 func (s *stream) RecvMsg(ctx context.Context, data any) error {
+	nctx := s.ctx
 	if s.recvTimeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, s.recvTimeout)
+		nctx, cancel = context.WithTimeout(nctx, s.recvTimeout)
 		defer cancel()
 	}
-	payload, err := s.reader.output(ctx)
+	payload, err := s.reader.output(nctx)
 	if err != nil {
 		return err
 	}
-	err = DecodePayload(ctx, payload, data)
+	err = DecodePayload(nctx, payload, data)
 	// payload will not be access after decode
 	mcache.Free(payload)
 


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix: 在 ttstream.RecvMsg 中使用与 stream 一致的 context，并修复 binary generic 的 nil message 异常

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:  In the ttstream.RecvMsg call, if the incoming context is used as an imported parameter for pipeline.Read, it may lead to a failure of cancel pass-through; if used as an imported parameter for DecodePayload, it may lead to a failure of rpcinfo retrieval.
zh(optional): 在 ttstream.RecvMsg 调用中，如果使用传入的 context 作为 pipeline.Read 的入参，可能导致 cancel 透传失败，作为DecodePayload 入参，则可能导致 rpcinfo 获取失败

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->