### PR TITLE
chore(codec): log data type before errDecodeMismatchMsgType

### DIFF
--- a/pkg/remote/codec/thrift/codec_frugal_test.go
+++ b/pkg/remote/codec/thrift/codec_frugal_test.go
@@ -223,7 +223,7 @@ func TestThriftCodec_unmarshalThriftDataFrugal(t *testing.T) {
 		codec := &thriftCodec{FrugalRead | EnableSkipDecoder}
 		trans := bufiox.NewBytesReader(mockReqThrift)
 		// specify dataLen with 0 so that skipDecoder works
-		err := codec.unmarshalThriftData(trans, req, 0)
+		err := codec.unmarshalThriftData(context.Background(), trans, req, 0)
 		checkDecodeResult(t, err, &mocks.MockReq{
 			Msg:     req.Msg,
 			StrList: req.StrList,
@@ -246,7 +246,7 @@ func TestThriftCodec_unmarshalThriftDataFrugal(t *testing.T) {
 		}
 		trans := bufiox.NewBytesReader(faultMockReqThrift)
 		// specify dataLen with 0 so that skipDecoder works
-		err := codec.unmarshalThriftData(trans, req, 0)
+		err := codec.unmarshalThriftData(context.Background(), trans, req, 0)
 		test.Assert(t, err != nil, err)
 		test.Assert(t, strings.Contains(err.Error(), "caught in Frugal using SkipDecoder Buffer"))
 	})

--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -215,7 +215,7 @@ func (c thriftCodec) Unmarshal(ctx context.Context, message remote.Message, in r
 			err = remote.NewTransError(remote.ProtocolError, err)
 		}
 	} else {
-		err = c.unmarshalThriftData(in, data, dataLen)
+		err = c.unmarshalThriftData(ctx, in, data, dataLen)
 	}
 	rpcinfo.Record(ctx, ri, stats.WaitReadFinish, err)
 	if err != nil {

--- a/pkg/remote/codec/thrift/thrift_data.go
+++ b/pkg/remote/codec/thrift/thrift_data.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloudwego/gopkg/bufiox"
 	"github.com/cloudwego/gopkg/protocol/thrift"
 
+	"github.com/cloudwego/kitex/pkg/klog"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/remote/codec/perrors"
 )
@@ -97,12 +98,12 @@ func UnmarshalThriftData(ctx context.Context, codec remote.PayloadCodec, method 
 	}
 	trans := bufiox.NewBytesReader(buf)
 	defer trans.Release(nil)
-	return c.unmarshalThriftData(trans, data, len(buf))
+	return c.unmarshalThriftData(ctx, trans, data, len(buf))
 }
 
 // unmarshalThriftData only decodes the data (after methodName, msgType and seqId)
 // method is only used for generic calls
-func (c thriftCodec) unmarshalThriftData(trans bufiox.Reader, data interface{}, dataLen int) error {
+func (c thriftCodec) unmarshalThriftData(ctx context.Context, trans bufiox.Reader, data interface{}, dataLen int) error {
 	dataLenOK := c.IsDataLenDeterministic(dataLen)
 	typecodec := getTypeCodec(data)
 	if dataLenOK && c.IsSet(FrugalRead) && typecodec.Frugal {
@@ -121,5 +122,6 @@ func (c thriftCodec) unmarshalThriftData(trans bufiox.Reader, data interface{}, 
 	if typecodec.Frugal {
 		return frugalUnmarshal(trans, data, dataLen)
 	}
+	klog.CtxErrorf(ctx, "KITEX: decode failed, msg type not match with thriftCodec, data type: %T", data)
 	return errDecodeMismatchMsgType
 }

--- a/pkg/remote/codec/thrift/thrift_data_test.go
+++ b/pkg/remote/codec/thrift/thrift_data_test.go
@@ -89,7 +89,7 @@ func TestThriftCodec_unmarshalThriftData(t *testing.T) {
 		codec := &thriftCodec{FastRead | EnableSkipDecoder}
 		trans := bufiox.NewBytesReader(mockReqThrift)
 		// specify dataLen with 0 so that skipDecoder works
-		err := codec.unmarshalThriftData(trans, req, 0)
+		err := codec.unmarshalThriftData(context.Background(), trans, req, 0)
 		checkDecodeResult(t, err, &mocks.MockReq{
 			Msg:     req.Msg,
 			StrList: req.StrList,
@@ -112,7 +112,7 @@ func TestThriftCodec_unmarshalThriftData(t *testing.T) {
 		}
 		trans := bufiox.NewBytesReader(faultMockReqThrift)
 		// specify dataLen with 0 so that skipDecoder works
-		err := codec.unmarshalThriftData(trans, req, 0)
+		err := codec.unmarshalThriftData(context.Background(), trans, req, 0)
 		test.Assert(t, err != nil, err)
 		test.Assert(t, strings.Contains(err.Error(), "caught in FastCodec using SkipDecoder Buffer"))
 	})


### PR DESCRIPTION
Add a warning log to print the actual data type when no decode path matches in unmarshalThriftData, aiding debugging of codec mismatches.

#### What type of PR is this?
chore
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->