### PR TITLE
perf: avoid grpc cleanupStream onWrite closure captures Stream

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/controlbuf.go
+++ b/pkg/remote/trans/nphttp2/grpc/controlbuf.go
@@ -84,6 +84,7 @@ func (il *itemList) dequeue() interface{} {
 	}
 	unused := il.head
 	i := unused.it
+	unused.it = nil
 	il.head = il.head.next
 	if il.head == nil {
 		il.tail = nil


### PR DESCRIPTION
#### What type of PR is this?
perf
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
perf: 避免 grpc cleanupStream onWrite 回调函数的闭包捕获 Stream

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
The gRPC cleanupStream captures the Stream via `s.id` within the `onWrite` closure. Since `itemList` caches some `cbItem` objects, this may prevent the cleanupStream—and consequently the Stream—from being released.
In certain scenarios, users may pass large amounts of metadata/metainfo, resulting in significant Stream memory consumption visible in flame graphs.
zh(optional): 
grpc cleanupStream 在 onWrite 闭包中通过 s.id 捕获了 Stream，由于 itemList 缓存了部分 cbItem，有可能导致 cleanupStream 进而 Stream 无法释放。
在某些场景下，用户会传入大量的 metadata/metainfo，因此在火焰图中会看到大块的 Stream 内存。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->