### PR TITLE
fix: fill up RPC config when seqID==0 (fix issue_1897)

### DIFF
--- a/pkg/remote/trans/netpollmux/mux_conn.go
+++ b/pkg/remote/trans/netpollmux/mux_conn.go
@@ -80,7 +80,7 @@ func (c *muxCliConn) OnRequest(ctx context.Context, connection netpoll.Connectio
 	if seqID == 0 {
 		iv := rpcinfo.NewInvocation("none", "none")
 		iv.SetSeqID(0)
-		ri := rpcinfo.NewRPCInfo(nil, nil, iv, nil, nil)
+		ri := rpcinfo.NewRPCInfo(nil, nil, iv, rpcinfo.NewRPCConfig(), nil)
 		ctl := NewControlFrame()
 		msg := remote.NewMessage(ctl, ri, remote.Reply, remote.Client)
 


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
当seqID==0时传入一个空的配置，避免出现panic

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: 
zh(optional): 
server和client同时启动多路复用，关闭server服务时client会触发panic #1897

1. 触发场景: 当服务端关闭时，会向客户端发送一个 seqID=0 的控制帧。
2. 进入控制帧处理逻辑: 客户端的 muxCliConn.OnRequest 收到该帧，因 seqID 为 0，进入控制帧处理逻辑。
源码路径: kitex/pkg/remote/trans/netpollmux/mux_conn.go
    ri := rpcinfo.NewRPCInfo(nil, nil, iv, nil, nil) // 关键点：第 4 个参数 config 为 nil

在这里，为了解码控制帧，代码创建了一个临时的 RPCInfo 实例 (ri)。关键在于，NewRPCInfo 的第四个参数 config 被传入了 nil。这意味着这个临时 Message 的 RPCInfo 中 Config() 返回的是 nil。
3. 解码调用链: 接着，代码调用 defaultCodec.Decode(ctx, msg, bufReader)。Decode 内部会调用 DecodePayload。
源码路径: kitex/pkg/remote/codec/default_codec.go
// kitex/pkg/remote/codec/default_codec.go:256

// kitex/pkg/remote/codec/default_codec.go:234


4. GetPayloadCodec 内部逻辑与 Panic 点: GetPayloadCodec 尝试获取 PayloadCodec。
源码路径: kitex/pkg/remote/payload_codec.go
// kitex/pkg/remote/payload_codec.go:36
  - 对于控制帧的 Message，message.PayloadCodec() 是 nil。
  - 代码执行到 ri.Config().PayloadCodec()。
  - 由于步骤 2 中创建 RPCInfo 时传入的 config 是 nil，所以 ri.Config() 返回 nil。
  - 在 nil 上调用 PayloadCodec() 方法，触发了空指针解引用 panic。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/cloudwego/kitex/issues/1897

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->