### PR TITLE
chore(mux): deprecate thrift mux transport

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -214,6 +214,7 @@ func WithLongConnection(cfg connpool.IdleConfig) Option {
 }
 
 // WithMuxConnection specifies the transport type to be mux.
+// Deprecated: Mux Connection is no longer being maintained.
 func WithMuxConnection(connNum int) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push("WithMuxConnection")

--- a/pkg/remote/trans/netpollmux/doc.go
+++ b/pkg/remote/trans/netpollmux/doc.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package netpollmux
+
+// Package netpollmux provides mux transport implementation.
+//
+// Deprecated: netpollmux is no longer being maintained.
+// Performance gains are not significant in real scenarios.
+// And the server must be started first, it is easy to misuse.

--- a/server/option.go
+++ b/server/option.go
@@ -81,6 +81,7 @@ func WithSuite(suite Suite) Option {
 }
 
 // WithMuxTransport specifies the transport type to be mux.
+// Deprecated: Mux Transport is no longer being maintained.
 func WithMuxTransport() Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push("WithMuxTransport()")


### PR DESCRIPTION
#### What type of PR is this?
chore
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->