### PR TITLE
feat(streaming): add Recv timeout config and adjust gRPC error/log

### DIFF
--- a/client/callopt/streamcall/call_options_test.go
+++ b/client/callopt/streamcall/call_options_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cloudwego/kitex/client/callopt"
 	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/streaming"
 )
 
 func TestWithRecvTimeout(t *testing.T) {
@@ -32,4 +33,25 @@ func TestWithRecvTimeout(t *testing.T) {
 	WithRecvTimeout(testTimeout).f(&callOpts, &sb)
 	test.Assert(t, callOpts.StreamOptions.RecvTimeout == testTimeout)
 	test.Assert(t, sb.String() == "WithRecvTimeout(1s)")
+}
+
+func TestWithRecvTimeoutConfig(t *testing.T) {
+	// config timeout
+	sb := strings.Builder{}
+	callOpts := callopt.CallOptions{}
+	WithRecvTimeoutConfig(streaming.TimeoutConfig{Timeout: 1 * time.Second}).f(&callOpts, &sb)
+	test.Assert(t, callOpts.StreamOptions.RecvTimeoutConfig.Timeout == 1*time.Second, callOpts)
+	test.Assert(t, !callOpts.StreamOptions.RecvTimeoutConfig.DisableCancelRemote, callOpts)
+	// config DisableCancelRemote
+	sb = strings.Builder{}
+	callOpts = callopt.CallOptions{}
+	WithRecvTimeoutConfig(streaming.TimeoutConfig{DisableCancelRemote: true}).f(&callOpts, &sb)
+	test.Assert(t, callOpts.StreamOptions.RecvTimeoutConfig.Timeout == 0, callOpts)
+	test.Assert(t, callOpts.StreamOptions.RecvTimeoutConfig.DisableCancelRemote, callOpts)
+	// config timeout and DisableCancelRemote
+	sb = strings.Builder{}
+	callOpts = callopt.CallOptions{}
+	WithRecvTimeoutConfig(streaming.TimeoutConfig{Timeout: 1 * time.Second, DisableCancelRemote: true}).f(&callOpts, &sb)
+	test.Assert(t, callOpts.StreamOptions.RecvTimeoutConfig.Timeout == 1*time.Second, callOpts)
+	test.Assert(t, callOpts.StreamOptions.RecvTimeoutConfig.DisableCancelRemote, callOpts)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -826,6 +826,9 @@ func initRPCInfo(ctx context.Context, method string, opt *client.Options, svcInf
 	if sopt.RecvTimeout > 0 {
 		cfg.SetStreamRecvTimeout(sopt.RecvTimeout)
 	}
+	if sopt.RecvTimeoutConfig.Timeout > 0 {
+		cfg.SetStreamRecvTimeoutConfig(sopt.RecvTimeoutConfig)
+	}
 
 	ctx = rpcinfo.NewCtxWithRPCInfo(ctx, ri)
 
@@ -836,6 +839,9 @@ func initRPCInfo(ctx context.Context, method string, opt *client.Options, svcInf
 		}
 		if callOpts.StreamOptions.RecvTimeout != 0 {
 			cfg.SetStreamRecvTimeout(callOpts.StreamOptions.RecvTimeout)
+		}
+		if callOpts.StreamOptions.RecvTimeoutConfig.Timeout > 0 {
+			cfg.SetStreamRecvTimeoutConfig(callOpts.StreamOptions.RecvTimeoutConfig)
 		}
 	}
 

--- a/client/stream.go
+++ b/client/stream.go
@@ -20,14 +20,21 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"sync/atomic"
+	"time"
 
+	"github.com/bytedance/gopkg/util/gopool"
+
+	internal_stream "github.com/cloudwego/kitex/internal/stream"
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/endpoint/cep"
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/remotecli"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/metadata"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/streaming"
@@ -190,6 +197,10 @@ func (kc *kClient) invokeStreamingEndpoint() (endpoint.Endpoint, error) {
 	}, nil
 }
 
+const (
+	recvTimeoutErrTpl = "stream Recv timeout, timeout config=%+v"
+)
+
 type stream struct {
 	streaming.ClientStream
 	grpcStream *grpcStream
@@ -198,11 +209,13 @@ type stream struct {
 	kc         *kClient
 	ri         rpcinfo.RPCInfo
 
-	recv cep.StreamRecvEndpoint
-	send cep.StreamSendEndpoint
+	recv      cep.StreamRecvEndpoint
+	recvTmCfg streaming.TimeoutConfig
+	send      cep.StreamSendEndpoint
 
 	streamingMode serviceinfo.StreamingMode
 	finished      uint32
+	isGRPC        bool
 }
 
 var (
@@ -214,6 +227,7 @@ var (
 func newStream(ctx context.Context, s streaming.ClientStream, scm *remotecli.StreamConnManager, kc *kClient, ri rpcinfo.RPCInfo, mode serviceinfo.StreamingMode,
 	sendEP cep.StreamSendEndpoint, recvEP cep.StreamRecvEndpoint, grpcSendEP endpoint.SendEndpoint, grpcRecvEP endpoint.RecvEndpoint,
 ) *stream {
+	recvTmCfg := ri.Config().StreamRecvTimeoutConfig()
 	st := &stream{
 		ClientStream:  s,
 		ctx:           ctx,
@@ -222,11 +236,13 @@ func newStream(ctx context.Context, s streaming.ClientStream, scm *remotecli.Str
 		ri:            ri,
 		streamingMode: mode,
 		recv:          recvEP,
+		recvTmCfg:     recvTmCfg,
 		send:          sendEP,
 	}
 	if grpcStreamGetter, ok := s.(streaming.GRPCStreamGetter); ok {
+		st.isGRPC = true
 		if grpcStream := grpcStreamGetter.GetGRPCStream(); grpcStream != nil {
-			st.grpcStream = newGRPCStream(grpcStream, grpcSendEP, grpcRecvEP)
+			st.grpcStream = newGRPCStream(grpcStream, grpcSendEP, grpcRecvEP, recvTmCfg)
 			st.grpcStream.st = st
 		}
 	}
@@ -257,7 +273,7 @@ func (s *stream) RecvMsg(ctx context.Context, m interface{}) (err error) {
 			ctx = rpcinfo.NewCtxWithRPCInfo(ctx, s.ri)
 		}
 	}
-	err = s.recv(ctx, s.ClientStream, m)
+	err = s.recvWithTimeout(ctx, m)
 	if err == nil {
 		// BizStatusErr is returned by the server handle, meaning the stream is ended;
 		// And it should be returned to the calling business code for error handling
@@ -274,6 +290,25 @@ func (s *stream) handleStreamRecvEvent(err error) {
 	s.kc.opt.TracerCtl.HandleStreamRecvEvent(s.ctx, s.ri, rpcinfo.StreamRecvEvent{
 		Err: err,
 	})
+}
+
+func (s *stream) recvWithTimeout(ctx context.Context, m interface{}) error {
+	if !s.isGRPC || s.recvTmCfg.Timeout <= 0 {
+		return s.recv(ctx, s.ClientStream, m)
+	}
+	return callWithTimeout(s.recvTmCfg,
+		func() error {
+			return s.recv(ctx, s.ClientStream, m)
+		},
+		s.cancel,
+	)
+}
+
+func (s *stream) cancel(err error) {
+	// for now, only gRPC ClientStream implements CancelableClientStream interface
+	if c, ok := s.ClientStream.(internal_stream.CancelableClientStream); ok {
+		c.CancelWithErr(err)
+	}
 }
 
 // SendMsg sends a message to the server.
@@ -324,11 +359,14 @@ func (s *stream) GetGRPCStream() streaming.Stream {
 	return s.grpcStream
 }
 
-func newGRPCStream(st streaming.Stream, sendEP endpoint.SendEndpoint, recvEP endpoint.RecvEndpoint) *grpcStream {
+func newGRPCStream(st streaming.Stream, sendEP endpoint.SendEndpoint, recvEP endpoint.RecvEndpoint,
+	recvTmCfg streaming.TimeoutConfig,
+) *grpcStream {
 	return &grpcStream{
 		Stream:       st,
 		sendEndpoint: sendEP,
 		recvEndpoint: recvEP,
+		recvTmCfg:    recvTmCfg,
 	}
 }
 
@@ -339,6 +377,7 @@ type grpcStream struct {
 
 	sendEndpoint endpoint.SendEndpoint
 	recvEndpoint endpoint.RecvEndpoint
+	recvTmCfg    streaming.TimeoutConfig
 }
 
 // Header returns the header metadata sent by the server if any.
@@ -351,7 +390,7 @@ func (s *grpcStream) Header() (md metadata.MD, err error) {
 }
 
 func (s *grpcStream) RecvMsg(m interface{}) (err error) {
-	err = s.recvEndpoint(s.Stream, m)
+	err = s.recvWithTimeout(m)
 	if err == nil {
 		// BizStatusErr is returned by the server handle, meaning the stream is ended;
 		// And it should be returned to the calling business code for error handling
@@ -362,6 +401,19 @@ func (s *grpcStream) RecvMsg(m interface{}) (err error) {
 		s.st.DoFinish(err)
 	}
 	return
+}
+
+func (s *grpcStream) recvWithTimeout(m interface{}) error {
+	if s.recvTmCfg.Timeout <= 0 {
+		return s.recvEndpoint(s.Stream, m)
+	}
+	return callWithTimeout(
+		s.recvTmCfg,
+		func() error {
+			return s.recvEndpoint(s.Stream, m)
+		},
+		s.st.cancel,
+	)
 }
 
 func (s *grpcStream) SendMsg(m interface{}) (err error) {
@@ -375,6 +427,34 @@ func (s *grpcStream) SendMsg(m interface{}) (err error) {
 
 func (s *grpcStream) DoFinish(err error) {
 	s.st.DoFinish(err)
+}
+
+func callWithTimeout(tmCfg streaming.TimeoutConfig, call func() error, cancel func(error)) error {
+	timer := time.NewTimer(tmCfg.Timeout)
+	defer timer.Stop()
+	finishChan := make(chan error, 1)
+	gopool.Go(func() {
+		var callErr error
+		defer func() {
+			if r := recover(); r != nil {
+				callErr = status.Errorf(codes.Internal, "stream Recv panic, panic=%v, stack=%s", r, debug.Stack())
+				cancel(callErr)
+			}
+			finishChan <- callErr
+		}()
+		callErr = call()
+	})
+	select {
+	case <-timer.C:
+		err := status.Errorf(codes.RecvDeadlineExceeded, recvTimeoutErrTpl, tmCfg)
+		if !tmCfg.DisableCancelRemote {
+			// finish the stream lifecycle so that the goroutine could exit
+			cancel(err)
+		}
+		return err
+	case callErr := <-finishChan:
+		return callErr
+	}
 }
 
 func isRPCError(err error) bool {

--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
+	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/pkg/transmeta"
 	"github.com/cloudwego/kitex/pkg/utils"
 	"github.com/cloudwego/kitex/pkg/warmup"
@@ -102,6 +103,7 @@ type StreamOption struct {
 type StreamOptions struct {
 	StreamEventHandlers          []rpcinfo.ClientStreamEventHandler
 	RecvTimeout                  time.Duration
+	RecvTimeoutConfig            streaming.TimeoutConfig
 	StreamMiddlewares            []cep.StreamMiddleware
 	StreamMiddlewareBuilders     []cep.StreamMiddlewareBuilder
 	StreamRecvMiddlewares        []cep.StreamRecvMiddleware

--- a/internal/stream/cancel.go
+++ b/internal/stream/cancel.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 CloudWeGo Authors
+ * Copyright 2026 CloudWeGo Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package kerrors
+package stream
 
-// ErrStreamingProtocol is the parent type of all streaming protocol(e.g. gRPC, TTHeader Streaming)
-// related but not user-aware errors.
-var ErrStreamingProtocol = &basicError{"streaming protocol error"}
-
-// ErrStreamingCanceled is the parent type of all streaming canceled errors
-var ErrStreamingCanceled = &basicError{"streaming canceled"}
-
-// ErrStreamingTimeout is the parent type of all streaming timeout errors
-var ErrStreamingTimeout = &basicError{"streaming timeout"}
+// CancelableClientStream is implemented by client-side Stream of gRPC in transport layer.
+// It terminates the local stream's lifecycle and cancels the remote peer.
+type CancelableClientStream interface {
+	CancelWithErr(err error)
+}

--- a/pkg/kerrors/kerrors_test.go
+++ b/pkg/kerrors/kerrors_test.go
@@ -50,6 +50,7 @@ func TestIsKitexError(t *testing.T) {
 		// streaming errors
 		ErrStreamingProtocol,
 		ErrStreamingCanceled,
+		ErrStreamingTimeout,
 	}
 	for _, e := range errs {
 		test.Assert(t, IsKitexError(e))

--- a/pkg/remote/trans/nphttp2/client_conn.go
+++ b/pkg/remote/trans/nphttp2/client_conn.go
@@ -174,6 +174,10 @@ func (c *clientConn) Header() (metadata.MD, error) { return c.s.Header() }
 func (c *clientConn) Trailer() metadata.MD         { return c.s.Trailer() }
 func (c *clientConn) GetRecvCompress() string      { return c.s.RecvCompress() }
 
+func (c *clientConn) cancel(err error) {
+	c.tr.CloseStream(c.s, err)
+}
+
 type hasGetRecvCompress interface {
 	GetRecvCompress() string
 }

--- a/pkg/remote/trans/nphttp2/codes/code_string.go
+++ b/pkg/remote/trans/nphttp2/codes/code_string.go
@@ -58,6 +58,8 @@ func (c Code) String() string {
 		return "DataLoss"
 	case Unauthenticated:
 		return "Unauthenticated"
+	case RecvDeadlineExceeded:
+		return "RecvDeadlineExceeded"
 	default:
 		return "Code(" + strconv.FormatInt(int64(c), 10) + ")"
 	}

--- a/pkg/remote/trans/nphttp2/codes/codes.go
+++ b/pkg/remote/trans/nphttp2/codes/codes.go
@@ -148,27 +148,32 @@ const (
 	// authentication credentials for the operation.
 	Unauthenticated Code = 16
 
-	_maxCode = 17
+	// RecvDeadlineExceeded indicates that the stream.Recv operation timed out.
+	// Kitex extension Code.
+	RecvDeadlineExceeded Code = 17
+
+	_maxCode = 18
 )
 
 var strToCode = map[string]Code{
 	`"OK"`: OK,
 	`"CANCELLED"`:/* [sic] */ Canceled,
-	`"UNKNOWN"`:             Unknown,
-	`"INVALID_ARGUMENT"`:    InvalidArgument,
-	`"DEADLINE_EXCEEDED"`:   DeadlineExceeded,
-	`"NOT_FOUND"`:           NotFound,
-	`"ALREADY_EXISTS"`:      AlreadyExists,
-	`"PERMISSION_DENIED"`:   PermissionDenied,
-	`"RESOURCE_EXHAUSTED"`:  ResourceExhausted,
-	`"FAILED_PRECONDITION"`: FailedPrecondition,
-	`"ABORTED"`:             Aborted,
-	`"OUT_OF_RANGE"`:        OutOfRange,
-	`"UNIMPLEMENTED"`:       Unimplemented,
-	`"INTERNAL"`:            Internal,
-	`"UNAVAILABLE"`:         Unavailable,
-	`"DATA_LOSS"`:           DataLoss,
-	`"UNAUTHENTICATED"`:     Unauthenticated,
+	`"UNKNOWN"`:                Unknown,
+	`"INVALID_ARGUMENT"`:       InvalidArgument,
+	`"DEADLINE_EXCEEDED"`:      DeadlineExceeded,
+	`"NOT_FOUND"`:              NotFound,
+	`"ALREADY_EXISTS"`:         AlreadyExists,
+	`"PERMISSION_DENIED"`:      PermissionDenied,
+	`"RESOURCE_EXHAUSTED"`:     ResourceExhausted,
+	`"FAILED_PRECONDITION"`:    FailedPrecondition,
+	`"ABORTED"`:                Aborted,
+	`"OUT_OF_RANGE"`:           OutOfRange,
+	`"UNIMPLEMENTED"`:          Unimplemented,
+	`"INTERNAL"`:               Internal,
+	`"UNAVAILABLE"`:            Unavailable,
+	`"DATA_LOSS"`:              DataLoss,
+	`"UNAUTHENTICATED"`:        Unauthenticated,
+	`"RECV_DEADLINE_EXCEEDED"`: RecvDeadlineExceeded,
 }
 
 // UnmarshalJSON unmarshals b into the Code.

--- a/pkg/remote/trans/nphttp2/codes/codes_test.go
+++ b/pkg/remote/trans/nphttp2/codes/codes_test.go
@@ -57,4 +57,6 @@ func TestCodeString(t *testing.T) {
 	test.Assert(t, c.String() == "OK")
 	c = _maxCode
 	test.Assert(t, c.String() == "Code("+strconv.FormatInt(int64(c), 10)+")")
+	c = RecvDeadlineExceeded
+	test.Assert(t, c.String() == "RecvDeadlineExceeded")
 }

--- a/pkg/remote/trans/nphttp2/stream.go
+++ b/pkg/remote/trans/nphttp2/stream.go
@@ -256,6 +256,10 @@ func (s *clientStream) Context() context.Context {
 	return s.ctx
 }
 
+func (s *clientStream) CancelWithErr(err error) {
+	s.conn.cancel(err)
+}
+
 func streamingHeaderToHTTP2MD(header streaming.Header) metadata.MD {
 	md := metadata.MD{}
 	for k, v := range header {

--- a/pkg/remote/trans/ttstream/client_handler.go
+++ b/pkg/remote/trans/ttstream/client_handler.go
@@ -83,7 +83,8 @@ func (c clientTransHandler) NewStream(ctx context.Context, ri rpcinfo.RPCInfo) (
 	// create new stream
 	cs := newClientStream(ctx, trans, streamFrame{sid: genStreamID(), method: method})
 	// stream should be configured before WriteStream or there would be a race condition for metaFrameHandler
-	cs.setRecvTimeout(rconfig.StreamRecvTimeout())
+
+	cs.setRecvTimeoutConfig(rconfig)
 	cs.setMetaFrameHandler(c.metaHandler)
 	cs.setTraceController(c.traceCtl)
 

--- a/pkg/remote/trans/ttstream/exception.go
+++ b/pkg/remote/trans/ttstream/exception.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/cloudwego/kitex/pkg/kerrors"
+	"github.com/cloudwego/kitex/pkg/streaming"
 )
 
 var (
@@ -41,6 +42,10 @@ var (
 	errBizHandlerReturnCancel = newException("canceled by business handler returning", kerrors.ErrStreamingCanceled, 12012)
 	errConnectionClosedCancel = newException("canceled by connection closed", kerrors.ErrStreamingCanceled, 12013)
 )
+
+func newStreamRecvTimeoutException(cfg streaming.TimeoutConfig) *Exception {
+	return newException(fmt.Sprintf("stream Recv timeout, timeout config=%+v", cfg), kerrors.ErrStreamingTimeout, 12014).withSide(clientSide)
+}
 
 const (
 	setSide = 1 << iota

--- a/pkg/remote/trans/ttstream/exception_test.go
+++ b/pkg/remote/trans/ttstream/exception_test.go
@@ -21,11 +21,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cloudwego/gopkg/protocol/thrift"
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/kerrors"
+	"github.com/cloudwego/kitex/pkg/streaming"
 )
 
 func TestErrors(t *testing.T) {
@@ -43,6 +45,9 @@ func TestErrors(t *testing.T) {
 	newExWithNilErr := errIllegalFrame.newBuilder().withCause(nil)
 	test.Assert(t, !newExWithNilErr.isCauseSet(), newExWithNilErr)
 	test.Assert(t, newExWithNilErr.cause == nil, newExWithNilErr)
+
+	recvTmErr := newStreamRecvTimeoutException(streaming.TimeoutConfig{Timeout: 1 * time.Second})
+	test.Assert(t, errors.Is(recvTmErr, kerrors.ErrStreamingTimeout), recvTmErr)
 }
 
 func TestCommonParentKerror(t *testing.T) {
@@ -68,6 +73,14 @@ func TestCommonParentKerror(t *testing.T) {
 	}
 	for _, err := range errs {
 		test.Assert(t, errors.Is(err, kerrors.ErrStreamingCanceled), err)
+	}
+
+	// timeout Exception
+	errs = []error{
+		newStreamRecvTimeoutException(streaming.TimeoutConfig{Timeout: 1 * time.Second}),
+	}
+	for _, err := range errs {
+		test.Assert(t, errors.Is(err, kerrors.ErrStreamingTimeout), err)
 	}
 }
 

--- a/pkg/rpcinfo/interface.go
+++ b/pkg/rpcinfo/interface.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
+	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/transport"
 )
 
@@ -75,6 +76,7 @@ type TimeoutProvider interface {
 
 type StreamConfig interface {
 	StreamRecvTimeout() time.Duration
+	StreamRecvTimeoutConfig() streaming.TimeoutConfig
 }
 
 // RPCConfig contains configuration for RPC.

--- a/pkg/rpcinfo/mocks_test.go
+++ b/pkg/rpcinfo/mocks_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
+	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/transport"
 )
 
@@ -92,6 +93,14 @@ func (m *MockRPCConfig) TransportProtocol() (r transport.Protocol) {
 
 func (m *MockRPCConfig) StreamRecvTimeout() time.Duration {
 	return time.Duration(0)
+}
+
+func (m *MockRPCConfig) StreamRecvTimeoutConfig() streaming.TimeoutConfig {
+	return streaming.TimeoutConfig{}
+}
+
+func (m *MockRPCConfig) StreamSendTimeoutConfig() streaming.TimeoutConfig {
+	return streaming.TimeoutConfig{}
 }
 
 type MockRPCStats struct{}

--- a/pkg/rpcinfo/mutable.go
+++ b/pkg/rpcinfo/mutable.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
+	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/transport"
 )
 
@@ -54,6 +55,7 @@ type MutableRPCConfig interface {
 	SetPayloadCodec(codec serviceinfo.PayloadCodec)
 
 	SetStreamRecvTimeout(timeout time.Duration)
+	SetStreamRecvTimeoutConfig(cfg streaming.TimeoutConfig)
 }
 
 // MutableRPCStats is used to change the information in the RPCStats.

--- a/pkg/rpcinfo/rpcconfig.go
+++ b/pkg/rpcinfo/rpcconfig.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cloudwego/kitex/pkg/kerrors"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/transport"
 )
 
@@ -68,7 +69,8 @@ type rpcConfig struct {
 	payloadCodec      serviceinfo.PayloadCodec
 
 	// stream config
-	streamRecvTimeout time.Duration
+	streamRecvTimeout       time.Duration
+	streamRecvTimeoutConfig streaming.TimeoutConfig
 }
 
 func init() {
@@ -202,6 +204,14 @@ func (r *rpcConfig) SetStreamRecvTimeout(timeout time.Duration) {
 
 func (r *rpcConfig) StreamRecvTimeout() time.Duration {
 	return r.streamRecvTimeout
+}
+
+func (r *rpcConfig) SetStreamRecvTimeoutConfig(cfg streaming.TimeoutConfig) {
+	r.streamRecvTimeoutConfig = cfg
+}
+
+func (r *rpcConfig) StreamRecvTimeoutConfig() streaming.TimeoutConfig {
+	return r.streamRecvTimeoutConfig
 }
 
 // Clone returns a copy of the current rpcConfig.

--- a/pkg/rpcinfo/rpcconfig_test.go
+++ b/pkg/rpcinfo/rpcconfig_test.go
@@ -18,9 +18,11 @@ package rpcinfo_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/streaming"
 	"github.com/cloudwego/kitex/transport"
 )
 
@@ -32,6 +34,7 @@ func TestRPCConfig(t *testing.T) {
 	test.Assert(t, c.ReadWriteTimeout() != 0)
 	test.Assert(t, c.IOBufferSize() != 0)
 	test.Assert(t, c.TransportProtocol() == transport.PurePayload)
+	test.Assert(t, c.StreamRecvTimeoutConfig() == streaming.TimeoutConfig{})
 }
 
 func TestSetTransportProtocol(t *testing.T) {
@@ -138,4 +141,19 @@ func TestSetTransportProtocol(t *testing.T) {
 		rpcinfo.AsMutableRPCConfig(c).SetTransportProtocol(transport.TTHeader)
 		test.Assert(t, (c.TransportProtocol()&transport.TTHeader == transport.TTHeader) && (c.TransportProtocol()&transport.GRPC == transport.GRPC), c.TransportProtocol())
 	})
+}
+
+func TestStreamConfig(t *testing.T) {
+	cfg := rpcinfo.NewRPCConfig()
+	c := rpcinfo.AsMutableRPCConfig(cfg)
+	test.Assert(t, cfg.StreamRecvTimeoutConfig().Timeout == 0, cfg)
+	test.Assert(t, !cfg.StreamRecvTimeoutConfig().DisableCancelRemote, cfg)
+
+	tmCfg := streaming.TimeoutConfig{
+		Timeout:             1 * time.Second,
+		DisableCancelRemote: true,
+	}
+	c.SetStreamRecvTimeoutConfig(tmCfg)
+	test.Assert(t, cfg.StreamRecvTimeoutConfig().Timeout == 1*time.Second, cfg)
+	test.Assert(t, cfg.StreamRecvTimeoutConfig().DisableCancelRemote, cfg)
 }

--- a/pkg/streaming/timeout.go
+++ b/pkg/streaming/timeout.go
@@ -27,6 +27,17 @@ import (
 	"github.com/cloudwego/kitex/pkg/kerrors"
 )
 
+type TimeoutConfig struct {
+	Timeout time.Duration
+	// DisableCancelRemote controls whether to cancel the remote peer when Recv/Send timeout.
+	// By default, it cancels the remote peer to prevent stream leakage.
+	//
+	// However, in certain scenarios (e.g., resume-enabled transfers: A → B → C), A may not wish to cancel B and C upon detecting a timeout.
+	// Instead, it expects B and C to complete one round of streaming communication and cache the results.
+	// This allows A to resume the request from the disconnected point on the next attempt, completing the resume-from-breakpoint process.
+	DisableCancelRemote bool
+}
+
 // CallWithTimeout executes a function with timeout.
 // If timeout is 0, the function will be executed without timeout; panic is not recovered in this case;
 // If time runs out, it will return a kerrors.ErrRPCTimeout;


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
- Kitex Streaming 将 client 侧的 Recv 超时逻辑内置，提供相应的 Recv 超时配置，降低用户的使用成本。
- 修改 gRPC 退出 handler 返回的错误，使得 context is canceled 唯一对应用户主动 cancel 的场景
- 修改 gRPC Server 侧连接断开的日志等级，调整为 info 辅助排查问题

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->