### PR TITLE
perf(event): remove unused tailVersion to eliminate Push allocation

### DIFF
--- a/pkg/event/queue.go
+++ b/pkg/event/queue.go
@@ -59,23 +59,16 @@ type Queue interface {
 
 // queue implements a fixed size Queue.
 type queue struct {
-	ring        []*Event
-	tail        uint32
-	tailVersion map[uint32]*uint32
-	mu          sync.RWMutex
+	ring []*Event
+	tail uint32
+	mu   sync.RWMutex
 }
 
 // NewQueue creates a queue with the given capacity.
 func NewQueue(cap int) Queue {
-	q := &queue{
-		ring:        make([]*Event, cap),
-		tailVersion: make(map[uint32]*uint32, cap),
+	return &queue{
+		ring: make([]*Event, cap),
 	}
-	for i := 0; i <= cap; i++ {
-		t := uint32(0)
-		q.tailVersion[uint32(i)] = &t
-	}
-	return q
 }
 
 // Push pushes an event to the queue.
@@ -84,10 +77,6 @@ func (q *queue) Push(e *Event) {
 	defer q.mu.Unlock()
 
 	q.ring[q.tail] = e
-
-	newVersion := (*(q.tailVersion[q.tail])) + 1
-	q.tailVersion[q.tail] = &newVersion
-
 	q.tail = (q.tail + 1) % uint32(len(q.ring))
 }
 


### PR DESCRIPTION
#### What type of PR is this?
perf

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
perf(event): 移除未使用的 tailVersion 字段以消除 Push 分配

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en: 
##### 1. Background

`pkg/event/queue.go` was originally implemented as a lock-free ring buffer in #2, where `tailVersion map[uint32]*uint32` served as the ABA version counter for the `atomic.CompareAndSwap` loop in `Push`.

In #668 the `Push` path was refactored to take `q.mu.Lock()` exclusively, which replaced the CAS loop entirely. However the `tailVersion` field was left in place and is still being updated on every `Push`. A repo-wide search confirms that **no code anywhere reads `tailVersion`** — it is dead state kept alive only by its own write path.

##### 2. What this PR does

Removes the `tailVersion` field, its initialization in `NewQueue`, and its two write lines in `Push`. No behavior change: the queue still serializes all mutations via `q.mu`, and `ring`, `tail`, and `Dump` semantics are unchanged.

As a side effect, this also fixes a pre-existing off-by-one in the initialization loop (`for i := 0; i <= cap` allocated `cap+1` entries for a `cap`-sized ring).

##### 3. Why this matters

The `&newVersion` store into the map forced `uint32` to escape to the heap, so every `Push` incurred an allocation. Removing the dead writes eliminates both the allocation and two map accesses on the hot path, and also shrinks the per-queue resident memory (no map, no N+1 `*uint32`).

`Queue` is used by `pkg/circuitbreak/cbsuite.go` and `client/middlewares.go`'s discovery event handler, so this is on paths that #1939 ("optimize(discovery): reduce object allocation in discovery event queue") was also targeting.

##### 4. Benchmark

`go test -bench=BenchmarkQueue -benchmem -count=10 -cpu=1,4 ./pkg/event/` compared with `benchstat` (go1.23.4, darwin/amd64, Intel i9-9880H):

**Latency (sec/op)**

| Benchmark           | Before        | After        | Delta       | p-value |
| ------------------- | ------------- | ------------ | ----------- | ------- |
| Queue               | 65.79n ± 6%   | 29.13n ± 5%  | -55.72%     | 0.000   |
| Queue-4             | 66.80n ± 4%   | 27.21n ± 6%  | -59.26%     | 0.000   |
| QueueConcurrent     | 67.43n ± 6%   | 29.52n ± 2%  | -56.21%     | 0.000   |
| QueueConcurrent-4   | 105.65n ± 7%  | 57.83n ± 5%  | -45.27%     | 0.000   |
| **geomean**         | **74.80n**    | **34.11n**   | **-54.40%** | —       |

**Allocations per `Push`**

| Metric      | Before | After | Delta    |
| ----------- | -----: | ----: | -------- |
| B/op        | 4      | 0     | -100.00% |
| allocs/op   | 1      | 0     | -100.00% |

_n=10 samples per benchmark, p-values from `benchstat`'s Mann-Whitney U test._

- Push latency: **~55% lower** across all variants
- Push allocation: **1 alloc / 4 B → 0 alloc / 0 B**

All existing tests — `TestQueueInvalidCapacity`, `TestQueue`, `TestQueueLazyExtra`, `TestQueueLazyExtraConcurrent` (race-enabled), `Test_DefaultEventNum` — pass unchanged. Dependent packages `pkg/circuitbreak` and `client` also pass under `go test -race`.


zh(optional): 

`pkg/event/queue.go` 最早在 #2 中以 lock-free 的方式实现，`tailVersion` 是 `Push` 里 `atomic.CompareAndSwap` 循环用的 ABA 版本号。#668 把 `Push` 改成由 `q.mu.Lock()` 独占保护、整段 CAS 循环被移除，但 `tailVersion` 字段被保留下来了，且每次 `Push` 仍会更新它 —— 全仓库 grep 后确认没有任何地方读取该字段，它实际上已经是只写不读的死状态。

本 PR 删除 `tailVersion` 字段及其 `NewQueue`/`Push` 中的所有相关代码，顺带修掉了初始化循环里原先就存在的 `i <= cap` off-by-one。行为不变：队列仍由 `q.mu` 串行化，`ring`、`tail`、`Dump` 的语义都不变。

由于 `&newVersion` 被写入 map 时强制 `uint32` 逃逸到堆上，这段死代码每次 `Push` 都多一次堆分配 + 两次 map 访问。移除之后：Push 延迟下降约 55%（几何平均 -54.4%），单次 Push 的分配从 1 次 4 B 降为 0，并且 `NewQueue` 也不再分配 map 与 N+1 个 `*uint32`。

`Queue` 被 `pkg/circuitbreak/cbsuite.go` 和 `client/middlewares.go` 的 discovery 事件处理用到，与 #1939 `optimize(discovery): reduce object allocation in discovery event queue` 的关注方向一致。


#### (Optional) Which issue(s) this PR fixes:
(none)

#### (optional) The PR that updates user documentation:
