### PR TITLE
fix(tool): DeepCopy assignment failed when map key type is binary

### DIFF
--- a/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
+++ b/tool/internal_pkg/pluginmode/thriftgo/struct_tpl.go
@@ -738,7 +738,7 @@ const FieldDeepCopyBaseType = `
 	{{- end}}
 	{{- if .IsPointer}}
 		if {{$Src}} != nil {
-			{{- if .Type.Category.IsBinary}}
+			{{- if and .Type.Category.IsBinary (not (IsGoStringType .TypeName))}}
 			tmp := make([]byte, len(*{{$Src}}))
 			if len(*{{$Src}}) != 0 {
 				copy(tmp, *{{$Src}})
@@ -750,7 +750,7 @@ const FieldDeepCopyBaseType = `
 			{{- end}}
 		}
 	{{- else}}
-		{{- if .Type.Category.IsBinary}}
+		{{- if and .Type.Category.IsBinary (not (IsGoStringType .TypeName))}}
 		if len({{$Src}}) != 0 {
 			tmp := make([]byte, len({{$Src}}))
 			copy(tmp, {{$Src}})


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
当 thrift idl 定义的 map key 为 binary 时，DeepCopy 的赋值逻辑有误：
例如：
```
struct TestStruct {
    1:optional map<binary,list<string>> ContentMap
}
``` 
DeepCopy 逻辑中将 []byte 直接赋值给 string:
<img width="1040" height="1014" alt="image" src="https://github.com/user-attachments/assets/64d43954-5689-441d-8d7c-05e7cef0b0ed" />

修改历史：
1. https://github.com/cloudwego/kitex/pull/1166 修复 map key 为 binary，DeepCopy 赋值 bug
当 map key 为 binary 时，视作 string 并利用```utils.StringDeepCopy```拷贝
2. https://github.com/cloudwego/kitex/pull/1832 移除```utils.StringDeepCopy```，但也同时 revert 了相关修复


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->