### PR TITLE
fix(streaming): server-side old Stream wrapped in server MW should not be discarded

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -331,8 +331,18 @@ func (s *server) unaryOrStreamEndpoint(ctx context.Context) endpoint.Endpoint {
 	streamEp := sep.StreamChain(s.opt.StreamOptions.StreamMiddlewares...)(s.streamHandleEndpoint())
 
 	return func(ctx context.Context, req, resp interface{}) (err error) {
-		if st, ok := req.(*streaming.Args); ok {
-			return streamEp(ctx, st.ServerStream)
+		if args, ok := req.(*streaming.Args); ok {
+			// keep the Stream for being compatible with old streaming interface
+			//
+			// when args.Stream is nil(set by users), we should not retrieve Stream from ServerStream for fallback:
+			//
+			// if getter, ok := args.ServerStream.(streaming.GRPCStreamGetter); ok {
+			//     st = getter.GetGRPCStream()
+			// }
+			return streamEp(ctx, gRPCCompatibleServerStream{
+				ServerStream: args.ServerStream,
+				st:           args.Stream,
+			})
 		} else {
 			return unaryEp(ctx, req, resp)
 		}

--- a/server/stream.go
+++ b/server/stream.go
@@ -152,3 +152,23 @@ type contextStream struct {
 func (cs contextStream) Context() context.Context {
 	return cs.ctx
 }
+
+var (
+	_ streaming.ServerStream     = (*gRPCCompatibleServerStream)(nil)
+	_ streaming.GRPCStreamGetter = (*gRPCCompatibleServerStream)(nil)
+)
+
+// gRPCCompatibleServerStream is responsible for being compatible with old streaming interface.
+// For users with old Streaming Interface, they may retrieve streaming.Stream from streaming.Args in Server MW
+// and wrap it to make extensions, then set back to streaming.Args.
+//
+// We need to preserve this wrapped Stream instead of discarding it.
+// This ensures middleware extensions on st.Stream are not lost when passing to streamHandleEndpoint.
+type gRPCCompatibleServerStream struct {
+	streaming.ServerStream
+	st streaming.Stream // store the gRPC Stream processed by Users' Server MW possibly
+}
+
+func (gs gRPCCompatibleServerStream) GetGRPCStream() streaming.Stream {
+	return gs.st
+}

--- a/server/stream_test.go
+++ b/server/stream_test.go
@@ -22,8 +22,11 @@ import (
 
 	internal_server "github.com/cloudwego/kitex/internal/server"
 	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/endpoint"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
+	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/stats"
+	"github.com/cloudwego/kitex/pkg/streaming"
 )
 
 type mockTracer struct {
@@ -44,4 +47,155 @@ func Test_server_initStreamMiddlewares(t *testing.T) {
 
 	test.Assert(t, len(s.opt.Streaming.RecvMiddlewares) == 0, "init middlewares failed")
 	test.Assert(t, len(s.opt.Streaming.SendMiddlewares) == 0, "init middlewares failed")
+}
+
+func Test_gRPCCompatibleServerStream(t *testing.T) {
+	t.Run("GetGRPCStream returns wrapped Stream", func(t *testing.T) {
+		mockSt := &mockStream{}
+		mockGs := &mockGRPCStream{}
+		wrapper := gRPCCompatibleServerStream{
+			ServerStream: mockSt,
+			st:           mockGs,
+		}
+
+		res := wrapper.GetGRPCStream()
+		test.Assert(t, res == mockGs, res)
+	})
+	t.Run("GetGRPCStream returns nil when st is nil", func(t *testing.T) {
+		mockSS := &mockStream{}
+		wrapper := gRPCCompatibleServerStream{
+			ServerStream: mockSS,
+			st:           nil,
+		}
+
+		result := wrapper.GetGRPCStream()
+		test.Assert(t, result == nil, result)
+	})
+}
+
+func Test_gRPCCompatibleServerStream_with_middleware(t *testing.T) {
+	t.Run("middleware wrapped Stream", func(t *testing.T) {
+		testService := "test_service"
+		testMethod := "test_method"
+
+		hdl := func(ctx context.Context, handler, req, result interface{}) error {
+			args, ok := req.(*streaming.Args)
+			test.Assert(t, ok, req)
+			test.Assert(t, args.Stream != nil, args)
+
+			cs, ok := args.Stream.(contextStream)
+			test.Assert(t, ok, args.Stream)
+			_, ok = cs.Stream.(*wrappedStreamByMiddleware)
+			test.Assert(t, ok, cs.Stream)
+
+			return nil
+		}
+
+		methods := map[string]serviceinfo.MethodInfo{
+			testMethod: serviceinfo.NewMethodInfo(
+				hdl,
+				nil,
+				nil,
+				false,
+				serviceinfo.WithStreamingMode(serviceinfo.StreamingBidirectional),
+			),
+		}
+
+		svcInfo := &serviceinfo.ServiceInfo{
+			ServiceName: testService,
+			Methods:     methods,
+		}
+
+		mws := []endpoint.Middleware{
+			func(next endpoint.Endpoint) endpoint.Endpoint {
+				return func(ctx context.Context, req, resp interface{}) (err error) {
+					if args, ok := req.(*streaming.Args); ok {
+						// user middleware wrapping the old gRPC Stream interface
+						if args.Stream != nil {
+							args.Stream = &wrappedStreamByMiddleware{
+								Stream: args.Stream,
+							}
+						}
+					}
+					return next(ctx, req, resp)
+				}
+			},
+		}
+
+		svr := newStreamingServer(svcInfo, mws)
+		svr.buildInvokeChain(context.Background())
+
+		ri := svr.initOrResetRPCInfoFunc()(nil, nil)
+		ink, ok := ri.Invocation().(rpcinfo.InvocationSetter)
+		test.Assert(t, ok)
+		ink.SetServiceName(testService)
+		ink.SetMethodName(testMethod)
+		ink.SetMethodInfo(svcInfo.MethodInfo(context.Background(), testMethod))
+
+		ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+		mock := &mockStream{}
+		err := svr.eps(ctx, &streaming.Args{ServerStream: mock, Stream: mock.GetGRPCStream()}, nil)
+
+		test.Assert(t, err == nil, err)
+	})
+	t.Run("middleware set Stream to nil", func(t *testing.T) {
+		testService := "test_service"
+		testMethod := "test_method"
+
+		streamHdlr := func(ctx context.Context, handler, req, result interface{}) error {
+			args, ok := req.(*streaming.Args)
+			test.Assert(t, ok, req)
+			test.Assert(t, args.ServerStream != nil, args)
+			test.Assert(t, args.Stream == nil, args)
+			return nil
+		}
+
+		methods := map[string]serviceinfo.MethodInfo{
+			testMethod: serviceinfo.NewMethodInfo(
+				streamHdlr,
+				nil,
+				nil,
+				false,
+				serviceinfo.WithStreamingMode(serviceinfo.StreamingBidirectional),
+			),
+		}
+
+		svcInfo := &serviceinfo.ServiceInfo{
+			ServiceName: testService,
+			Methods:     methods,
+		}
+
+		mws := []endpoint.Middleware{
+			func(next endpoint.Endpoint) endpoint.Endpoint {
+				return func(ctx context.Context, req, resp interface{}) (err error) {
+					args, ok := req.(*streaming.Args)
+					test.Assert(t, ok, req)
+					test.Assert(t, args.ServerStream != nil)
+					test.Assert(t, args.Stream != nil)
+					args.Stream = nil
+					return next(ctx, req, resp)
+				}
+			},
+		}
+
+		svr := newStreamingServer(svcInfo, mws)
+		svr.buildInvokeChain(context.Background())
+
+		ri := svr.initOrResetRPCInfoFunc()(nil, nil)
+		ink, ok := ri.Invocation().(rpcinfo.InvocationSetter)
+		test.Assert(t, ok)
+		ink.SetServiceName(testService)
+		ink.SetMethodName(testMethod)
+		ink.SetMethodInfo(svcInfo.MethodInfo(context.Background(), testMethod))
+
+		ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+		mock := &mockStream{}
+		err := svr.eps(ctx, &streaming.Args{ServerStream: mock, Stream: mock.GetGRPCStream()}, nil)
+		test.Assert(t, err == nil, err)
+	})
+}
+
+// wrappedStreamByMiddleware simulates a user-wrapped stream in middleware
+type wrappedStreamByMiddleware struct {
+	streaming.Stream
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
在 Server 侧，使用老流式接口的用户可能会在 Server MW 中使用 wrap 的方式进行扩展，需要将其透传给 streamHandleEndpoint 以保证用户升级 Kitex 后，扩展依然生效。
- `gRPCCompatibleServerStream`实现`streaming.GRPCStreamGetter`接口
<img width="1128" height="350" alt="image" src="https://github.com/user-attachments/assets/5abb8084-69be-4f15-89fb-cc41589e420d" />

- `streamHandleEndpoint` 获取被用户 wrap 过的 Stream
<img width="1230" height="528" alt="image" src="https://github.com/user-attachments/assets/2ff259bc-053d-444d-9281-06e534b118e2" />


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->