### PR TITLE
fix(generic): panic when generic writing different elem types of container

### DIFF
--- a/pkg/generic/thrift/write.go
+++ b/pkg/generic/thrift/write.go
@@ -189,6 +189,14 @@ func typeJSONOf(data *gjson.Result, t *descriptor.TypeDescriptor, opt *writerOpt
 	return 0, nil, fmt.Errorf("data:%#v, expected type:%s, err:%#v", data, tt, err)
 }
 
+func getWriterAndWrite(ctx context.Context, elem interface{}, out *thrift.BufferWriter, t *descriptor.TypeDescriptor, opt *writerOption) error {
+	w, err := nextWriter(elem, t, opt)
+	if err != nil {
+		return err
+	}
+	return w(ctx, elem, out, t, opt)
+}
+
 func nextWriter(sample interface{}, t *descriptor.TypeDescriptor, opt *writerOption) (writer, error) {
 	tt, fn, err := typeOf(sample, t, opt)
 	if err != nil {
@@ -498,23 +506,14 @@ func writeList(ctx context.Context, val interface{}, out *thrift.BufferWriter, t
 	if length == 0 {
 		return nil
 	}
-	var (
-		writer writer
-		err    error
-	)
-	for _, elem := range l {
+	for i, elem := range l {
 		if elem == nil {
-			if err = writeEmptyValue(out, t.Elem, opt); err != nil {
+			if err := writeEmptyValue(out, t.Elem, opt); err != nil {
 				return err
 			}
 		} else {
-			if writer == nil {
-				if writer, err = nextWriter(elem, t.Elem, opt); err != nil {
-					return err
-				}
-			}
-			if err := writer(ctx, elem, out, t.Elem, opt); err != nil {
-				return err
+			if err := getWriterAndWrite(ctx, elem, out, t.Elem, opt); err != nil {
+				return fmt.Errorf("list element (%v) at index %d: %w", elem, i, err)
 			}
 		}
 	}
@@ -551,33 +550,17 @@ func writeInterfaceMap(ctx context.Context, val interface{}, out *thrift.BufferW
 	if length == 0 {
 		return nil
 	}
-	var (
-		keyWriter  writer
-		elemWriter writer
-		err        error
-	)
+
 	for key, elem := range m {
-		if keyWriter == nil {
-			if keyWriter, err = nextWriter(key, t.Key, opt); err != nil {
-				return err
-			}
-		}
-		if err := keyWriter(ctx, key, out, t.Key, opt); err != nil {
-			return err
+		if err := getWriterAndWrite(ctx, key, out, t.Key, opt); err != nil {
+			return fmt.Errorf("map key (%v): %w", key, err)
 		}
 		if elem == nil {
-			if err = writeEmptyValue(out, t.Elem, opt); err != nil {
+			if err := writeEmptyValue(out, t.Elem, opt); err != nil {
 				return err
 			}
-		} else {
-			if elemWriter == nil {
-				if elemWriter, err = nextWriter(elem, t.Elem, opt); err != nil {
-					return err
-				}
-			}
-			if err := elemWriter(ctx, elem, out, t.Elem, opt); err != nil {
-				return err
-			}
+		} else if err := getWriterAndWrite(ctx, elem, out, t.Elem, opt); err != nil {
+			return fmt.Errorf("map value (%v) for key (%v): %w", elem, key, err)
 		}
 	}
 	return nil
@@ -593,36 +576,20 @@ func writeStringMap(ctx context.Context, val interface{}, out *thrift.BufferWrit
 		return nil
 	}
 
-	var (
-		keyWriter  writer
-		elemWriter writer
-	)
 	for key, elem := range m {
 		_key, err := buildinTypeFromString(key, t.Key)
 		if err != nil {
 			return err
 		}
-		if keyWriter == nil {
-			if keyWriter, err = nextWriter(_key, t.Key, opt); err != nil {
-				return err
-			}
-		}
-		if err := keyWriter(ctx, _key, out, t.Key, opt); err != nil {
-			return err
+		if err = getWriterAndWrite(ctx, _key, out, t.Key, opt); err != nil {
+			return fmt.Errorf("map key (%v): %w", key, err)
 		}
 		if elem == nil {
 			if err = writeEmptyValue(out, t.Elem, opt); err != nil {
 				return err
 			}
-		} else {
-			if elemWriter == nil {
-				if elemWriter, err = nextWriter(elem, t.Elem, opt); err != nil {
-					return err
-				}
-			}
-			if err := elemWriter(ctx, elem, out, t.Elem, opt); err != nil {
-				return err
-			}
+		} else if err = getWriterAndWrite(ctx, elem, out, t.Elem, opt); err != nil {
+			return fmt.Errorf("map value (%v) for key (%v): %w", elem, key, err)
 		}
 	}
 	return nil

--- a/pkg/generic/thrift/write_test.go
+++ b/pkg/generic/thrift/write_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/gopkg/bufiox"
@@ -974,9 +975,10 @@ func Test_writeList(t *testing.T) {
 		opt *writerOption
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name           string
+		args           args
+		wantErr        bool
+		errMsgContains string
 	}{
 		// TODO: Add test cases.
 		{
@@ -991,6 +993,7 @@ func Test_writeList(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeListWithNil",
@@ -1004,6 +1007,7 @@ func Test_writeList(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeListWithNilOnly",
@@ -1017,6 +1021,7 @@ func Test_writeList(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeListWithNextWriterError",
@@ -1030,12 +1035,53 @@ func Test_writeList(t *testing.T) {
 				},
 			},
 			true,
+			"at index 0",
+		},
+		{
+			"int8 then string",
+			args{
+				val: []interface{}{int8(1), "hello"},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.LIST,
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.I08},
+				},
+			},
+			true,
+			"at index 1",
+		},
+		{
+			"string then int32",
+			args{
+				val: []interface{}{"hello", int32(100)},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.LIST,
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING},
+				},
+			},
+			true,
+			"at index 1",
+		},
+		{
+			"nil then non-nil",
+			args{
+				val: []interface{}{nil, int32(100)},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.LIST,
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING},
+				},
+			},
+			true,
+			"at index 1",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := writeList(context.Background(), tt.args.val, getBufferWriter(nil), tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
-				t.Errorf("writeList() error = %v, wantErr %v", err, tt.wantErr)
+			err := writeList(context.Background(), tt.args.val, getBufferWriter(nil), tt.args.t, tt.args.opt)
+			if tt.wantErr {
+				test.Assert(t, err != nil)
+				test.Assert(t, strings.Contains(err.Error(), tt.errMsgContains), err)
+			} else {
+				test.Assert(t, err == nil, err)
 			}
 		})
 	}
@@ -1049,9 +1095,10 @@ func Test_writeInterfaceMap(t *testing.T) {
 		opt *writerOption
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name           string
+		args           args
+		wantErr        bool
+		errMsgContains string
 	}{
 		// TODO: Add test cases.
 		{
@@ -1067,6 +1114,7 @@ func Test_writeInterfaceMap(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeInterfaceMapWithNil",
@@ -1081,6 +1129,7 @@ func Test_writeInterfaceMap(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeInterfaceMapWithNilOnly",
@@ -1095,6 +1144,7 @@ func Test_writeInterfaceMap(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeInterfaceMapWithElemNextWriterError",
@@ -1109,6 +1159,7 @@ func Test_writeInterfaceMap(t *testing.T) {
 				},
 			},
 			true,
+			"",
 		},
 		{
 			"writeInterfaceMapWithKeyWriterError",
@@ -1123,13 +1174,69 @@ func Test_writeInterfaceMap(t *testing.T) {
 				},
 			},
 			true,
+			"map key",
+		},
+		{
+			"different key types only",
+			args{
+				val: map[interface{}]interface{}{int8(1): "value1", "key2": "value2"},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.I08},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING},
+				},
+			},
+			true,
+			"map key",
+		},
+		{
+			"different val types only",
+			args{
+				val: map[interface{}]interface{}{"key1": int8(1), "key2": "hello"},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.I08},
+				},
+			},
+			true,
+			"map value",
+		},
+		{
+			"different key types and val types",
+			args{
+				val: map[interface{}]interface{}{int8(1): int8(10), "key2": "hello"},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.I08},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.I08},
+				},
+			},
+			true,
+			"map key",
+		},
+		{
+			"nil and non-nil val types",
+			args{
+				val: map[interface{}]interface{}{"key1": nil, "key2": "hello"},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.I08},
+				},
+			},
+			true,
+			"map value",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := writeInterfaceMap(context.Background(), tt.args.val, getBufferWriter(nil), tt.args.t,
-				tt.args.opt); (err != nil) != tt.wantErr {
-				t.Errorf("writeInterfaceMap() error = %v, wantErr %v", err, tt.wantErr)
+			err := writeInterfaceMap(context.Background(), tt.args.val, getBufferWriter(nil), tt.args.t, tt.args.opt)
+			if tt.wantErr {
+				test.Assert(t, err != nil)
+				test.Assert(t, strings.Contains(err.Error(), tt.errMsgContains), err)
+			} else {
+				test.Assert(t, err == nil, err)
 			}
 		})
 	}
