### PR TITLE
optimize: remove ttstream connection write goroutine to avoid Sender OOM

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,6 +6,7 @@ extend-exclude = ["go.mod", "go.sum"]
 [default.extend-words]
 typ = "typ"   # type
 Descritor = "Descritor" # reflect pkg typo, exported func, let it go
+consts = "consts" # conventional abbreviation for constants
 
 [default.extend-identifiers]
 GoAways = "GoAways" # GoAway frame plural noun

--- a/pkg/remote/trans/ttstream/frame.go
+++ b/pkg/remote/trans/ttstream/frame.go
@@ -299,3 +299,13 @@ func decodeException(buf []byte) (*gopkgthrift.ApplicationException, error) {
 	}
 	return ex, nil
 }
+
+func encodeFrameAndFlush(ctx context.Context, writer bufiox.Writer, fr *Frame) (err error) {
+	if err = EncodeFrame(ctx, writer, fr); err != nil {
+		return err
+	}
+	if err = writer.Flush(); err != nil {
+		return errTransport.newBuilder().withCause(err)
+	}
+	return nil
+}

--- a/pkg/remote/trans/ttstream/frame_test.go
+++ b/pkg/remote/trans/ttstream/frame_test.go
@@ -50,6 +50,21 @@ func TestFrameCodec(t *testing.T) {
 		test.DeepEqual(t, string(wframe.payload), string(rframe.payload))
 		test.DeepEqual(t, wframe.header, rframe.header)
 	}
+
+	for i := 0; i < 10; i++ {
+		wframe.sid = int32(i)
+		err = encodeFrameAndFlush(context.Background(), writer, wframe)
+		test.Assert(t, err == nil, err)
+	}
+	err = writer.Flush()
+	test.Assert(t, err == nil, err)
+
+	for i := 0; i < 10; i++ {
+		rframe, err := DecodeFrame(context.Background(), reader)
+		test.Assert(t, err == nil, err)
+		test.DeepEqual(t, string(wframe.payload), string(rframe.payload))
+		test.DeepEqual(t, wframe.header, rframe.header)
+	}
 }
 
 func TestFrameWithoutPayloadCodec(t *testing.T) {

--- a/pkg/remote/trans/ttstream/server_handler_test.go
+++ b/pkg/remote/trans/ttstream/server_handler_test.go
@@ -101,7 +101,9 @@ func (m *mockTracer) Start(ctx context.Context) context.Context {
 }
 
 func (m *mockTracer) Finish(ctx context.Context) {
-	m.finishFunc(ctx)
+	if m.finishFunc != nil {
+		m.finishFunc(ctx)
+	}
 }
 
 type mockHeaderFrameReadHandler struct {

--- a/pkg/remote/trans/ttstream/transport.go
+++ b/pkg/remote/trans/ttstream/transport.go
@@ -31,6 +31,9 @@ const (
 
 	streamCacheSize = 32
 	frameCacheSize  = 256
+
+	connStateOpen   = 0
+	connStateClosed = 1
 )
 
 func isIgnoreError(err error) bool {


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
性能测试(一个连接一个 stream)，与 v0.16.0 进行对比：
- Body 1K

Kind                   Concurrency  Data_Size  QPS                          AVG                P99                Server_CPU      Client_CPU
[ttstream-bidi]  100                 1024           230261.94(+6.0%)  0.43(-6.5%)  1.44(-8.3%)  394.61(+0.0%)  522.34(-1.3%)
-  Body 1M

Kind                   Concurrency  Data_Size  QPS                      AVG                 P99                  Server_CPU       Client_CPU
[ttstream-bidi]  100                 1048576    2408.15(+0.4%)  41.49(-0.4%)  96.69(-3.2%)  395.03(-0.2%)  496.67(-0.0%)

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->