### PR TITLE
fix(ttstream): ttstream should supplement sending Header Frame when exiting handler directly

### DIFF
--- a/pkg/remote/trans/ttstream/stream_client.go
+++ b/pkg/remote/trans/ttstream/stream_client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloudwego/gopkg/protocol/ttheader"
 
 	"github.com/cloudwego/kitex/pkg/klog"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/pkg/transmeta"
 )
@@ -246,6 +247,9 @@ func (s *clientStream) onReadTrailerFrame(fr *Frame) error {
 			// todo: unify bizErr with Exception
 			// bizErr is independent of rpc exception handling
 			exception = bizErr
+			if setter, ok := s.rpcInfo.Invocation().(rpcinfo.InvocationSetter); ok {
+				setter.SetBizStatusErr(bizErr)
+			}
 		}
 	}
 

--- a/pkg/remote/trans/ttstream/stream_server.go
+++ b/pkg/remote/trans/ttstream/stream_server.go
@@ -122,6 +122,11 @@ func (s *serverStream) SendMsg(ctx context.Context, res any) error {
 // after CloseSend stream cannot be access again
 func (s *serverStream) CloseSend(exception error) error {
 	s.close(errBizHandlerReturnCancel)
+	if s.wheader != nil {
+		if err := s.sendHeader(); err != nil {
+			return err
+		}
+	}
 	return s.sendTrailer(exception)
 }
 

--- a/pkg/remote/trans/ttstream/test_utils.go
+++ b/pkg/remote/trans/ttstream/test_utils.go
@@ -27,13 +27,22 @@ import (
 	"github.com/cloudwego/kitex/pkg/streaming"
 )
 
-type mockStreamWriter struct{}
+type mockStreamWriter struct {
+	writeFrameFunc  func(f *Frame) error
+	closeStreamFunc func(sid int32) error
+}
 
 func (m mockStreamWriter) WriteFrame(f *Frame) error {
+	if m.writeFrameFunc != nil {
+		return m.writeFrameFunc(f)
+	}
 	return nil
 }
 
 func (m mockStreamWriter) CloseStream(sid int32) error {
+	if m.closeStreamFunc != nil {
+		return m.closeStreamFunc(sid)
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(ttstream): 当直接退出 handler 时，ttstream 应当补充发送 Header 帧

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
- 补发 Header Frame
根据 TTHeader Streaming 协议，一个 Stream 某个方向的第一个 Frame 应当是 Header Frame。
从 Kitex 支持 TTHeader Streaming 开始(v0.12.0)，当直接退出 handler 时，只会发送 Trailer Frame，不会补发 Header Frame
- 修复 client-side BizErr 丢点问题

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->