@@ -1143,9 +1250,10 @@ func Test_writeStringMap(t *testing.T) {
 		opt *writerOption
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name           string
+		args           args
+		wantErr        bool
+		errMsgContains string
 	}{
 		// TODO: Add test cases.
 		{
@@ -1161,6 +1269,7 @@ func Test_writeStringMap(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeStringMapWithNil",
@@ -1175,6 +1284,7 @@ func Test_writeStringMap(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeStringMapWithNilOnly",
@@ -1189,6 +1299,7 @@ func Test_writeStringMap(t *testing.T) {
 				},
 			},
 			false,
+			"",
 		},
 		{
 			"writeStringMapWithElemNextWriterError",
@@ -1203,12 +1314,56 @@ func Test_writeStringMap(t *testing.T) {
 				},
 			},
 			true,
+			"map value",
+		},
+		{
+			"val int8 then string",
+			args{
+				val: map[string]interface{}{"key1": int8(1), "key2": "hello"},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.I08},
+				},
+			},
+			true,
+			"map value",
+		},
+		{
+			"val string then int32",
+			args{
+				val: map[string]interface{}{"key1": "hello", "key2": int32(100)},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING},
+				},
+			},
+			true,
+			"map value",
+		},
+		{
+			"val nil then non-nil",
+			args{
+				val: map[string]interface{}{"key1": nil, "key2": int32(100)},
+				t: &descriptor.TypeDescriptor{
+					Type: descriptor.MAP,
+					Key:  &descriptor.TypeDescriptor{Type: descriptor.STRING},
+					Elem: &descriptor.TypeDescriptor{Type: descriptor.STRING},
+				},
+			},
+			true,
+			"map value",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := writeStringMap(context.Background(), tt.args.val, getBufferWriter(nil), tt.args.t, tt.args.opt); (err != nil) != tt.wantErr {
-				t.Errorf("writeStringMap() error = %v, wantErr %v", err, tt.wantErr)
+			err := writeStringMap(context.Background(), tt.args.val, getBufferWriter(nil), tt.args.t, tt.args.opt)
+			if tt.wantErr {
+				test.Assert(t, err != nil)
+				test.Assert(t, strings.Contains(err.Error(), tt.errMsgContains), err)
+			} else {
+				test.Assert(t, err == nil, err)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
容器类型（List、Map）的泛化 write 可能 panic。

以 writeStringMap 为例：
data := map[string]interface{}{
    "key1": int8(1),    // 第一个元素：int8 类型
    "key2": "hello",    // 第二个元素：string 类型
}

write 流程：
1. 处理第一个元素 int8(1) 时，获取 writeInt8 writer 并缓存
2. 处理第二个元素 "hello" 时，直接复用缓存的 writeInt8 writer
3. 尝试将 string 强转为 int8 → panic

类似地，writeInterfaceMap 和 writeList 均存在这个问题。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->