### PR TITLE
feat(streaming): remove rpcinfo reuse for streaming

### DIFF
--- a/pkg/remote/trans/nphttp2/stream.go
+++ b/pkg/remote/trans/nphttp2/stream.go
@@ -35,7 +35,6 @@ type grpcServerStream struct {
 type serverStream struct {
 	ctx     context.Context
 	rpcInfo rpcinfo.RPCInfo
-	svcInfo *serviceinfo.ServiceInfo
 	conn    *serverConn
 	handler remote.TransReadWriter
 	// for grpc compatibility
@@ -49,11 +48,10 @@ func (s *serverStream) GetGRPCStream() streaming.Stream {
 }
 
 // newServerStream ...
-func newServerStream(ctx context.Context, svcInfo *serviceinfo.ServiceInfo, conn *serverConn, handler remote.TransReadWriter) *serverStream {
+func newServerStream(ctx context.Context, conn *serverConn, handler remote.TransReadWriter) *serverStream {
 	sx := &serverStream{
 		ctx:     ctx,
 		rpcInfo: rpcinfo.GetRPCInfo(ctx),
-		svcInfo: svcInfo,
 		conn:    conn,
 		handler: handler,
 	}

--- a/pkg/remote/trans/nphttp2/stream_test.go
+++ b/pkg/remote/trans/nphttp2/stream_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
-	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
 
 func TestStream(t *testing.T) {
@@ -41,15 +40,7 @@ func TestStream(t *testing.T) {
 	ctx := newMockCtxWithRPCInfo()
 
 	// test newServerStream()
-	stream := newServerStream(ctx, &serviceinfo.ServiceInfo{
-		PackageName:     "",
-		ServiceName:     "",
-		HandlerType:     nil,
-		Methods:         nil,
-		PayloadCodec:    0,
-		KiteXGenVersion: "",
-		Extra:           nil,
-	}, serverConn, handler)
+	stream := newServerStream(ctx, serverConn, handler)
 
 	// test Context()
 	strCtx := stream.GetGRPCStream().Context()


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(streaming): 移除流式调用 rpcinfo 复用

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
在流式 handler 里启动 goroutine 操作 stream，并依赖 handler 退出结束 stream 生命周期是很常见的使用范式。
若 goroutine 中会访问 rpcinfo，handler 退出并复用 rpcinfo 很可能导致并发读写。
因此对于流式接口，不再复用 rpcinfo。

- gRPC
Unary/None 调用复用 rpcinfo
Streaming 调用不复用
- ttstream
不存在 Unary 调用，一律不复用

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->