### PR TITLE
optimize(discovery): reduce object allocation in discovery event queue and support changing default capacity of queue

### DIFF
--- a/client/middlewares.go
+++ b/client/middlewares.go
@@ -58,6 +58,33 @@ func newProxyMW(prx proxy.ForwardProxy) endpoint.Middleware {
 	}
 }
 
+// instSnapshot captures the essential instance data as value types during Push,
+// avoiding holding references to discovery.Instance (which may carry large tags maps).
+type instSnapshot struct {
+	network string
+	address string
+	weight  int
+}
+
+type discoveryEventExtra struct {
+	cacheable bool
+	cacheKey  string
+	added     []instSnapshot
+	updated   []instSnapshot
+	removed   []instSnapshot
+}
+
+// KitexDumpLazyExtra implements lazyExtra interface in pkg/event
+func (e *discoveryEventExtra) KitexDumpLazyExtra() interface{} {
+	return map[string]interface{}{
+		"Cacheable": e.cacheable,
+		"CacheKey":  e.cacheKey,
+		"Added":     formatSnapshots(e.added),
+		"Updated":   formatSnapshots(e.updated),
+		"Removed":   formatSnapshots(e.removed),
+	}
+}
+
 func discoveryEventHandler(name string, bus event.Bus, queue event.Queue) func(d *discovery.Change) {
 	return func(d *discovery.Change) {
 		now := time.Now()
@@ -69,12 +96,12 @@ func discoveryEventHandler(name string, bus event.Bus, queue event.Queue) func(d
 		queue.Push(&event.Event{
 			Name: name,
 			Time: now,
-			Extra: map[string]interface{}{
-				"Cacheable": d.Result.Cacheable,
-				"CacheKey":  d.Result.CacheKey,
-				"Added":     wrapInstances(d.Added),
-				"Updated":   wrapInstances(d.Updated),
-				"Removed":   wrapInstances(d.Removed),
+			Extra: &discoveryEventExtra{
+				cacheable: d.Result.Cacheable,
+				cacheKey:  d.Result.CacheKey,
+				added:     snapshotInstances(d.Added),
+				updated:   snapshotInstances(d.Updated),
+				removed:   snapshotInstances(d.Removed),
 			},
 		})
 	}
@@ -209,17 +236,37 @@ type instInfo struct {
 	Weight  int
 }
 
-func wrapInstances(insts []discovery.Instance) []*instInfo {
+// snapshotInstances captures instance data as value types in a single slice allocation.
+// This avoids holding discovery.Instance references (and their potentially large tags maps).
+func snapshotInstances(insts []discovery.Instance) []instSnapshot {
 	if len(insts) == 0 {
 		return nil
 	}
-	instInfos := make([]*instInfo, 0, len(insts))
-	for i := range insts {
-		inst := insts[i]
-		addr := fmt.Sprintf("%s://%s", inst.Address().Network(), inst.Address().String())
-		instInfos = append(instInfos, &instInfo{Address: addr, Weight: inst.Weight()})
+	snapshots := make([]instSnapshot, len(insts))
+	for i, inst := range insts {
+		addr := inst.Address()
+		snapshots[i] = instSnapshot{
+			network: addr.Network(),
+			address: addr.String(),
+			weight:  inst.Weight(),
+		}
 	}
-	return instInfos
+	return snapshots
+}
+
+// formatSnapshots converts snapshots to []*instInfo during Dump (cold path).
+func formatSnapshots(snapshots []instSnapshot) []*instInfo {
+	if len(snapshots) == 0 {
+		return nil
+	}
+	infos := make([]*instInfo, len(snapshots))
+	for i := range snapshots {
+		infos[i] = &instInfo{
+			Address: snapshots[i].network + "://" + snapshots[i].address,
+			Weight:  snapshots[i].weight,
+		}
+	}
+	return infos
 }
 
 func retryable(err error) bool {

--- a/client/middlewares_test.go
+++ b/client/middlewares_test.go
@@ -19,8 +19,10 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 
@@ -278,24 +280,243 @@ func BenchmarkResolverMWParallel(b *testing.B) {
 }
 
 func TestDiscoveryEventHandler(t *testing.T) {
-	bus, queue := event.NewEventBus(), event.NewQueue(200)
-	h := discoveryEventHandler(discovery.ChangeEventName, bus, queue)
-	ins := []discovery.Instance{discovery.NewInstance("tcp", "addr", 10, nil)}
-	cacheKey := "testCacheKey"
-	c := &discovery.Change{
+	t.Run("Added", func(t *testing.T) {
+		bus, queue := event.NewEventBus(), event.NewQueue(200)
+		h := discoveryEventHandler(discovery.ChangeEventName, bus, queue)
+		ins := []discovery.Instance{discovery.NewInstance("tcp", "addr", 10, nil)}
+		cacheKey := "testCacheKey"
+		c := &discovery.Change{
+			Result: discovery.Result{
+				Cacheable: true,
+				CacheKey:  cacheKey,
+			},
+			Added: ins,
+		}
+		h(c)
+		events := queue.Dump().([]*event.Event)
+		test.Assert(t, len(events) == 1)
+		extra, ok := events[0].Extra.(map[string]interface{})
+		test.Assert(t, ok)
+		test.Assert(t, extra["Cacheable"] == true)
+		test.Assert(t, extra["CacheKey"] == cacheKey)
+		added := extra["Added"].([]*instInfo)
+		test.Assert(t, len(added) == 1)
+		test.Assert(t, added[0].Address == "tcp://addr")
+		test.Assert(t, added[0].Weight == 10)
+		test.Assert(t, len(extra["Updated"].([]*instInfo)) == 0)
+		test.Assert(t, len(extra["Removed"].([]*instInfo)) == 0)
+	})
+
+	t.Run("Updated", func(t *testing.T) {
+		bus, queue := event.NewEventBus(), event.NewQueue(200)
+		h := discoveryEventHandler(discovery.ChangeEventName, bus, queue)
+		c := &discovery.Change{
+			Result:  discovery.Result{Cacheable: true, CacheKey: "key"},
+			Updated: []discovery.Instance{discovery.NewInstance("tcp", "10.0.0.1:8080", 20, nil)},
+		}
+		h(c)
+		extra := queue.Dump().([]*event.Event)[0].Extra.(map[string]interface{})
+		test.Assert(t, len(extra["Added"].([]*instInfo)) == 0)
+		updated := extra["Updated"].([]*instInfo)
+		test.Assert(t, len(updated) == 1)
+		test.Assert(t, updated[0].Address == "tcp://10.0.0.1:8080")
+		test.Assert(t, updated[0].Weight == 20)
+		test.Assert(t, len(extra["Removed"].([]*instInfo)) == 0)
+	})
+
+	t.Run("Removed", func(t *testing.T) {
+		bus, queue := event.NewEventBus(), event.NewQueue(200)
+		h := discoveryEventHandler(discovery.ChangeEventName, bus, queue)
+		c := &discovery.Change{
+			Result:  discovery.Result{Cacheable: false, CacheKey: "key"},
+			Removed: []discovery.Instance{discovery.NewInstance("tcp", "10.0.0.2:9090", 30, nil)},
+		}
+		h(c)
+		extra := queue.Dump().([]*event.Event)[0].Extra.(map[string]interface{})
+		test.Assert(t, extra["Cacheable"] == false)
+		test.Assert(t, len(extra["Added"].([]*instInfo)) == 0)
+		test.Assert(t, len(extra["Updated"].([]*instInfo)) == 0)
+		removed := extra["Removed"].([]*instInfo)
+		test.Assert(t, len(removed) == 1)
+		test.Assert(t, removed[0].Address == "tcp://10.0.0.2:9090")
+		test.Assert(t, removed[0].Weight == 30)
+	})
+
+	t.Run("AllEmpty", func(t *testing.T) {
+		bus, queue := event.NewEventBus(), event.NewQueue(200)
+		h := discoveryEventHandler(discovery.ChangeEventName, bus, queue)
+		c := &discovery.Change{
+			Result: discovery.Result{Cacheable: true, CacheKey: "empty"},
+		}
+		h(c)
+		extra := queue.Dump().([]*event.Event)[0].Extra.(map[string]interface{})
+		test.Assert(t, extra["CacheKey"] == "empty")
+		test.Assert(t, len(extra["Added"].([]*instInfo)) == 0)
+		test.Assert(t, len(extra["Updated"].([]*instInfo)) == 0)
+		test.Assert(t, len(extra["Removed"].([]*instInfo)) == 0)
+	})
+
+	t.Run("Mixed", func(t *testing.T) {
+		bus, queue := event.NewEventBus(), event.NewQueue(200)
+		h := discoveryEventHandler(discovery.ChangeEventName, bus, queue)
+		c := &discovery.Change{
+			Result: discovery.Result{Cacheable: true, CacheKey: "mixed"},
+			Added:  []discovery.Instance{discovery.NewInstance("tcp", "10.0.0.1:9090", 1, nil)},
+			Updated: []discovery.Instance{
+				discovery.NewInstance("tcp", "10.0.0.2:9090", 2, nil),
+				discovery.NewInstance("tcp", "10.0.0.3:9090", 3, nil),
+			},
+			Removed: []discovery.Instance{discovery.NewInstance("tcp", "10.0.0.4:9090", 4, nil)},
+		}
+		h(c)
+		extra := queue.Dump().([]*event.Event)[0].Extra.(map[string]interface{})
+		added := extra["Added"].([]*instInfo)
+		updated := extra["Updated"].([]*instInfo)
+		removed := extra["Removed"].([]*instInfo)
+		test.Assert(t, len(added) == 1)
+		test.Assert(t, len(updated) == 2)
+		test.Assert(t, len(removed) == 1)
+		test.Assert(t, updated[0].Address == "tcp://10.0.0.2:9090")
+		test.Assert(t, updated[1].Address == "tcp://10.0.0.3:9090")
+	})
+}
+
+// oldWrapInstances is the original implementation for benchmark comparison.
+func oldWrapInstances(insts []discovery.Instance) []*instInfo {
+	if len(insts) == 0 {
+		return nil
+	}
+	instInfos := make([]*instInfo, 0, len(insts))
+	for i := range insts {
+		inst := insts[i]
+		addr := fmt.Sprintf("%s://%s", inst.Address().Network(), inst.Address().String())
+		instInfos = append(instInfos, &instInfo{Address: addr, Weight: inst.Weight()})
+	}
+	return instInfos
+}
+
+func makeInstances(n int) []discovery.Instance {
+	insts := make([]discovery.Instance, n)
+	for i := 0; i < n; i++ {
+		tags := map[string]string{
+			"cluster":      "default",
+			"dc":           "dc",
+			"zone":         "zone-a",
+			"env":          "production",
+			"canary":       "false",
+			"version":      "v1.2.3",
+			"container_id": fmt.Sprintf("container-%06d", i),
+			"pod_name":     fmt.Sprintf("svc-abcdef-%06d", i),
+			"namespace":    "default",
+			"deploy_stage": "stable",
+		}
+		insts[i] = discovery.NewInstance("tcp", fmt.Sprintf("10.0.%d.%d:8080", i/256, i%256), 100, tags)
+	}
+	return insts
+}
+
+func makeChange(insts []discovery.Instance) *discovery.Change {
+	return &discovery.Change{
 		Result: discovery.Result{
 			Cacheable: true,
-			CacheKey:  cacheKey,
+			CacheKey:  "bench-service",
+			Instances: insts,
 		},
-		Added: ins,
+		Updated: insts,
 	}
-	h(c)
-	events := queue.Dump().([]*event.Event)
-	test.Assert(t, len(events) == 1)
-	extra, ok := events[0].Extra.(map[string]interface{})
-	test.Assert(t, ok)
-	test.Assert(t, extra["Cacheable"] == true)
-	test.Assert(t, extra["CacheKey"] == cacheKey)
-	added := extra["Added"].([]*instInfo)
-	test.Assert(t, len(added) == 1)
+}
+
+func BenchmarkDiscoveryEventPush(b *testing.B) {
+	sizes := []int{10, 100, 1000, 10000}
+	for _, n := range sizes {
+		insts := makeInstances(n)
+		change := makeChange(insts)
+
+		b.Run(fmt.Sprintf("Old/%d", n), func(b *testing.B) {
+			queue := event.NewQueue(event.GetDefaultEventNum())
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				queue.Push(&event.Event{
+					Name: "test",
+					Time: time.Now(),
+					Extra: map[string]interface{}{
+						"Cacheable": change.Result.Cacheable,
+						"CacheKey":  change.Result.CacheKey,
+						"Added":     oldWrapInstances(change.Added),
+						"Updated":   oldWrapInstances(change.Updated),
+						"Removed":   oldWrapInstances(change.Removed),
+					},
+				})
+			}
+		})
+		b.Run(fmt.Sprintf("New/%d", n), func(b *testing.B) {
+			queue := event.NewQueue(event.GetDefaultEventNum())
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				queue.Push(&event.Event{
+					Name: "test",
+					Time: time.Now(),
+					Extra: &discoveryEventExtra{
+						cacheable: change.Result.Cacheable,
+						cacheKey:  change.Result.CacheKey,
+						added:     snapshotInstances(change.Added),
+						updated:   snapshotInstances(change.Updated),
+						removed:   snapshotInstances(change.Removed),
+					},
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkDiscoveryEventDump(b *testing.B) {
+	insts := makeInstances(1000)
+	change := makeChange(insts)
+
+	b.Run("Old/1000", func(b *testing.B) {
+		defEvtNum := event.GetDefaultEventNum()
+		queue := event.NewQueue(defEvtNum)
+		for i := 0; i < defEvtNum; i++ {
+			queue.Push(&event.Event{
+				Name: "test",
+				Time: time.Now(),
+				Extra: map[string]interface{}{
+					"Cacheable": change.Result.Cacheable,
+					"CacheKey":  change.Result.CacheKey,
+					"Added":     oldWrapInstances(change.Added),
+					"Updated":   oldWrapInstances(change.Updated),
+					"Removed":   oldWrapInstances(change.Removed),
+				},
+			})
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			queue.Dump()
+		}
+	})
+	b.Run("New/1000", func(b *testing.B) {
+		defEvtNum := event.GetDefaultEventNum()
+		queue := event.NewQueue(defEvtNum)
+		for i := 0; i < defEvtNum; i++ {
+			queue.Push(&event.Event{
+				Name: "test",
+				Time: time.Now(),
+				Extra: &discoveryEventExtra{
+					cacheable: change.Result.Cacheable,
+					cacheKey:  change.Result.CacheKey,
+					added:     snapshotInstances(change.Added),
+					updated:   snapshotInstances(change.Updated),
+					removed:   snapshotInstances(change.Removed),
+				},
+			})
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			queue.Dump()
+		}
+	})
 }

--- a/internal/client/option.go
+++ b/internal/client/option.go
@@ -240,7 +240,7 @@ func NewOptions(opts []Option) *Options {
 		DebugService: diagnosis.NoopService,
 
 		Bus:    event.NewEventBus(),
-		Events: event.NewQueue(event.MaxEventNum),
+		Events: event.NewQueue(event.GetDefaultEventNum()),
 
 		TracerCtl: &rpcinfo.TraceController{},
 

--- a/internal/server/option.go
+++ b/internal/server/option.go
@@ -204,7 +204,7 @@ func NewOptions(opts []Option) *Options {
 		ExitSignal:   DefaultSysExitSignal,
 
 		Bus:    event.NewEventBus(),
-		Events: event.NewQueue(event.MaxEventNum),
+		Events: event.NewQueue(event.GetDefaultEventNum()),
 
 		TracerCtl: &rpcinfo.TraceController{},
 		Registry:  registry.NoopRegistry,

--- a/pkg/circuitbreak/cbsuite_test.go
+++ b/pkg/circuitbreak/cbsuite_test.go
@@ -304,7 +304,7 @@ func TestInstanceCB(t *testing.T) {
 
 func TestCBSuite_AddEvent4CB(t *testing.T) {
 	cb := NewCBSuite(RPCInfo2Key)
-	cb.SetEventBusAndQueue(event.NewEventBus(), event.NewQueue(event.MaxEventNum))
+	cb.SetEventBusAndQueue(event.NewEventBus(), event.NewQueue(event.GetDefaultEventNum()))
 	var mws []endpoint.Middleware
 	mws = append(mws, cb.InstanceCBMW())
 	ctx := prepareCtx()
@@ -329,7 +329,7 @@ func TestCBSuite_AddEvent4CB(t *testing.T) {
 func TestRemoveInstBreaker(t *testing.T) {
 	cb := NewCBSuite(RPCInfo2Key)
 	bus := event.NewEventBus()
-	queue := event.NewQueue(event.MaxEventNum)
+	queue := event.NewQueue(event.GetDefaultEventNum())
 	cb.SetEventBusAndQueue(bus, queue)
 
 	var mws []endpoint.Middleware
@@ -373,7 +373,7 @@ func TestRemoveInstBreaker(t *testing.T) {
 func TestCBSuite_Dump(t *testing.T) {
 	cb := NewCBSuite(RPCInfo2Key)
 	bus := event.NewEventBus()
-	queue := event.NewQueue(event.MaxEventNum)
+	queue := event.NewQueue(event.GetDefaultEventNum())
 	cb.SetEventBusAndQueue(bus, queue)
 
 	var mws []endpoint.Middleware

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -25,3 +25,13 @@ type Event struct {
 	Detail string
 	Extra  interface{}
 }
+
+// lazyExtra is an interface for deferred materialization of Event.Extra.
+// Implementations MUST be safe for concurrent read access from multiple goroutines,
+// because KitexDumpLazyExtra() is called outside the queue lock.
+// In practice this means the struct should be immutable after construction.
+//
+// Use KitexDumpLazyExtra as the method name to minimize the risk of accidental interface satisfaction.
+type lazyExtra interface {
+	KitexDumpLazyExtra() interface{}
+}

--- a/pkg/event/queue.go
+++ b/pkg/event/queue.go
@@ -18,10 +18,36 @@ package event
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
+var defaultEventNum = int64(MaxEventNum)
+
+// GetDefaultEventNum returns the default event number for Queue
+//
+// concurrent safe.
+func GetDefaultEventNum() int {
+	return int(atomic.LoadInt64(&defaultEventNum))
+}
+
+// SetDefaultEventNum sets the default event number for Queue to num.
+// It only affects queues created after the call; existing queues are not resized.
+// It is not exposed as client/server option because the queue is used for internal debugging workflows,
+// and users do not need to be aware of it.
+//
+// num must be > 0; non-positive values are ignored and the default remains unchanged.
+// concurrent safe.
+func SetDefaultEventNum(num int) {
+	if num <= 0 {
+		return
+	}
+	atomic.StoreInt64(&defaultEventNum, int64(num))
+}
+
 const (
-	// MaxEventNum is the default size of a event queue.
+	// MaxEventNum is the initial default size of an event queue.
+	// Use GetDefaultEventNum() to read the runtime default,
+	// which can be changed via SetDefaultEventNum().
 	MaxEventNum = 200
 )
 
@@ -68,7 +94,6 @@ func (q *queue) Push(e *Event) {
 // Dump dumps the previously pushed events out in a reversed order.
 func (q *queue) Dump() interface{} {
 	q.mu.RLock()
-	defer q.mu.RUnlock()
 	results := make([]*Event, 0, len(q.ring))
 	pos := int32(q.tail)
 	for i := 0; i < len(q.ring); i++ {
@@ -79,10 +104,19 @@ func (q *queue) Dump() interface{} {
 
 		e := q.ring[pos]
 		if e == nil {
-			return results
+			break
 		}
-
 		results = append(results, e)
+	}
+	q.mu.RUnlock()
+
+	for i, res := range results {
+		if lazy, ok := res.Extra.(lazyExtra); ok {
+			// copy a new event to prevent Extra field race
+			cp := *res
+			cp.Extra = lazy.KitexDumpLazyExtra()
+			results[i] = &cp
+		}
 	}
 
 	return results

--- a/pkg/event/queue_test.go
+++ b/pkg/event/queue_test.go
@@ -18,6 +18,8 @@ package event
 
 import (
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
@@ -52,6 +54,136 @@ func TestQueue(t *testing.T) {
 		es := q.Dump().([]*Event)
 		test.Assert(t, len(es) == size)
 	}
+}
+
+var _ lazyExtra = (*mockLazyExtra)(nil)
+
+// mockLazyExtra implements lazyExtra interface
+type mockLazyExtra struct {
+	data string
+}
+
+func (m *mockLazyExtra) KitexDumpLazyExtra() interface{} {
+	return map[string]interface{}{"data": m.data}
+}
+
+func TestQueueLazyExtra(t *testing.T) {
+	q := NewQueue(5)
+
+	q.Push(&Event{Name: "plain", Extra: "hello"})
+	q.Push(&Event{Name: "lazy", Extra: &mockLazyExtra{data: "world"}})
+
+	es := q.Dump().([]*Event)
+	test.Assert(t, len(es) == 2)
+
+	test.Assert(t, es[0].Name == "lazy")
+	m, ok := es[0].Extra.(map[string]interface{})
+	test.Assert(t, ok, es[0].Extra)
+	test.Assert(t, m["data"] == "world", m)
+
+	test.Assert(t, es[1].Name == "plain")
+	test.Assert(t, es[1].Extra == "hello")
+}
+
+func TestQueueLazyExtraConcurrent(t *testing.T) {
+	t.Run("PushAndDump", func(t *testing.T) {
+		q := NewQueue(50)
+		var failures atomic.Int64
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				q.Push(&Event{Name: "lazy", Extra: &mockLazyExtra{data: strconv.Itoa(i)}})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				es := q.Dump().([]*Event)
+				for _, e := range es {
+					if _, ok := e.Extra.(map[string]interface{}); !ok {
+						failures.Add(1)
+					}
+				}
+			}
+		}()
+		wg.Wait()
+		test.Assert(t, failures.Load() == 0, failures.Load())
+	})
+	t.Run("PushMixed", func(t *testing.T) {
+		q := NewQueue(50)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				q.Push(&Event{Name: "lazy", Extra: &mockLazyExtra{data: strconv.Itoa(i)}})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				q.Push(&Event{Name: "plain", Extra: "hello"})
+			}
+		}()
+		wg.Wait()
+
+		es := q.Dump().([]*Event)
+		test.Assert(t, len(es) == 50)
+		for _, e := range es {
+			switch e.Name {
+			case "lazy":
+				_, ok := e.Extra.(map[string]interface{})
+				test.Assert(t, ok, e.Extra)
+			case "plain":
+				test.Assert(t, e.Extra == "hello")
+			default:
+				t.Fatalf("unexpected event name: %s", e.Name)
+			}
+		}
+	})
+	t.Run("DumpDoesNotMutateRing", func(t *testing.T) {
+		q := NewQueue(50)
+		for i := 0; i < 50; i++ {
+			q.Push(&Event{Name: "lazy", Extra: &mockLazyExtra{data: strconv.Itoa(i)}})
+		}
+		var failures atomic.Int64
+		var wg sync.WaitGroup
+		wg.Add(3)
+		for g := 0; g < 3; g++ {
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 500; i++ {
+					es := q.Dump().([]*Event)
+					if len(es) != 50 {
+						failures.Add(1)
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		test.Assert(t, failures.Load() == 0, failures.Load())
+	})
+}
+
+func Test_DefaultEventNum(t *testing.T) {
+	initNum := GetDefaultEventNum()
+	defer SetDefaultEventNum(initNum)
+
+	test.Assert(t, initNum == MaxEventNum, initNum)
+	// negative num does not take effect
+	SetDefaultEventNum(-1)
+	curNum := GetDefaultEventNum()
+	test.Assert(t, curNum == initNum, curNum)
+	// 0 does not take effect
+	SetDefaultEventNum(0)
+	curNum = GetDefaultEventNum()
+	test.Assert(t, curNum == initNum, curNum)
+
+	SetDefaultEventNum(100)
+	curNum = GetDefaultEventNum()
+	test.Assert(t, curNum == 100, curNum)
 }
 
 func BenchmarkQueue(b *testing.B) {


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
1. Replace eager```wrapInstances```with lazy snapshot + on-demand Dump via```LazyExtra```interface, cutting Push-path allocations to a constant 4 regardless of instance count.
```
cpu: Apple M3 Pro
BenchmarkDiscoveryEventPush

BenchmarkDiscoveryEventPush/Old/100-12             94315	     12688 ns/op	    9357 B/op	     407 allocs/op

BenchmarkDiscoveryEventPush/New/100-12        	 1241863	       964.1 ns/op	    4276 B/op	       4 allocs/op

BenchmarkDiscoveryEventPush/Old/1000-12       	    9549	    127306 ns/op	   88660 B/op	    4007 allocs/op

BenchmarkDiscoveryEventPush/New/1000-12       	  126002	      8686 ns/op	   41140 B/op	       4 allocs/op
```
2. Provide```GetDefaultEventNum```and```SetDefaultEventNum``` for changing/retrieving the default queue size to reduce memory consumption.

zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->