### PR TITLE
fix: make typeOf() in generic thrift write compatible with int and int-based maps

### DIFF
--- a/pkg/generic/descriptor/type.go
+++ b/pkg/generic/descriptor/type.go
@@ -46,6 +46,9 @@ const (
 	UTF16  Type = 17
 	// BINARY Type = 18   wrong and unused
 	JSON Type = 19
+
+	MAX_TYPE        // indicates max type, so it has the value of previous one
+	TYPE_UPPERBOUND = MAX_TYPE + 1
 )
 
 var typeNames = map[Type]string{

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -335,19 +335,19 @@ func writeIntSeries[T ~int | ~int8 | ~uint8 | ~int16 | ~int32 | ~int64](ctx cont
 	switch t.Type {
 	case descriptor.I08:
 		// uint8 will never exceed the range
-		if _, ok := val.(uint8); !ok && (i < math.MinInt8 || i > math.MaxInt8) {
+		if _, ok := val.(uint8); !ok && (int64(i) < math.MinInt8 || int64(i) > math.MaxInt8) {
 			return fmt.Errorf("value is beyond range of i8: %v", i)
 		}
 		return out.WriteByte(int8(i))
 	case descriptor.I16:
-		if i < math.MinInt16 || i > math.MaxInt16 {
+		if int64(i) < math.MinInt16 || int64(i) > math.MaxInt16 {
 			return fmt.Errorf("value is beyond range of i16: %v", i)
 		}
 		return out.WriteI16(int16(i))
 	case descriptor.I32:
 		// for int on 32-bit architectures: this branch is considered dead hence removed by go compiler
 		// for int on 64-bit architectures: this branch functions as writeInt64() does
-		if i < math.MinInt32 || i > math.MaxInt32 {
+		if int64(i) < math.MinInt32 || int64(i) > math.MaxInt32 {
 			return fmt.Errorf("value is beyond range of i32: %v", i)
 		}
 		return out.WriteI32(int32(i))

--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -136,6 +136,8 @@ func typeOf(sample interface{}, t *descriptor.TypeDescriptor, opt *writerOption)
 		return descriptor.MAP, writeVariousComparableMap[int32], nil
 	case map[int64]interface{}:
 		return descriptor.MAP, writeVariousComparableMap[int64], nil
+	case map[int]interface{}:
+		return descriptor.MAP, writeVariousComparableMap[int], nil
 	}
 	return 0, nil, fmt.Errorf("unsupported type:%T, expected type:%s", sample, tt)
 }

--- a/pkg/generic/thrift/write_new.go
+++ b/pkg/generic/thrift/write_new.go
@@ -1,0 +1,117 @@
+package thrift
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/cloudwego/gopkg/protocol/thrift"
+	"github.com/cloudwego/kitex/pkg/generic/descriptor"
+)
+
+type thriftWriter func(ctx context.Context, out *thrift.BufferWriter, val interface{}) error
+
+func nopWriter(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	return nil
+}
+
+var (
+	_ thriftWriter = nopWriter
+	_ thriftWriter = voidWriter
+)
+
+var writeFunctions = [descriptor.TYPE_UPPERBOUND]thriftWriter{
+	nopWriter,    // STOP = 0
+	voidWriter,   // VOID = 1
+	boolWriter,   // BOOL = 2
+	byteWriter,   // BYTE/I08 = 3
+	doubleWriter, // DOUBLE = 4
+	nopWriter,    // nothing, index = 5
+	int16Writer,  // I16 = 6
+	nopWriter,    // nothing, index = 7
+	int32Writer,  // I32 = 8
+	nopWriter,    // nothing, index = 9
+	int64Writer,  // I64 = 10
+	stringWriter, // STRING = 11
+}
+
+func voidWriter(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	panic("todo")
+}
+
+func boolWriter(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	b, ok := val.(bool)
+	if !ok {
+		return fmt.Errorf("val must be bool, got %T", val)
+	}
+	return out.WriteBool(b)
+}
+
+func byteWriter(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	switch b := val.(type) {
+	case int8:
+		return out.WriteByte(b)
+	case uint8:
+		return out.WriteByte(int8(b))
+	}
+
+	// slow path
+	if b, ok := asInt64(val); ok {
+		if b <= math.MaxInt8 && b >= math.MinInt8 {
+			return out.WriteByte(int8(b))
+		}
+		return fmt.Errorf("val[%d] is out of range (int8)", b)
+	}
+	return fmt.Errorf("val must be int, got %T", val)
+}
+
+func doubleWriter(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	b, ok := asFloat64(val)
+	if ok {
+		return out.WriteDouble(b)
+	}
+	return fmt.Errorf("val must be float64, got %T", val)
+}
+
+func int16Writer(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	if b, ok := val.(int16); ok {
+		return out.WriteI16(b)
+	}
+	if b, ok := asInt64(val); ok {
+		if b <= math.MaxInt16 && b >= math.MinInt16 {
+			return out.WriteI16(int16(b))
+		}
+		return fmt.Errorf("val[%d] is out of range (int16)", b)
+	}
+	return fmt.Errorf("val must be int16, got %T", val)
+}
+
+func int32Writer(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	if b, ok := val.(int32); ok {
+		return out.WriteI32(b)
+	}
+	if b, ok := asInt64(val); ok {
+		if b <= math.MaxInt32 && b >= math.MinInt32 {
+			return out.WriteI32(int32(b))
+		}
+		return fmt.Errorf("val[%d] is out of range (int32)", b)
+	}
+	return fmt.Errorf("val must be int32, got %T", val)
+}
+
+func int64Writer(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	if b, ok := val.(int64); ok {
+		return out.WriteI64(b)
+	}
+	if b, ok := asInt64(val); ok {
+		return out.WriteI64(b)
+	}
+	return fmt.Errorf("val must be int64, got %T", val)
+}
+
+func stringWriter(ctx context.Context, out *thrift.BufferWriter, val interface{}) error {
+	if b, ok := val.(string); ok {
+		return out.WriteString(b)
+	}
+	return fmt.Errorf("val must be string, got %T", val)
+}

--- a/pkg/generic/thrift/write_utils.go
+++ b/pkg/generic/thrift/write_utils.go
@@ -1,0 +1,57 @@
+package thrift
+
+import "encoding/json"
+
+func asInt64(v interface{}) (int64, bool) {
+	switch v := v.(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	}
+	return asInt64Slow(v)
+}
+
+func asInt64Slow(v interface{}) (int64, bool) {
+	switch v := v.(type) {
+	case int8:
+		return int64(v), true
+	case uint8:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case uint32:
+		return int64(v), true
+	case json.Number:
+		r, e := v.Int64()
+		return r, e == nil
+	case int16:
+		return int64(v), true
+	case uint16:
+		return int64(v), true
+	case uint:
+		return int64(v), (v >> 63) > 0
+	case uint64:
+		return int64(v), (v >> 63) > 0
+	}
+	return 0, false
+}
+
+func asFloat64(v interface{}) (float64, bool) {
+	switch v := v.(type) {
+	case float64:
+		return v, true
+	case json.Number:
+		r, e := v.Float64()
+		return r, e == nil
+	}
+	return asFloat64Slow(v)
+}
+
+func asFloat64Slow(v interface{}) (float64, bool) {
+	if b, ok := v.(float32); ok {
+		return float64(b), true
+	}
+	i64, ok := asInt64(v)
+	return float64(i64), ok
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: In generic call of thrift protocol, the tool does not accept some basic go types such as int and int-based maps (like map[int32]interface{}). This PR make the tool accepting them.
zh(optional): 修复 thrift 泛化调用不接受诸如 int, map[int32]interface{} 这样的基础 go 类型

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->