### PR TITLE
fix(rpcinfo): fix type conversion panic when chaining call FreezeRPCInfo twice

### DIFF
--- a/pkg/rpcinfo/copy_test.go
+++ b/pkg/rpcinfo/copy_test.go
@@ -43,13 +43,23 @@ func TestFreezeRPCInfo(t *testing.T) {
 	ctx2 := FreezeRPCInfo(ctx)
 	test.Assert(t, ctx2 != ctx)
 	ri2 := GetRPCInfo(ctx2)
-	test.Assert(t, ri2 != nil)
-	test.Assert(t, ri2 != ri)
+	checkFreezeRPCInfo(t, ri2, ri)
 
-	test.Assert(t, AsTaggable(ri2.From()) == nil)
-	test.Assert(t, AsTaggable(ri2.To()) == nil)
-	test.Assert(t, AsMutableEndpointInfo(ri2.From()) == nil)
-	test.Assert(t, AsMutableEndpointInfo(ri2.To()) == nil)
-	test.Assert(t, AsMutableRPCConfig(ri2.Config()) == nil)
-	test.Assert(t, ri2.Stats() == nil)
+	// call FreezeRPCInfo continuously should not cause a panic
+	ctx3 := FreezeRPCInfo(ctx2)
+	test.Assert(t, ctx3 != ctx2)
+	ri3 := GetRPCInfo(ctx3)
+	checkFreezeRPCInfo(t, ri3, ri2)
+}
+
+func checkFreezeRPCInfo(t *testing.T, ri, prevRI RPCInfo) {
+	test.Assert(t, ri != nil)
+	test.Assert(t, ri != prevRI)
+
+	test.Assert(t, AsTaggable(ri.From()) == nil)
+	test.Assert(t, AsTaggable(ri.To()) == nil)
+	test.Assert(t, AsMutableEndpointInfo(ri.From()) == nil)
+	test.Assert(t, AsMutableEndpointInfo(ri.To()) == nil)
+	test.Assert(t, AsMutableRPCConfig(ri.Config()) == nil)
+	test.Assert(t, ri.Stats() == nil)
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(rpcinfo): 修复当链式调用 FreezeRPCInfo 造成的类型转换 panic

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
出于代码复用的考虑，用户可能会在每个函数启动 goroutine 前都调用`rpcinfo.FreezeRPCInfo`解决异步使用 rpcinfo 的问题：
```
func func1(ctx context.Context) {
    freezeCtx := rpcinfo.FreezeRPCInfo(ctx)
    go func2(freezeCtx)
}

func func2(ctx context.Context) {
    freezeCtx := rpcinfo.FreezeRPCInfo(ctx)
    go func3(freezeCtx)
}
```
导致第二次调用`rpcinfo.FreezeRPCInfo`时，```plainRPCInfo```的 Invocation 类型(```struct{ Invocation }```) 与```*invocation``` 不匹配，类型强转造成 panic。

bug 引入版本：v0.15.0
#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->