### PR TITLE
perf(server): use inline RPCInfo fields in LocalCaller

### DIFF
--- a/server/local_caller.go
+++ b/server/local_caller.go
@@ -277,18 +277,18 @@ func (lc *localCaller) doResolve(method string) (*cachedResult, error) {
 // the normal server-side allocation in initOrResetRPCInfoFunc (server.go).
 func (lc *localCaller) newLocalRPCInfo(svcInfo *serviceinfo.ServiceInfo, mi serviceinfo.MethodInfo, methodName, callerMethod string) rpcinfo.RPCInfo {
 	s := lc.svr
-	rpcStats := rpcinfo.AsMutableRPCStats(rpcinfo.NewRPCStats())
+	// Use inlined fields to avoid separate pool allocations.
+	ri := rpcinfo.NewRPCInfoWithInlineFields()
+	rpcinfo.AsMutableEndpointInfo(ri.To()).ResetFromBasicInfo(s.opt.Svr)
+	rpcinfo.AsMutableRPCConfig(ri.Config()).CopyFrom(s.opt.Configs)
+	rpcStats := rpcinfo.AsMutableRPCStats(ri.Stats())
 	if s.opt.StatsLevel != nil {
 		rpcStats.SetLevel(*s.opt.StatsLevel)
 	}
-	from := rpcinfo.NewMutableEndpointInfo(lc.caller, callerMethod, localCallerAddr, nil)
-	ri := rpcinfo.NewRPCInfo(
-		from.ImmutableView(),
-		rpcinfo.FromBasicInfo(s.opt.Svr),
-		rpcinfo.NewServerInvocation(),
-		rpcinfo.AsMutableRPCConfig(s.opt.Configs).Clone().ImmutableView(),
-		rpcStats.ImmutableView(),
-	)
+	from := rpcinfo.AsMutableEndpointInfo(ri.From())
+	from.SetServiceName(lc.caller)
+	from.SetMethod(callerMethod)
+	from.SetAddress(localCallerAddr)
 	rpcinfo.AsMutableEndpointInfo(ri.To()).SetMethod(methodName)
 
 	if setter, ok := ri.Invocation().(rpcinfo.InvocationSetter); ok {


### PR DESCRIPTION
Use NewRPCInfoWithInlineFields instead of NewRPCInfo in LocalCaller's newLocalRPCInfo to avoid separate pool allocations for endpoint info, invocation, config, and stats — matching the pattern in server.go and service_inline.go.
```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/kitex/server
cpu: Apple M2 Pro
                    │ old.txt      │             new.txt                      │
                    │   sec/op     │   sec/op     vs base                     │
LocalCaller_Call-12    311.3n ± 1%    238.6n ± 0%  -23.37% (p=0.000 n=10)
```
#### What type of PR is this?
perf

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->