### PR TITLE
fix(codec): frugalAvailable for void func result structs

### DIFF
--- a/pkg/remote/codec/thrift/codec_frugal.go
+++ b/pkg/remote/codec/thrift/codec_frugal.go
@@ -31,7 +31,16 @@ import (
 
 func frugalAvailable(data interface{}) bool {
 	rt := reflect.TypeOf(data).Elem()
-	return rt.NumField() <= 0 || rt.Field(0).Tag.Get("frugal") != ""
+	n := rt.NumField()
+	if n <= 0 {
+		return true
+	}
+	f0 := rt.Field(0)
+	if f0.Tag.Get("frugal") != "" {
+		return true
+	}
+	// for void func, the result struct may only have one _unknownFields field
+	return n == 1 && f0.Name == "_unknownFields"
 }
 
 func frugalMarshal(out bufiox.Writer, methodName string, msgType remote.MessageType,

--- a/pkg/remote/codec/thrift/codec_frugal_test.go
+++ b/pkg/remote/codec/thrift/codec_frugal_test.go
@@ -33,6 +33,40 @@ import (
 	"github.com/cloudwego/kitex/transport"
 )
 
+func TestFrugalAvailable(t *testing.T) {
+	type withFrugalTag struct {
+		Msg string `frugal:"1,default,string"`
+	}
+	type noTag struct {
+		Msg string
+	}
+	type empty struct{}
+	type onlyUnknownFields struct {
+		_unknownFields []byte //nolint:unused // accessed via reflection by frugal
+	}
+	type unknownFieldsWithTag struct {
+		_unknownFields []byte //nolint:unused // accessed via reflection by frugal
+		Msg            string `frugal:"1,default,string"`
+	}
+
+	tests := []struct {
+		name string
+		data any
+		want bool
+	}{
+		{"with frugal tag", &withFrugalTag{}, true},
+		{"no tag", &noTag{}, false},
+		{"empty struct", &empty{}, true},
+		{"only _unknownFields", &onlyUnknownFields{}, true},
+		{"_unknownFields with tagged field", &unknownFieldsWithTag{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test.Assert(t, frugalAvailable(tt.data) == tt.want)
+		})
+	}
+}
+
 type MockFrugalTagReq struct {
 	Msg     string            `frugal:"1,default,string"`
 	StrMap  map[string]string `frugal:"2,default,map<string:string>"`


### PR DESCRIPTION
frugalAvailable now returns true when the struct only has _unknownFields, which happens for void func result structs with KeepUnknownFields enabled. Frugal can handle this case since it's effectively an empty struct.

#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->