### PR TITLE
optimize(gRPC): support pooling HTTP2 framer write buffer to reduce idle connection memory

### DIFF
--- a/client/option.go
+++ b/client/option.go
@@ -548,21 +548,21 @@ func WithGRPCKeepaliveParams(kp grpc.ClientKeepalive) Option {
 	}}
 }
 
-// WithGRPCReuseWriteBuffer enables write buffer reusing across connection lifecycle.
-// When enabled, a fixed-size buffer allocation (default 64KB) is no longer assigned to each connection.
-// Instead, buffers are allocated on-demand from buffer pool and put back to buffer pool after each flush.
-// Trading CPU overhead (malloc/free) for reduced memory usage.
+// WithGRPCReuseWriteBuffer enables write buffer pooling to reduce idle connection memory.
+//
+// The config has two independent switches:
+//   - Enable: pools the flush buffer (default 64KB per connection saved).
+//   - EnableReuseHTTP2FramerBuffer: pools the per-frame encoding buffer (at most 32 KB in large-payload scenarios).
+//
+// Enabling both yields the best memory savings. Both are disabled by default.
 //
 // Use cases:
 //   - Scenarios with thousands of idle/low-traffic connections
 //   - Memory-constrained environments
 //
 // Trade-offs:
-//   - Reduces memory: ~2*WriteBufferSize per connection
-//   - Increases CPU: buffer pool malloc/free overhead on each write=>flush cycle
+//   - Reduces memory at the cost of per-write buffer pool overhead
 //   - Slightly higher GC pressure
-//
-// This feature is disabled by default. (optimized for throughput)
 func WithGRPCReuseWriteBuffer(cfg grpc.ReuseWriteBufferConfig) Option {
 	return Option{F: func(o *client.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCReuseWriteBuffer(%+v)", cfg))

--- a/pkg/remote/trans/nphttp2/grpc/framer.go
+++ b/pkg/remote/trans/nphttp2/grpc/framer.go
@@ -53,11 +53,28 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize, maxHeaderListSize
 	fr.SetReuseFrames()
 	fr.MaxHeaderListSize = maxHeaderListSize
 	fr.ReadMetaHeaders = hpack.NewDecoder(http2InitHeaderTableSize, nil)
+	if reuseCfg.EnableReuseHTTP2FramerBuffer {
+		fr.SetWriteBufferPoolEnabled(true)
+	}
 	return fr
 }
 
+// ReuseWriteBufferConfig controls whether reusing gRPC write buffers with pool.
+// Used to address high memory usage caused by a large number of idle connections in scenarios with massive connections.
+//
+// By default both options are false: each connection keeps its write buffers for its entire
+// lifetime. Enabling pooling reduces idle memory at the cost of a small per-write pool overhead.
+// Enabling both options together yields the best memory savings.
+//
+// Callers MUST use keyed literals (e.g. ReuseWriteBufferConfig{Enable: true}) to remain
+// compatible with future field additions.
 type ReuseWriteBufferConfig struct {
+	// Enable pools the flush buffer used to batch small writes before sending to the network.
 	Enable bool
+
+	// EnableReuseHTTP2FramerBuffer pools the per-frame encoding buffer used to assemble
+	// individual HTTP/2 frames. Can be enabled independently of Enable.
+	EnableReuseHTTP2FramerBuffer bool
 }
 
 type bufWriter interface {

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader.go
@@ -38,7 +38,10 @@ type Framer struct {
 	maxReadSize uint32
 
 	writer io.Writer
-	wbuf   []byte
+	// when enabled, wbuf is allocated from pool in startWrite and returned after a successful endWrite.
+	// On write failure the buffer is intentionally not returned, as the underlying writer may still hold a reference.
+	reuseWriteBuffer bool
+	wbuf             []byte
 	// maxWriteSize uint32 // zero means unlimited; TODO: implement
 
 	// AllowIllegalWrites permits the Framer's Write methods to
@@ -122,6 +125,14 @@ func (fr *Framer) SetMaxReadFrameSize(v uint32) {
 		v = maxFrameSize
 	}
 	fr.maxReadSize = v
+}
+
+// SetWriteBufferPoolEnabled sets whether the write buffer should be pooled.
+// When enabled, wbuf is allocated from pool in startWrite and returned after a successful endWrite.
+// On write failure the buffer is not returned, as the underlying writer may still hold a reference.
+// It is the caller's responsibility to not call other Write methods and SetWriteBufferPoolEnabled concurrently.
+func (fr *Framer) SetWriteBufferPoolEnabled(enabled bool) {
+	fr.reuseWriteBuffer = enabled
 }
 
 // ErrorDetail returns a more detailed error of the last error

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_reader_test.go
@@ -101,3 +101,12 @@ func Test_Framer_readAndCheckFrameHeader(t *testing.T) {
 		})
 	}
 }
