### PR TITLE
fix：`cancel` should be called to release resources

### DIFF
--- a/server/middlewares.go
+++ b/server/middlewares.go
@@ -36,7 +36,7 @@ func serverTimeoutMW(next endpoint.Endpoint) endpoint.Endpoint {
 
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
-		
+
 		return next(ctx, request, response)
 	}
 }

--- a/server/middlewares.go
+++ b/server/middlewares.go
@@ -35,11 +35,8 @@ func serverTimeoutMW(next endpoint.Endpoint) endpoint.Endpoint {
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, timeout)
-		defer func() {
-			if err != nil {
-				cancel()
-			}
-		}()
+		defer cancel()
+		
 		return next(ctx, request, response)
 	}
 }


### PR DESCRIPTION
When `defer` runs, the function `next(ctx, request, response)` has already completed. Regardless of whether `err` is nil, `cancel` should be called to release resources promptly.

#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
cancel 应该在next函数执行结束后，立即执行。


#1883 