+
+func Test_Framer_SetWriteBufferPoolEnabled(t *testing.T) {
+	fr := NewFramer(nil, nil)
+	test.Assert(t, !fr.reuseWriteBuffer, fr)
+	fr.SetWriteBufferPoolEnabled(true)
+	test.Assert(t, fr.reuseWriteBuffer, fr)
+	fr.SetWriteBufferPoolEnabled(false)
+	test.Assert(t, !fr.reuseWriteBuffer, fr)
+}

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_writer.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_writer.go
@@ -15,6 +15,7 @@ package grpcframe
 import (
 	"errors"
 
+	"github.com/bytedance/gopkg/lang/mcache"
 	"golang.org/x/net/http2"
 )
 
@@ -27,9 +28,13 @@ var (
 	errDepStreamID = errors.New("invalid dependent stream ID")
 )
 
+// During the write cycle from startWrite to endWrite, the actual length of payload written must equal payloadLen
 func (fr *Framer) startWrite(ftype http2.FrameType, flags http2.Flags, streamID uint32, payloadLen int) (err error) {
 	if payloadLen >= (1 << 24) {
 		return http2.ErrFrameTooLarge
+	}
+	if fr.reuseWriteBuffer {
+		fr.wbuf = mcache.Malloc(frameHeaderLen + payloadLen)
 	}
 	fr.wbuf = append(fr.wbuf[:0],
 		byte(payloadLen>>16),
@@ -41,11 +46,19 @@ func (fr *Framer) startWrite(ftype http2.FrameType, flags http2.Flags, streamID 
 		byte(streamID>>16),
 		byte(streamID>>8),
 		byte(streamID))
+
 	return nil
 }
 
 func (fr *Framer) endWrite() (err error) {
 	_, err = fr.writer.Write(fr.wbuf)
+	if fr.reuseWriteBuffer {
+		// Reuse only when err is nil, to prevent the underlying connection from still holding buf after a Write failure.
+		if err == nil {
+			mcache.Free(fr.wbuf)
+		}
+		fr.wbuf = nil
+	}
 	return err
 }
 

--- a/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_writer_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/grpcframe/frame_writer_test.go
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpcframe
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"golang.org/x/net/http2"
+
+	"github.com/cloudwego/kitex/internal/test"
+)
+
+// newReadBack returns a golang.org/x/net/http2.Framer that reads the bytes
+// produced by the grpcframe.Framer. Using the upstream framer as an
+// independent parser validates byte-level protocol correctness.
+func newReadBack(buf *bytes.Buffer) *http2.Framer {
+	return http2.NewFramer(io.Discard, buf)
+}
+
+// errWriter always returns an error on Write, used to test write-failure paths.
+type errWriter struct{ err error }
+
+func (w *errWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestFramer_Write(t *testing.T) {
+	testcases := []struct {
+		desc      string
+		setFramer func(framer *Framer)
+	}{
+		{
+			desc: "without reusing write buffer",
+		},
+		{
+			desc: "with reusing write buffer",
+			setFramer: func(framer *Framer) {
+				framer.SetWriteBufferPoolEnabled(true)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Run("WriteData round trip", func(t *testing.T) {
+				var buf bytes.Buffer
+				fr := NewFramer(&buf, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				payload1 := []byte("hello")
+				payload2 := []byte("world frame")
+				test.Assert(t, fr.WriteData(1, false, payload1) == nil)
+				test.Assert(t, fr.WriteData(3, true, payload2) == nil)
+
+				rb := newReadBack(&buf)
+
+				f1, err := rb.ReadFrame()
+				test.Assert(t, err == nil, err)
+				d1 := f1.(*http2.DataFrame)
+				test.Assert(t, d1.StreamID == 1, d1.StreamID)
+				test.Assert(t, !d1.StreamEnded())
+				test.Assert(t, bytes.Equal(d1.Data(), payload1), d1.Data())
+
+				f2, err := rb.ReadFrame()
+				test.Assert(t, err == nil, err)
+				d2 := f2.(*http2.DataFrame)
+				test.Assert(t, d2.StreamID == 3, d2.StreamID)
+				test.Assert(t, d2.StreamEnded())
+				test.Assert(t, bytes.Equal(d2.Data(), payload2), d2.Data())
+
+				// And the buffer must be fully consumed — no trailing bytes.
+				test.Assert(t, buf.Len() == 0, buf.Len())
+			})
+			t.Run("WriteHeaders round trip", func(t *testing.T) {
+				var buf bytes.Buffer
+				fr := NewFramer(&buf, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				hfp := http2.HeadersFrameParam{
+					StreamID:      1,
+					BlockFragment: []byte{0x00, 0x01, 0x02, 0x03},
+					EndStream:     true,
+					EndHeaders:    true,
+				}
+				test.Assert(t, fr.WriteHeaders(hfp) == nil)
+
+				rb := newReadBack(&buf)
+				f, err := rb.ReadFrame()
+				test.Assert(t, err == nil, err)
+				h := f.(*http2.HeadersFrame)
+				test.Assert(t, h.StreamID == 1, h.StreamID)
+				test.Assert(t, h.StreamEnded())
+				test.Assert(t, h.HeadersEnded())
+				test.Assert(t, bytes.Equal(h.HeaderBlockFragment(), hfp.BlockFragment))
+			})
+			t.Run("WriteSettingsAck zero payload", func(t *testing.T) {
+				var buf bytes.Buffer
+				fr := NewFramer(&buf, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				test.Assert(t, fr.WriteSettingsAck() == nil)
+
+				rb := newReadBack(&buf)
+				f, err := rb.ReadFrame()
+				test.Assert(t, err == nil, err)
+				sf := f.(*http2.SettingsFrame)
+				test.Assert(t, sf.IsAck())
+				test.Assert(t, sf.NumSettings() == 0, sf.NumSettings())
+				test.Assert(t, buf.Len() == 0, buf.Len())
+			})
+			t.Run("WriteWindowUpdate zero payload body", func(t *testing.T) {
+				var buf bytes.Buffer
+				fr := NewFramer(&buf, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				test.Assert(t, fr.WriteWindowUpdate(0, 12345) == nil)
+
+				rb := newReadBack(&buf)
+				f, err := rb.ReadFrame()
+				test.Assert(t, err == nil, err)
+				wuf := f.(*http2.WindowUpdateFrame)
+				test.Assert(t, wuf.StreamID == 0)
+				test.Assert(t, wuf.Increment == 12345, wuf.Increment)
+				test.Assert(t, buf.Len() == 0, buf.Len())
+			})
+			t.Run("WriteData large payload", func(t *testing.T) {
+				var buf bytes.Buffer
+				fr := NewFramer(&buf, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				// 16384 bytes = http2 default max DATA frame size
+				payload := make([]byte, 16384)
+				for i := range payload {
+					payload[i] = byte(i % 251)
+				}
+				test.Assert(t, fr.WriteData(1, true, payload) == nil)
+
+				rb := newReadBack(&buf)
+				f, err := rb.ReadFrame()
+				test.Assert(t, err == nil, err)
+				d := f.(*http2.DataFrame)
+				test.Assert(t, d.StreamID == 1)
+				test.Assert(t, d.StreamEnded())
+				test.Assert(t, bytes.Equal(d.Data(), payload))
+				test.Assert(t, buf.Len() == 0, buf.Len())
+			})
+			t.Run("write failure returns error", func(t *testing.T) {
+				writeErr := errors.New("connection reset")
+				fr := NewFramer(&errWriter{err: writeErr}, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				err := fr.WriteData(1, false, []byte("data"))
+				test.Assert(t, err != nil)
+				test.Assert(t, errors.Is(err, writeErr), err)
+			})
+			t.Run("write failure with zero payload", func(t *testing.T) {
+				writeErr := errors.New("broken pipe")
+				fr := NewFramer(&errWriter{err: writeErr}, nil)
+				if tc.setFramer != nil {
+					tc.setFramer(fr)
+				}
+
+				err := fr.WriteSettingsAck()
+				test.Assert(t, err != nil)
+				test.Assert(t, errors.Is(err, writeErr), err)
+			})
+		})
+	}
+}

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -2340,6 +2340,43 @@ func runPingPongTest(t *testing.T, msgSize int) {
 				return setUpWithOptions(t, 0, &ServerConfig{ReuseWriteBufferConfig: ReuseWriteBufferConfig{Enable: true}}, pingpong, ConnectOptions{ReuseWriteBufferConfig: ReuseWriteBufferConfig{Enable: true}})
 			},
 		},
+		{
+			desc: "client enables framer buffer pooling",
+			setupFunc: func(t *testing.T) (*server, *http2Client) {
+				return setUpWithOptions(t, 0, &ServerConfig{}, pingpong, ConnectOptions{ReuseWriteBufferConfig: ReuseWriteBufferConfig{EnableReuseHTTP2FramerBuffer: true}})
+			},
+		},
+		{
+			desc: "server enables framer buffer pooling",
+			setupFunc: func(t *testing.T) (*server, *http2Client) {
+				return setUpWithOptions(t, 0, &ServerConfig{ReuseWriteBufferConfig: ReuseWriteBufferConfig{EnableReuseHTTP2FramerBuffer: true}}, pingpong, ConnectOptions{})
+			},
+		},
+		{
+			desc: "client and server enables framer buffer pooling",
+			setupFunc: func(t *testing.T) (*server, *http2Client) {
+				return setUpWithOptions(t, 0, &ServerConfig{ReuseWriteBufferConfig: ReuseWriteBufferConfig{EnableReuseHTTP2FramerBuffer: true}}, pingpong, ConnectOptions{ReuseWriteBufferConfig: ReuseWriteBufferConfig{EnableReuseHTTP2FramerBuffer: true}})
+			},
+		},
+		{
+			desc: "client enables writer buffer sharing and framer buffer pooling",
+			setupFunc: func(t *testing.T) (*server, *http2Client) {
+				return setUpWithOptions(t, 0, &ServerConfig{}, pingpong, ConnectOptions{ReuseWriteBufferConfig: ReuseWriteBufferConfig{Enable: true, EnableReuseHTTP2FramerBuffer: true}})
+			},
+		},
+		{
+			desc: "server enables writer buffer sharing and framer buffer pooling",
+			setupFunc: func(t *testing.T) (*server, *http2Client) {
+				return setUpWithOptions(t, 0, &ServerConfig{ReuseWriteBufferConfig: ReuseWriteBufferConfig{Enable: true, EnableReuseHTTP2FramerBuffer: true}}, pingpong, ConnectOptions{})
+			},
+		},
+		{
+			desc: "client and server enable all buffer pooling",
+			setupFunc: func(t *testing.T) (*server, *http2Client) {
+				cfg := ReuseWriteBufferConfig{Enable: true, EnableReuseHTTP2FramerBuffer: true}
+				return setUpWithOptions(t, 0, &ServerConfig{ReuseWriteBufferConfig: cfg}, pingpong, ConnectOptions{ReuseWriteBufferConfig: cfg})
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/server/option.go
+++ b/server/option.go
@@ -359,21 +359,21 @@ func WithGRPCUnknownServiceHandler(f func(ctx context.Context, methodName string
 	}}
 }
 
-// WithGRPCReuseWriteBuffer enables write buffer reusing across connection lifecycle.
-// When enabled, a fixed-size buffer allocation (default 64KB) is no longer assigned to each connection.
-// Instead, buffers are allocated on-demand from buffer pool and put back to buffer pool after each flush.
-// Trading CPU overhead (malloc/free) for reduced memory usage.
+// WithGRPCReuseWriteBuffer enables write buffer pooling to reduce idle connection memory.
+//
+// The config has two independent switches:
+//   - Enable: pools the flush buffer (default 64KB per connection saved).
+//   - EnableReuseHTTP2FramerBuffer: pools the per-frame encoding buffer (at most 32 KB in large-payload scenarios).
+//
+// Enabling both yields the best memory savings. Both are disabled by default.
 //
 // Use cases:
 //   - Scenarios with thousands of idle/low-traffic connections
 //   - Memory-constrained environments
 //
 // Trade-offs:
-//   - Reduces memory: ~2*WriteBufferSize per connection
-//   - Increases CPU: buffer pool malloc/free overhead on each write=>flush cycle
+//   - Reduces memory at the cost of per-write buffer pool overhead
 //   - Slightly higher GC pressure
-//
-// This feature is disabled by default. (optimized for throughput)
 func WithGRPCReuseWriteBuffer(cfg grpc.ReuseWriteBufferConfig) Option {
 	return Option{F: func(o *internal_server.Options, di *utils.Slice) {
 		di.Push(fmt.Sprintf("WithGRPCReuseWriteBuffer(%+v)", cfg))


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
- Add```EnableReuseHTTP2FramerBuffer```to```ReuseWriteBufferConfig```.
- Update```WithGRPCReuseWriteBuffer``` comment to describe both config switches.
- Allocate per-frame wbuf from mcache in startWrite and return after successful endWrite.
On write failure the buffer is not returned, as the underlying writer may still hold a reference.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->