### PR TITLE
fix(gRPC): connection pool leak when connection is closed and there are no more subsequent calls

### DIFF
--- a/pkg/remote/trans/nphttp2/conn_pool.go
+++ b/pkg/remote/trans/nphttp2/conn_pool.go
@@ -30,11 +30,16 @@ import (
 
 	"github.com/cloudwego/kitex/pkg/klog"
 	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
 
-var _ remote.LongConnPool = &connPool{}
+const (
+	poolOpen   int32 = 0
+	poolClosed int32 = 1
+)
 
 func poolSize() uint32 {
 	// One connection per processor, and need redundancy。
@@ -60,84 +65,20 @@ func NewConnPool(remoteService string, size uint32, connOpts grpc.ConnectOptions
 	}
 }
 
-// MuxPool manages a pool of long connections.
+// connPool manages a pool of gRPC long connections.
 type connPool struct {
 	size          uint32
 	sfg           singleflight.Group
 	conns         sync.Map // key: address, value: *transports
 	remoteService string   // remote service name
 	connOpts      grpc.ConnectOptions
+	closed        int32 // 1 means connPool has been closed
 }
 
-type transports struct {
-	index         uint32
-	size          uint32
-	cliTransports []grpc.ClientTransport
-}
-
-// get connection from the pool, load balance with round-robin.
-func (t *transports) get() grpc.ClientTransport {
-	idx := atomic.AddUint32(&t.index, 1)
-	return t.cliTransports[idx%t.size]
-}
-
-// put find the first empty position to put the connection to the pool.
-func (t *transports) put(trans grpc.ClientTransport) {
-	for i := 0; i < int(t.size); i++ {
-		cliTransport := t.cliTransports[i]
-		if cliTransport == nil {
-			t.cliTransports[i] = trans
-			return
-		}
-		if !cliTransport.(grpc.IsActive).IsActive() {
-			t.cliTransports[i].GracefulClose()
-			t.cliTransports[i] = trans
-			return
-		}
-	}
-}
-
-// close all connections of the pool.
-func (t *transports) close() {
-	for i := range t.cliTransports {
-		if c := t.cliTransports[i]; c != nil {
-			c.GracefulClose()
-		}
-	}
-}
-
-var _ remote.LongConnPool = (*connPool)(nil)
-
-func (p *connPool) newTransport(ctx context.Context, dialer remote.Dialer, network, address string,
-	connectTimeout time.Duration, opts grpc.ConnectOptions,
-) (grpc.ClientTransport, error) {
-	conn, err := dialer.DialTimeout(network, address, connectTimeout)
-	if err != nil {
-		return nil, err
-	}
-	if opts.TLSConfig != nil {
-		tlsConn, err := newTLSConn(conn, opts.TLSConfig)
-		if err != nil {
-			return nil, err
-		}
-		conn = tlsConn
-	}
-	return grpc.NewClientTransport(
-		ctx,
-		conn,
-		opts,
-		p.remoteService,
-		func(grpc.GoAwayReason) {
-			// remove connection from the pool.
-			// we do not need to close this grpc transport manually
-			// since grpc client is responsible for doing this.
-			p.conns.Delete(address)
-		},
-		func() {
-			// do nothing
-		},
-	)
-}
+var (
+	_                 remote.LongConnPool = (*connPool)(nil)
+	errConnPoolClosed                     = status.Err(codes.Aborted, "connection pool has been closed")
+)
 
 // Get pick or generate a net.Conn and return
 func (p *connPool) Get(ctx context.Context, network, address string, opt remote.ConnOption) (net.Conn, error) {
@@ -146,48 +87,74 @@ func (p *connPool) Get(ctx context.Context, network, address string, opt remote.
 	}
 
 	var (
-		trans *transports
-		conn  *clientConn
-		err   error
+		tr   grpc.ClientTransport
+		idx  uint32
+		conn *clientConn
+		err  error
 	)
 
+	// there is no need to check whether connPool has been closed
+	// because connPool would only be closed when Kitex Client is GCed
 	v, ok := p.conns.Load(address)
 	if ok {
-		trans = v.(*transports)
-		if tr := trans.get(); tr != nil {
-			if tr.(grpc.IsActive).IsActive() {
-				// Actually new a stream, reuse the connection (grpc.ClientTransport)
-				conn, err = newClientConn(ctx, tr, address)
-				if err == nil {
-					return conn, nil
-				}
-				klog.CtxDebugf(ctx, "KITEX: New grpc stream failed, network=%s, address=%s, error=%s", network, address, err.Error())
+		trans := v.(*transports)
+		tr, idx = trans.getActiveTransport()
+		if tr != nil {
+			// Actually new a stream, reuse the connection (grpc.ClientTransport)
+			conn, err = newClientConn(ctx, tr, address)
+			if err == nil {
+				return conn, nil
 			}
+
+			// when stream creations failed:
+			// - gRPC Connection closed or draining: create a new connection
+			// - ctx canceled: the request lifecycle has ended, exit immediately
+			select {
+			// ctx provided by users is canceled, we should not try to create a new gRPC connection
+			case <-ctx.Done():
+				return nil, err
+			default:
+			}
+			klog.CtxDebugf(ctx, "KITEX: New grpc stream failed, network=%s, address=%s, error=%s", network, address, err.Error())
 		}
 	}
-	tr, err, _ := p.sfg.Do(address, func() (i interface{}, e error) {
-		// Notice: newTransport means new a connection, the timeout of connection cannot be set,
-		// so using context.Background() but not the ctx passed in as the parameter.
-		tr, err := p.newTransport(context.Background(), opt.Dialer, network, address, opt.ConnectTimeout, p.connOpts)
-		if err != nil {
-			return nil, err
+	rawTr, dErr, _ := p.sfg.Do(address, func() (i interface{}, e error) {
+		var trans *transports
+		var isNew bool
+		// avoid creating duplicate transports
+		if existTrans, ok := p.conns.Load(address); ok {
+			trans = existTrans.(*transports)
+		} else {
+			trans = newTransports(p.size)
+			isNew = true
 		}
-		if trans == nil {
-			trans = &transports{
-				size:          p.size,
-				cliTransports: make([]grpc.ClientTransport, p.size),
+
+		res, cErr := trans.createTransport(idx, p.remoteService, opt.Dialer, network, address, opt.ConnectTimeout, p.connOpts)
+		if cErr != nil {
+			return nil, cErr
+		}
+
+		if isNew {
+			// Store first, then recheck closed state to eliminate TOCTOU:
+			// if Close() finished its Range between our earlier check and this store,
+			// self-clean here to prevent orphaned transports.
+			p.conns.LoadOrStore(address, trans)
+			if p.isClosed() {
+				if recheckV, recheckOK := p.conns.LoadAndDelete(address); recheckOK {
+					recheckV.(*transports).close()
+				}
+				return nil, errConnPoolClosed
 			}
 		}
-		trans.put(tr) // the tr (connection) maybe not in the pool, but can be recycled by keepalive.
-		p.conns.Store(address, trans)
-		return tr, nil
+
+		return res, nil
 	})
-	if err != nil {
-		klog.CtxErrorf(ctx, "KITEX: New grpc client connection failed, network=%s, address=%s, error=%s", network, address, err.Error())
-		return nil, err
+	if dErr != nil {
+		klog.CtxErrorf(ctx, "KITEX: New grpc client connection failed, network=%s, address=%s, error=%s", network, address, dErr.Error())
+		return nil, dErr
 	}
 	klog.CtxDebugf(ctx, "KITEX: New grpc client connection succeed, network=%s, address=%s", network, address)
-	return newClientConn(ctx, tr.(grpc.ClientTransport), address)
+	return newClientConn(ctx, rawTr.(grpc.ClientTransport), address)
 }
 
 // Put implements the ConnPool interface.
@@ -205,9 +172,7 @@ func (p *connPool) release(conn net.Conn) error {
 }
 
 func (p *connPool) createShortConn(ctx context.Context, network, address string, opt remote.ConnOption) (net.Conn, error) {
-	// Notice: newTransport means new a connection, the timeout of connection cannot be set,
-	// so using context.Background() but not the ctx passed in as the parameter.
-	tr, err := p.newTransport(context.Background(), opt.Dialer, network, address, opt.ConnectTimeout, p.connOpts)
+	tr, err := newTransport(p.remoteService, opt.Dialer, network, address, opt.ConnectTimeout, p.connOpts, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -224,20 +189,36 @@ func (p *connPool) Discard(conn net.Conn) error {
 
 // Clean implements the LongConnPool interface.
 func (p *connPool) Clean(network, address string) {
-	if v, ok := p.conns.Load(address); ok {
-		p.conns.Delete(address)
+	if v, ok := p.conns.LoadAndDelete(address); ok {
 		v.(*transports).close()
 	}
 }
 
 // Close is to release resource of ConnPool, it is executed when client is closed.
 func (p *connPool) Close() error {
+	if !p.casClosed() {
+		return nil
+	}
+
 	p.conns.Range(func(addr, trans interface{}) bool {
 		p.conns.Delete(addr)
 		trans.(*transports).close()
 		return true
 	})
 	return nil
+}
+
+func (p *connPool) isClosed() bool {
+	return atomic.LoadInt32(&p.closed) == poolClosed
+}
+
+func (p *connPool) casClosed() bool {
+	return atomic.CompareAndSwapInt32(&p.closed, poolOpen, poolClosed)
+}
+
+type dumpEntry struct {
+	addr string
+	tr   grpc.ClientTransport
 }
 
 // Dump dumps the connection pool with the details of the underlying transport.
@@ -251,30 +232,68 @@ func (p *connPool) Dump() interface{} {
 	// remoteAddress -> []clientTransport, where each clientTransport is a connection. Distinguish the connection via localAddress.
 	// If mesh egress is not enabled, toAddr should be the address of the callee service.
 	// Otherwise, toAddr will be the same, so you should check the remoteAddress in each stream, which is read from the header.
+
+	// sync.Map does not expose its length directly.
+	// Since dump is a cold-path operation, performance is not a major concern here
 	poolDump := make(map[string]interface{}, p.size)
+	var cliTransDumps []dumpEntry
 	p.conns.Range(func(k, v interface{}) bool {
 		addr := k.(string)
-		ts := v.(*transports)
-		for _, t := range ts.cliTransports {
-			if t == nil {
-				continue
-			}
-			dumper, ok := t.(interface{ Dump() interface{} })
-			if !ok {
-				continue
-			}
-			var curr []interface{}
-			if poolDump[addr] == nil {
-				curr = make([]interface{}, 0)
-			} else {
-				curr = poolDump[addr].([]interface{})
-			}
-			curr = append(curr, dumper.Dump())
-			poolDump[addr] = curr
+		for _, tr := range v.(*transports).loadAll() {
+			cliTransDumps = append(cliTransDumps, dumpEntry{addr: addr, tr: tr})
 		}
 		return true
 	})
+
+	for _, cliTransDump := range cliTransDumps {
+		dumper, ok := cliTransDump.tr.(interface{ Dump() interface{} })
+		if !ok {
+			continue
+		}
+		var curr []interface{}
+		if poolDump[cliTransDump.addr] == nil {
+			curr = make([]interface{}, 0)
+		} else {
+			curr = poolDump[cliTransDump.addr].([]interface{})
+		}
+		curr = append(curr, dumper.Dump())
+		poolDump[cliTransDump.addr] = curr
+	}
 	return poolDump
+}
+
+// newTransport creates a gRPC connection
+func newTransport(remoteService string,
+	dialer remote.Dialer, network, address string, connectTimeout time.Duration, opts grpc.ConnectOptions,
+	onGoAway func(context.Context, grpc.ClientTransport, grpc.GoAwayReason),
+	onClose func(context.Context, grpc.ClientTransport, error),
+) (grpc.ClientTransport, error) {
+	conn, err := dialer.DialTimeout(network, address, connectTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if opts.TLSConfig != nil {
+		tlsConn, tErr := newTLSConn(conn, opts.TLSConfig)
+		if tErr != nil {
+			// release tls handshake failed connection
+			cErr := conn.Close()
+			if cErr != nil {
+				klog.Warnf("KITEX: Close TLS handshake failed connection, err: %v", cErr)
+			}
+			return nil, tErr
+		}
+		conn = tlsConn
+	}
+	return grpc.NewClientTransportWithConfig(
+		context.Background(), // gRPC connection does not need to be bound to a specific ctx
+		conn,
+		opts,
+		grpc.ClientConfig{
+			RemoteService: remoteService,
+			OnGoAway:      onGoAway,
+			OnClose:       onClose,
+		},
+	)
 }
 
 // newTLSConn constructs a client-side TLS connection and performs handshake.
@@ -284,4 +303,13 @@ func newTLSConn(conn net.Conn, tlsCfg *tls.Config) (net.Conn, error) {
 		return nil, err
 	}
 	return tlsConn, nil
+}
+
+func checkActive(trans grpc.ClientTransport) bool {
+	if trans == nil {
+		return false
+	}
+	// grpc.ClientTransport is implemented by *http2Client in pkg/remote/trans/nphttp2/grpc
+	// it implements grpc.IsActive
+	return trans.(grpc.IsActive).IsActive()
 }

--- a/pkg/remote/trans/nphttp2/conn_pool_slot.go
+++ b/pkg/remote/trans/nphttp2/conn_pool_slot.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nphttp2
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+)
+
+const (
+	slotClosed int32 = 1
+)
+
+// transports holds a fixed-size array of independent transportSlots for a single address.
+// Slots are selected by round-robin; each slot manages its own connection independently.
+type transports struct {
+	index uint32 // atomic round-robin counter
+	size  uint32
+
+	transportSlots []*transportSlot
+}
+
+func newTransports(size uint32) *transports {
+	slots := make([]*transportSlot, size)
+	for i := 0; i < int(size); i++ {
+		slots[i] = &transportSlot{}
+	}
+
+	return &transports{
+		size:           size,
+		transportSlots: slots,
+	}
+}
+
+// getNextTransportSlot returns the next slot by round-robin and its index.
+func (t *transports) getNextTransportSlot() (*transportSlot, uint32) {
+	idx := atomic.AddUint32(&t.index, 1) % t.size
+	return t.transportSlots[idx], idx
+}
+
+func (t *transports) getTransportSlot(idx uint32) *transportSlot {
+	return t.transportSlots[idx]
+}
+
+// getActiveTransport picks the next slot by round-robin and returns its transport if active.
+// Returns (nil, idx) when the slot is empty or the transport is inactive.
+func (t *transports) getActiveTransport() (grpc.ClientTransport, uint32) {
+	slot, idx := t.getNextTransportSlot()
+	trans := slot.load()
+	if checkActive(trans) {
+		return trans, idx
+	}
+	return nil, idx
+}
+
+// createTransport creates or reuses transport in the slot at idx.
+func (t *transports) createTransport(idx uint32, remoteService string,
+	dialer remote.Dialer, network, address string, connectTimeout time.Duration, opts grpc.ConnectOptions,
+) (grpc.ClientTransport, error) {
+	slot := t.getTransportSlot(idx)
+	return slot.createTransport(remoteService, dialer, network, address, connectTimeout, opts)
+}
+
+// loadAll returns a snapshot of all non-nil transports across all slots.
+func (t *transports) loadAll() []grpc.ClientTransport {
+	result := make([]grpc.ClientTransport, 0, t.size)
+	for _, slot := range t.transportSlots {
+		if tr := slot.load(); tr != nil {
+			result = append(result, tr)
+		}
+	}
+	return result
+}
+
+// close shuts down all slots. Each slot is closed independently.
+func (t *transports) close() {
+	for i := 0; i < int(t.size); i++ {
+		slot := t.transportSlots[i]
+		slot.close()
+	}
+}
+
+var errTransportsClosed = status.Err(codes.Aborted, "transports have been closed due to instance offline")
+
+// transportRef wraps grpc.ClientTransport for use with atomic.Pointer,
+// which requires a non-interface type parameter.
+// A nil *transportRef means the slot is empty.
+type transportRef struct {
+	ct grpc.ClientTransport
+}
+
+// transportSlot manages a single gRPC connection with lock-free reads.
+type transportSlot struct {
+	mu    sync.Mutex // serializes createTransport to prevent redundant dials for the same slot.
+	state int32      // closed flag, protected by mu. Once closed, createTransport is rejected
+
+	ref atomic.Pointer[transportRef]
+}
+
+func (slot *transportSlot) load() grpc.ClientTransport {
+	ref := slot.ref.Load()
+	if ref == nil {
+		return nil
+	}
+	return ref.ct
+}
+
+// createTransport creates a new gRPC transport and stores it in this slot.
+// If the slot already has an active transport, it is returned directly.
+// The mutex serializes concurrent callers; network I/O runs with the mutex held
+// to prevent redundant dials for the same slot.
+func (slot *transportSlot) createTransport(
+	remoteService string,
+	dialer remote.Dialer, network, address string, connectTimeout time.Duration, opts grpc.ConnectOptions,
+) (grpc.ClientTransport, error) {
+	slot.mu.Lock()
+	if slot.state == slotClosed {
+		slot.mu.Unlock()
+		return nil, errTransportsClosed
+	}
+
+	// Double-check: another goroutine may have filled this slot.
+	if ref := slot.ref.Load(); ref != nil && checkActive(ref.ct) {
+		slot.mu.Unlock()
+		return ref.ct, nil
+	}
+
+	newTrans, err := newTransport(remoteService, dialer, network, address, connectTimeout, opts,
+		func(ctx context.Context, trans grpc.ClientTransport, reason grpc.GoAwayReason) {
+			slot.removeTransport(trans)
+		},
+		func(ctx context.Context, trans grpc.ClientTransport, err error) {
+			slot.removeTransport(trans)
+		},
+	)
+	if err != nil {
+		slot.mu.Unlock()
+		return nil, err
+	}
+
+	oldRef := slot.ref.Swap(&transportRef{ct: newTrans})
+	slot.mu.Unlock()
+
+	if oldRef != nil && oldRef.ct != nil {
+		oldRef.ct.GracefulClose()
+	}
+
+	return newTrans, nil
+}
+
+// removeTransport atomically clears this slot if it currently holds the given transport.
+// Lock-free (CAS only). Called from onClose/onGoAway callbacks.
+func (slot *transportSlot) removeTransport(trans grpc.ClientTransport) {
+	ref := slot.ref.Load()
+	if ref == nil || ref.ct != trans {
+		return
+	}
+	slot.ref.CompareAndSwap(ref, nil)
+}
+
+// close marks this slot as permanently closed and removes any stored transport.
+// Idempotent: only the first call performs cleanup.
+func (slot *transportSlot) close() {
+	slot.mu.Lock()
+	if slot.state == slotClosed {
+		slot.mu.Unlock()
+		return
+	}
+	slot.state = slotClosed
+	ref := slot.ref.Swap(nil)
+	slot.mu.Unlock()
+
+	if ref != nil && ref.ct != nil {
+		ref.ct.GracefulClose()
+	}
+}

--- a/pkg/remote/trans/nphttp2/conn_pool_slot_test.go
+++ b/pkg/remote/trans/nphttp2/conn_pool_slot_test.go
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nphttp2
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
+)
+
+var slotTestOpts = grpc.ConnectOptions{
+	WriteBufferSize: defaultMockReadWriteBufferSize,
+	ReadBufferSize:  defaultMockReadWriteBufferSize,
+}
+
+func TestTransportSlot(t *testing.T) {
+	t.Run("load() empty slot", func(t *testing.T) {
+		slot := &transportSlot{}
+		test.Assert(t, slot.load() == nil, slot)
+	})
+	t.Run("createTransport() and load()", func(t *testing.T) {
+		slot := &transportSlot{}
+		t.Cleanup(slot.close)
+		tr, err := slot.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tr != nil)
+		test.Assert(t, slot.load() == tr)
+	})
+	t.Run("createTransport() returns existing active transport", func(t *testing.T) {
+		slot := &transportSlot{}
+		t.Cleanup(slot.close)
+		dialer := newMockDialer()
+		tr1, err := slot.createTransport("test", dialer, "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+
+		tr2, err := slot.createTransport("test", dialer, "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tr1 == tr2, tr1, tr2)
+	})
+	t.Run("createTransport() after close()", func(t *testing.T) {
+		slot := &transportSlot{}
+		slot.close()
+
+		_, err := slot.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == errTransportsClosed, err)
+	})
+	t.Run("removeTransport() clears matching transport", func(t *testing.T) {
+		slot := &transportSlot{}
+		t.Cleanup(slot.close)
+		tr, err := slot.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+
+		slot.removeTransport(tr)
+		// After removeTransport the slot is empty but the transport itself
+		// is still alive. Close it explicitly so the test does not leak it.
+		tr.GracefulClose()
+		test.Assert(t, slot.load() == nil)
+	})
+	t.Run("removeTransport() ignores non-matching transport", func(t *testing.T) {
+		slot1 := &transportSlot{}
+		t.Cleanup(slot1.close)
+		tr1, err := slot1.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+
+		slot2 := &transportSlot{}
+		t.Cleanup(slot2.close)
+		tr2, err := slot2.createTransport("test", newMockDialer(), "tcp", mockAddr1, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+
+		slot1.removeTransport(tr2)
+		test.Assert(t, slot1.load() == tr1, "should not remove non-matching transport")
+	})
+	t.Run("close() is idempotent", func(t *testing.T) {
+		slot := &transportSlot{}
+		_, err := slot.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, slot.load() != nil)
+
+		slot.close()
+		test.Assert(t, slot.load() == nil)
+
+		slot.close()
+		test.Assert(t, slot.load() == nil)
+	})
+	t.Run("close() then removeTransport()", func(t *testing.T) {
+		slot := &transportSlot{}
+		tr, err := slot.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+
+		slot.close()
+		slot.removeTransport(tr)
+	})
+	t.Run("concurrent createTransport() and close()", func(t *testing.T) {
+		nums := 50
+		var wg sync.WaitGroup
+		wg.Add(nums + 1)
+
+		slot := &transportSlot{}
+		t.Cleanup(slot.close)
+
+		var nilTr, unexpectedErrs atomic.Int32
+		for i := 0; i < nums; i++ {
+			go func() {
+				defer wg.Done()
+				tr, err := slot.createTransport("test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+				if err == nil {
+					if tr == nil {
+						nilTr.Add(1)
+					}
+				} else if err != errTransportsClosed {
+					unexpectedErrs.Add(1)
+				}
+			}()
+		}
+
+		// concurrent close
+		go func() {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond)
+			slot.close()
+		}()
+
+		wg.Wait()
+		test.Assert(t, slot.load() == nil)
+		test.Assert(t, nilTr.Load() == 0, nilTr.Load())
+		test.Assert(t, unexpectedErrs.Load() == 0, unexpectedErrs.Load())
+	})
+}
+
+func TestTransports(t *testing.T) {
+	t.Run("newTransports()", func(t *testing.T) {
+		ts := newTransports(4)
+		test.Assert(t, ts.size == 4)
+		test.Assert(t, len(ts.transportSlots) == 4)
+		test.Assert(t, len(ts.loadAll()) == 0)
+	})
+	t.Run("getActiveTransport() on empty transports", func(t *testing.T) {
+		ts := newTransports(4)
+		tr, _ := ts.getActiveTransport()
+		test.Assert(t, tr == nil)
+	})
+	t.Run("createTransport() and loadAll()", func(t *testing.T) {
+		ts := newTransports(4)
+		t.Cleanup(ts.close)
+		tr, err := ts.createTransport(0, "test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tr != nil)
+
+		all := ts.loadAll()
+		test.Assert(t, len(all) == 1)
+		test.Assert(t, all[0] == tr)
+	})
+	t.Run("close clears all slots", func(t *testing.T) {
+		ts := newTransports(4)
+		for i := uint32(0); i < 2; i++ {
+			tr, err := ts.createTransport(i, "test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+			test.Assert(t, err == nil, err)
+			test.Assert(t, tr != nil)
+		}
+		test.Assert(t, len(ts.loadAll()) == 2)
+
+		ts.close()
+		test.Assert(t, len(ts.loadAll()) == 0)
+
+		// createTransport after close should fail
+		_, err := ts.createTransport(0, "test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == errTransportsClosed, err)
+	})
+	t.Run("onClose callback removes transport from slot", func(t *testing.T) {
+		ts := newTransports(4)
+		t.Cleanup(ts.close)
+		tr, err := ts.createTransport(0, "test", newMockDialer(), "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, len(ts.loadAll()) == 1)
+
+		// simulate transport close (triggers onClose -> removeTransport)
+		tr.Close(errors.New("test close"))
+
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if len(ts.loadAll()) == 0 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		test.Assert(t, len(ts.loadAll()) == 0, len(ts.loadAll()))
+	})
+	t.Run("onGoAway callback removes transport from slot", func(t *testing.T) {
+		// Dialer queues a GOAWAY frame after the initial SETTINGS frame and
+		// enables autoStartReader so the http2Client reader goroutine runs.
+		// The reader parses GOAWAY, handleGoAway fires onGoAway, and onGoAway
+		// calls slot.removeTransport, clearing the slot.
+		dialFunc := func(network, address string, timeout time.Duration) (net.Conn, error) {
+			npConn := newMockNpConn(address)
+			npConn.autoStartReader = true
+			npConn.mockSettingFrame()
+			npConn.mockGoAwayFrame()
+			return npConn, nil
+		}
+		dialer := newMockDialerWithDialFunc(dialFunc)
+
+		ts := newTransports(4)
+		t.Cleanup(ts.close)
+		_, err := ts.createTransport(0, "test", dialer, "tcp", mockAddr0, time.Second, slotTestOpts)
+		test.Assert(t, err == nil, err)
+
+		// Wait for the reader goroutine to parse GOAWAY and fire onGoAway.
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if len(ts.loadAll()) == 0 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		test.Assert(t, len(ts.loadAll()) == 0, "onGoAway should have removed the transport")
+	})
+}

--- a/pkg/remote/trans/nphttp2/conn_pool_test.go
+++ b/pkg/remote/trans/nphttp2/conn_pool_test.go
@@ -17,7 +17,13 @@
 package nphttp2
 
 import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"math/rand"
 	"net"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,46 +32,466 @@ import (
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/remote"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
+	"github.com/cloudwego/kitex/pkg/utils"
 )
 
 func TestConnPool(t *testing.T) {
-	// mock init
-	connPool := newMockConnPool(nil)
-	defer connPool.Close()
-	opt := newMockConnOption()
-	ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingNone)
+	t.Run("normal", func(t *testing.T) {
+		// mock init
+		connPool := newMockConnPool(nil)
+		defer connPool.Close()
+		opt := newMockConnOption()
+		ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
 
-	// test Get()
-	_, err := connPool.Get(ctx, "tcp", mockAddr0, opt)
-	test.Assert(t, err == nil, err)
-
-	// test connection reuse
-	// keep create new connection until filling the pool size,
-	// then Get() will reuse established connection by round-robin
-	for i := 0; uint32(i) < connPool.size*2; i++ {
-		_, err := connPool.Get(ctx, "tcp", mockAddr1, opt)
+		// test Get()
+		_, err := connPool.Get(ctx, "tcp", mockAddr0, opt)
 		test.Assert(t, err == nil, err)
+
+		// test connection reuse
+		// keep create new connection until filling the pool size,
+		// then Get() will reuse established connection by round-robin
+		for i := 0; uint32(i) < connPool.size*2; i++ {
+			_, err := connPool.Get(ctx, "tcp", mockAddr1, opt)
+			test.Assert(t, err == nil, err)
+		}
+
+		// test TimeoutGet()
+		opt.ConnectTimeout = time.Microsecond
+		_, err = connPool.Get(ctx, "tcp", mockAddr0, opt)
+		test.Assert(t, err != nil, err)
+
+		// test Dump()
+		dump := connPool.Dump()
+		test.Assert(t, dump != nil)
+		m := dump.(map[string]interface{})
+		test.Assert(t, m[mockAddr0] != nil)
+		test.Assert(t, m[mockAddr1] != nil)
+		_, err = sonic.Marshal(dump)
+		test.Assert(t, err == nil, err)
+
+		// test Clean()
+		connPool.Clean("tcp", mockAddr0)
+		_, ok := connPool.conns.Load(mockAddr0)
+		test.Assert(t, !ok)
+	})
+	t.Run("ctx canceled", func(t *testing.T) {
+		// When stream quota is exhausted, NewStream blocks. If the user's ctx
+		// expires while blocked, Get() should return the context error immediately
+		// without entering singleflight (which would waste a dial or block others).
+		//
+		// Setup: mockNetpollConn with MaxConcurrentStreams=1 + blockOnQueueEmpty
+		// to keep the reader goroutine alive after processing the SETTINGS frame.
+		// Hold 1 stream → quota=0 → 2nd Get with short deadline blocks → timeout.
+		blockCh := make(chan struct{})
+		t.Cleanup(func() {
+			select {
+			case <-blockCh:
+			default:
+				close(blockCh)
+			}
+		})
+		dialFunc := func(network, address string, timeout time.Duration) (net.Conn, error) {
+			npConn := newMockNpConn(address)
+			npConn.autoStartReader = true
+			npConn.blockOnQueueEmpty = blockCh
+			npConn.mockSettingFrameWithMaxStreams(1)
+			return npConn, nil
+		}
+		opt := remote.ConnOption{
+			Dialer:         newMockDialerWithDialFunc(dialFunc),
+			ConnectTimeout: time.Second,
+		}
+		// Use size=1 so round-robin always hits the same slot.
+		pool := NewConnPool("test", 1, grpc.ConnectOptions{
+			WriteBufferSize: defaultMockReadWriteBufferSize,
+			ReadBufferSize:  defaultMockReadWriteBufferSize,
+		})
+		defer pool.Close()
+
+		// Create the first stream — triggers transport creation + reader goroutine.
+		ctx1 := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+		ctx1Timeout, cancel1 := context.WithTimeout(ctx1, 2*time.Second)
+		defer cancel1()
+		conn1, err := pool.Get(ctx1Timeout, "tcp", mockAddr0, opt)
+		test.Assert(t, err == nil, err)
+		cc1 := conn1.(*clientConn)
+
+		// Wait for the reader goroutine to process SETTINGS (MaxConcurrentStreams=1).
+		// After our held stream, quota=0.
+		time.Sleep(50 * time.Millisecond)
+
+		// Second Get with a very short deadline — should block on quota then timeout.
+		ctx2 := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+		ctx2Timeout, cancel2 := context.WithTimeout(ctx2, 80*time.Millisecond)
+		defer cancel2()
+
+		_, err = pool.Get(ctx2Timeout, "tcp", mockAddr0, opt)
+		test.Assert(t, err != nil)
+		test.Assert(t, ctx2Timeout.Err() != nil)
+
+		// Verify the pool still has only the original transport —
+		// the ctx.Done() fast exit in Get() should have prevented singleflight entry.
+		v, ok := pool.conns.Load(mockAddr0)
+		test.Assert(t, ok)
+		allTransports := v.(*transports).loadAll()
+		test.Assert(t, len(allTransports) == 1, len(allTransports))
+		test.Assert(t, allTransports[0] == cc1.tr, allTransports[0])
+
+		cc1.tr.CloseStream(cc1.s, nil)
+	})
+}
+
+// getAndReleaseStream wraps pool.Get with a deadline context,
+// holds the stream for a random duration (0~200ms) simulating real RPC latency,
+// then closes it.
+func getAndReleaseStream(pool *connPool, parent context.Context, network, address string, opt remote.ConnOption) error {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+	conn, err := pool.Get(ctx, network, address, opt)
+	if err != nil {
+		return err
 	}
+	time.Sleep(time.Duration(rand.Intn(200)) * time.Millisecond)
+	cc := conn.(*clientConn)
+	cc.tr.CloseStream(cc.s, nil)
+	return nil
+}
 
-	// test TimeoutGet()
-	opt.ConnectTimeout = time.Microsecond
-	_, err = connPool.Get(ctx, "tcp", mockAddr0, opt)
-	test.Assert(t, err != nil, err)
+func isExpectedShutdownErr(err error) bool {
+	if err == nil || err == errTransportsClosed || err == errConnPoolClosed || err == grpc.ErrConnClosing {
+		return true
+	}
+	return false
+}
 
-	// test Dump()
-	dump := connPool.Dump()
-	test.Assert(t, dump != nil)
-	m := dump.(map[string]interface{})
-	test.Assert(t, m[mockAddr0] != nil)
-	test.Assert(t, m[mockAddr1] != nil)
-	_, err = sonic.Marshal(dump)
-	test.Assert(t, err == nil, err)
+func TestConnPoolConcurrent(t *testing.T) {
+	t.Run("Get() and Clean() concurrently", func(t *testing.T) {
+		// Simulates service discovery repeatedly marking an instance as
+		// offline while traffic is still flowing.
+		// Some Get calls are expected to fail with errTransportsClosed;
+		// that is the intended semantic of Clean.
+		pool := newMockConnPool(nil)
+		t.Cleanup(func() { pool.Close() })
+		opt := newMockConnOption()
 
-	// test Clean()
-	connPool.Clean("tcp", mockAddr0)
-	_, ok := connPool.conns.Load(mockAddr0)
-	test.Assert(t, !ok)
+		iterNum := 50
+		var wg sync.WaitGroup
+		var successNum, failNum, unexpectedErrs atomic.Int32
+
+		stopDone := make(chan struct{})
+		cleanerDone := make(chan struct{})
+		go func() {
+			defer close(cleanerDone)
+			ticker := time.NewTicker(5 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopDone:
+					return
+				case <-ticker.C:
+					pool.Clean("tcp", mockAddr0)
+				}
+			}
+		}()
+
+		wg.Add(iterNum)
+		for i := 0; i < iterNum; i++ {
+			go func() {
+				defer wg.Done()
+				ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+				err := getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt)
+				if err == nil {
+					successNum.Add(1)
+				} else {
+					failNum.Add(1)
+					if !isExpectedShutdownErr(err) {
+						unexpectedErrs.Add(1)
+						t.Error(err)
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		close(stopDone)
+		<-cleanerDone
+
+		test.Assert(t, successNum.Load() > 0)
+		test.Assert(t, successNum.Load()+failNum.Load() == int32(iterNum))
+		test.Assert(t, unexpectedErrs.Load() == 0, unexpectedErrs.Load())
+		t.Logf("success=%d fail=%d", successNum.Load(), failNum.Load())
+
+		// After cleaning, Get() with the same addr should still succeed
+		// (recovery). Use the helper so the stream quota is released too.
+		ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+		test.Assert(t, getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt) == nil)
+	})
+	t.Run("Get() and Close() concurrently", func(t *testing.T) {
+		// Simulates process shutdown: a flood of in-flight Gets racing with
+		// pool.Close. Each Get immediately closes its stream so the per-
+		// transport stream quota does not saturate, allowing pool.Close to
+		// gracefully drain.
+		pool := newMockConnPool(nil)
+		opt := newMockConnOption()
+
+		iterNum := 50
+		var wg sync.WaitGroup
+		var unexpectedErrs atomic.Int32
+		wg.Add(iterNum)
+		for i := 0; i < iterNum; i++ {
+			go func() {
+				defer wg.Done()
+				ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+				err := getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt)
+				if !isExpectedShutdownErr(err) {
+					unexpectedErrs.Add(1)
+					t.Error(err)
+				}
+			}()
+		}
+
+		time.Sleep(10 * time.Millisecond)
+		test.Assert(t, pool.Close() == nil)
+
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("goroutines did not exit after pool.Close")
+		}
+		test.Assert(t, unexpectedErrs.Load() == 0, "unexpected errs:", unexpectedErrs.Load())
+	})
+	t.Run("Dump() during concurrent Get", func(t *testing.T) {
+		// Observability hit while traffic is in-flight. Dump must not
+		// panic and its output must remain JSON-serializable.
+		pool := newMockConnPool(nil)
+		t.Cleanup(func() { pool.Close() })
+		opt := newMockConnOption()
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+		var getErrs, dumpNilCount, dumpMarshalErrs atomic.Int32
+		// Concurrent Get goroutines. Each loop iteration closes its stream
+		// to release the per-transport stream quota.
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+				addr := mockAddr0
+				if idx%2 == 0 {
+					addr = mockAddr1
+				}
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						if err := getAndReleaseStream(pool, ctx, "tcp", addr, opt); err != nil {
+							getErrs.Add(1)
+						}
+					}
+				}
+			}(i)
+		}
+
+		// Concurrent Dump + Marshal.
+		var dumpCount atomic.Int32
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						dump := pool.Dump()
+						if dump == nil {
+							dumpNilCount.Add(1)
+							continue
+						}
+						if _, err := sonic.Marshal(dump); err != nil {
+							dumpMarshalErrs.Add(1)
+						}
+						dumpCount.Add(1)
+					}
+				}
+			}()
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+		wg.Wait()
+		test.Assert(t, dumpCount.Load() > 0)
+		test.Assert(t, dumpNilCount.Load() == 0, "Dump returned nil:", dumpNilCount.Load())
+		test.Assert(t, dumpMarshalErrs.Load() == 0, "Dump output not marshalable:", dumpMarshalErrs.Load())
+		test.Assert(t, getErrs.Load() == 0, "unexpected Get errors:", getErrs.Load())
+		t.Logf("dumped %d times", dumpCount.Load())
+	})
+	t.Run("Get() across multiple addresses", func(t *testing.T) {
+		// Many addresses, many goroutines per address.
+		// Verifies per-address transports are created independently without
+		// cross-address races.
+		pool := newMockConnPool(nil)
+		t.Cleanup(func() { pool.Close() })
+		opt := newMockConnOption()
+
+		addrCount := 8
+		perAddrGoroutines := 50
+
+		addrs := make([]string, addrCount)
+		for i := 0; i < addrCount; i++ {
+			addrs[i] = "127.0.0.1:3000" + strconv.Itoa(i)
+		}
+
+		var wg sync.WaitGroup
+		var successNum atomic.Int32
+		for _, addr := range addrs {
+			for j := 0; j < perAddrGoroutines; j++ {
+				wg.Add(1)
+				go func(a string) {
+					defer wg.Done()
+					ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+					if err := getAndReleaseStream(pool, ctx, "tcp", a, opt); err == nil {
+						successNum.Add(1)
+					}
+				}(addr)
+			}
+		}
+		wg.Wait()
+
+		test.Assert(t, successNum.Load() == int32(addrCount*perAddrGoroutines),
+			successNum.Load(), addrCount*perAddrGoroutines)
+
+		for _, addr := range addrs {
+			_, ok := pool.conns.Load(addr)
+			test.Assert(t, ok, addr)
+		}
+	})
+	t.Run("Get() after Clean()", func(t *testing.T) {
+		// Instance goes offline (Clean) then back online. New Get must
+		// build a fresh transports bag instead of reusing the closed one.
+		// Use the helper for both Gets so stream quota is released and
+		// pool.Close in t.Cleanup can drain cleanly.
+		pool := newMockConnPool(nil)
+		t.Cleanup(func() { pool.Close() })
+
+		opt := newMockConnOption()
+		ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+		test.Assert(t, getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt) == nil)
+
+		// Grab the old transports pointer to verify it is discarded.
+		oldV, ok := pool.conns.Load(mockAddr0)
+		test.Assert(t, ok)
+		oldTrans := oldV.(*transports)
+
+		pool.Clean("tcp", mockAddr0)
+		_, ok = pool.conns.Load(mockAddr0)
+		test.Assert(t, !ok)
+
+		// create a new one
+		test.Assert(t, getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt) == nil)
+		newV, ok := pool.conns.Load(mockAddr0)
+		test.Assert(t, ok)
+		test.Assert(t, newV.(*transports) != oldTrans)
+	})
+	t.Run("Get() after Close()", func(t *testing.T) {
+		pool := newMockConnPool(nil)
+
+		opt := newMockConnOption()
+		ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+		test.Assert(t, getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt) == nil)
+
+		_, ok := pool.conns.Load(mockAddr0)
+		test.Assert(t, ok)
+
+		test.Assert(t, pool.Close() == nil)
+
+		// After Close, all entries should be cleaned up.
+		_, ok = pool.conns.Load(mockAddr0)
+		test.Assert(t, !ok)
+
+		// Get after Close should not leak a new transports
+		err := getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt)
+		test.Assert(t, err != nil)
+		test.Assert(t, err == errConnPoolClosed, err)
+	})
+	t.Run("onClose() triggered under sustained Get()", func(t *testing.T) {
+		// Continuous connection churn (simulates flapping instances).
+		// Transports are killed via onClose while Gets keep coming;
+		// the pool must keep serving without unexpected error classes.
+		pool := newMockConnPool(nil)
+		t.Cleanup(func() { pool.Close() })
+		opt := newMockConnOption()
+
+		var getWG sync.WaitGroup
+		stop := make(chan struct{})
+
+		closerDone := make(chan struct{})
+		go func() {
+			defer close(closerDone)
+			ticker := time.NewTicker(2 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-ticker.C:
+					pool.conns.Range(func(_, v any) bool {
+						for _, tr := range v.(*transports).loadAll() {
+							if checkActive(tr) {
+								tr.Close(grpc.ErrConnClosing)
+								return false
+							}
+						}
+						return true
+					})
+				}
+			}
+		}()
+
+		// Get loop. Each iteration releases its stream quota.
+		var successNum, failNum, unexpectedErrs atomic.Int32
+		for i := 0; i < 20; i++ {
+			getWG.Add(1)
+			go func() {
+				defer getWG.Done()
+				ctx := newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional)
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						err := getAndReleaseStream(pool, ctx, "tcp", mockAddr0, opt)
+						if err == nil {
+							successNum.Add(1)
+							continue
+						}
+						failNum.Add(1)
+						if !isExpectedShutdownErr(err) {
+							unexpectedErrs.Add(1)
+							t.Error(err)
+						}
+					}
+				}
+			}()
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+		<-closerDone
+		getWG.Wait()
+
+		test.Assert(t, successNum.Load() > 0)
+		test.Assert(t, unexpectedErrs.Load() == 0, unexpectedErrs.Load())
+		t.Logf("success=%d fail=%d", successNum.Load(), failNum.Load())
+	})
 }
 
 func TestReleaseConn(t *testing.T) {
@@ -85,7 +511,7 @@ func TestReleaseConn(t *testing.T) {
 	shortCP.connOpts.ShortConn = true
 	defer shortCP.Close()
 
-	conn, err := shortCP.Get(newMockCtxWithRPCInfo(serviceinfo.StreamingNone), "tcp", mockAddr0, remote.ConnOption{Dialer: newMockDialerWithDialFunc(dialFunc1)})
+	conn, err := shortCP.Get(newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional), "tcp", mockAddr0, remote.ConnOption{Dialer: newMockDialerWithDialFunc(dialFunc1)})
 	// close stream to ensure no active stream on this connection,
 	// which will be released when put back to the connection pool and closed by GracefulClose
 	s := conn.(*clientConn).s
@@ -111,9 +537,76 @@ func TestReleaseConn(t *testing.T) {
 	longCP.connOpts.ShortConn = false
 	defer longCP.Close()
 
-	longConn, err := longCP.Get(newMockCtxWithRPCInfo(serviceinfo.StreamingNone), "tcp", mockAddr0, remote.ConnOption{Dialer: newMockDialerWithDialFunc(dialFunc2)})
+	longConn, err := longCP.Get(newMockCtxWithRPCInfo(serviceinfo.StreamingBidirectional), "tcp", mockAddr0, remote.ConnOption{Dialer: newMockDialerWithDialFunc(dialFunc2)})
 	longConn.Close()
 	test.Assert(t, err == nil, err)
 	longCP.Put(longConn)
 	test.Assert(t, atomic.LoadInt32(&closed2) == 0)
+}
+
+func Test_newTransport(t *testing.T) {
+	t.Run("tls handshake failure closes dialed conn", func(t *testing.T) {
+		var closed atomic.Int32
+		dialFunc := func(network, address string, timeout time.Duration) (net.Conn, error) {
+			return &mockConn{
+				RemoteAddrFunc: func() net.Addr { return utils.NewNetAddr("tcp", address) },
+				WriteFunc:      func(b []byte) (int, error) { return len(b), nil },
+				ReadFunc:       func(b []byte) (int, error) { return 0, errors.New("not a TLS server") },
+				CloseFunc:      func() error { closed.Add(1); return nil },
+			}, nil
+		}
+		dialer := newMockDialerWithDialFunc(dialFunc)
+		opts := grpc.ConnectOptions{
+			TLSConfig:       &tls.Config{InsecureSkipVerify: true},
+			WriteBufferSize: defaultMockReadWriteBufferSize,
+			ReadBufferSize:  defaultMockReadWriteBufferSize,
+		}
+
+		tr, err := newTransport("test", dialer, "tcp", mockAddr0, time.Second, opts, nil, nil)
+		test.Assert(t, err != nil)
+		test.Assert(t, tr == nil)
+		test.Assert(t, closed.Load() == 1, closed.Load())
+	})
+	t.Run("flush failed during init closes conn", func(t *testing.T) {
+		var closed atomic.Int32
+		var writeCount atomic.Int32
+		closeCh := make(chan struct{})
+		dialFunc := func(network, address string, timeout time.Duration) (net.Conn, error) {
+			return &mockConn{
+				RemoteAddrFunc: func() net.Addr { return utils.NewNetAddr("tcp", address) },
+				ReadFunc: func(b []byte) (int, error) {
+					<-closeCh // block until conn is closed
+					return 0, errors.New("closed")
+				},
+				WriteFunc: func(b []byte) (int, error) {
+					if writeCount.Add(1) >= 2 {
+						return 0, errors.New("mock flush error")
+					}
+					return len(b), nil
+				},
+				CloseFunc: func() error {
+					closed.Add(1)
+					select {
+					case <-closeCh:
+					default:
+						close(closeCh)
+					}
+					return nil
+				},
+			}, nil
+		}
+		dialer := newMockDialerWithDialFunc(dialFunc)
+
+		_, err := newTransport("test", dialer, "tcp", mockAddr0, time.Second, slotTestOpts, nil, nil)
+		test.Assert(t, err != nil)
+		// newHTTP2Client calls t.Close(err) on Flush failure, which calls conn.Close().
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if closed.Load() >= 1 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		test.Assert(t, closed.Load() == 1, closed.Load())
+	})
 }

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -115,9 +115,9 @@ type http2Client struct {
 	// This is checked before attempting to signal the above condition
 	// variable.
 	kpDormant bool
-	onGoAway  func(GoAwayReason)
-	// Important: when onClose is invoked, the http2Client.mu is held
-	onClose func()
+	onGoAway  func(context.Context, ClientTransport, GoAwayReason)
+	// when onClose is invoked, the http2Client.mu is not held
+	onClose func(context.Context, ClientTransport, error)
 
 	bufferPool *bufferPool
 
@@ -128,7 +128,7 @@ type http2Client struct {
 // and starts to receive messages on it. Non-nil error returns if construction
 // fails.
 func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
-	remoteService string, onGoAway func(GoAwayReason), onClose func(),
+	cfg ClientConfig,
 ) (_ *http2Client, err error) {
 	scheme := "http"
 	if opts.TLSConfig != nil {
@@ -196,8 +196,6 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 		maxConcurrentStreams:  defaultMaxStreamsClient,
 		streamQuota:           defaultMaxStreamsClient,
 		streamsQuotaAvailable: make(chan struct{}, 1),
-		onGoAway:              onGoAway,
-		onClose:               onClose,
 		bufferPool:            newBufferPool(),
 		traceCtl:              opts.TraceController,
 	}
@@ -214,10 +212,26 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 	}
 	t.loopy = newLoopyWriter(clientSide, t.framer, t.controlBuf, t.bdpEst)
 	task := &closeStreamTask{t: t}
-	t.onClose = func() {
-		onClose()
-		// when http2Client has been closed, remove this task
-		ticker.Delete(task)
+	t.onGoAway = func(ctx context.Context, trans ClientTransport, reason GoAwayReason) {
+		defer func() {
+			if r := recover(); r != nil {
+				klog.Warnf("KITEX: gRPC http2Client onGoAway panic, goaway reason: %+v, recover reason: %+v", reason, r)
+			}
+			// Unlike onClose, onGoAway must not remove the task when it is invoked.
+			// If there are still active streams at that point, they still need to be handled by task.
+			// We will check in task.Tick() whether the http2Client is in a draining state and the number of active streams is 0;
+			// if so, remove this task directly.
+		}()
+		cfg.OnGoAway(ctx, trans, reason)
+	}
+	t.onClose = func(ctx context.Context, trans ClientTransport, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				klog.Warnf("KITEX: gRPC http2Client onClose panic, err: %+v, recover reason: %+v", err, r)
+			}
+			ticker.Delete(task)
+		}()
+		cfg.OnClose(ctx, trans, err)
 	}
 	ticker.Add(task)
 
@@ -230,12 +244,12 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 			return nil
 		})
 	} else {
-		gofunc.RecoverGoFuncWithInfo(ctx, t.reader, gofunc.NewBasicInfo(remoteService, conn.RemoteAddr().String()))
+		gofunc.RecoverGoFuncWithInfo(ctx, t.reader, gofunc.NewBasicInfo(cfg.RemoteService, conn.RemoteAddr().String()))
 	}
 
 	if t.keepaliveEnabled {
 		t.kpDormancyCond = sync.NewCond(&t.mu)
-		gofunc.RecoverGoFuncWithInfo(ctx, t.keepalive, gofunc.NewBasicInfo(remoteService, conn.RemoteAddr().String()))
+		gofunc.RecoverGoFuncWithInfo(ctx, t.keepalive, gofunc.NewBasicInfo(cfg.RemoteService, conn.RemoteAddr().String()))
 	}
 
 	// Send connection preface to server.
@@ -274,6 +288,8 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 	}
 
 	if err := t.framer.writer.Flush(); err != nil {
+		err = connectionErrorf(true, err, "transport: failed to Flush initial settings frame: %v", err)
+		t.Close(err)
 		return nil, err
 	}
 	gofunc.RecoverGoFuncWithInfo(ctx, func() {
@@ -287,7 +303,7 @@ func newHTTP2Client(ctx context.Context, conn net.Conn, opts ConnectOptions,
 			t.conn.Close()
 		}
 		close(t.writerDone)
-	}, gofunc.NewBasicInfo(remoteService, conn.RemoteAddr().String()))
+	}, gofunc.NewBasicInfo(cfg.RemoteService, conn.RemoteAddr().String()))
 
 	return t, nil
 }
@@ -301,6 +317,8 @@ type closeStreamTask struct {
 func (task *closeStreamTask) Tick() {
 	trans := task.t
 	trans.mu.Lock()
+	state := trans.state
+	activeStreamsNum := len(trans.activeStreams)
 	for _, stream := range trans.activeStreams {
 		select {
 		// judge whether stream has been canceled
@@ -311,6 +329,13 @@ func (task *closeStreamTask) Tick() {
 	}
 	trans.mu.Unlock()
 
+	// http2Client has invoked GracefulClose() or received GoAway Frame, and there are no active streams
+	// remove current task from global ticker so that this http2Client could be GCed.
+	// Note: ticker.Delete may also be called by onClose's defer. This is safe because
+	// SharedTicker.Delete is idempotent — deleting an already-removed key is a map no-op.
+	if state == draining && activeStreamsNum == 0 {
+		ticker.Delete(task)
+	}
 	for i, stream := range task.toCloseStreams {
 		if !trans.casStreamDone(stream) {
 			// stream has been closed.
@@ -703,21 +728,12 @@ func (t *http2Client) doCloseStream(s *Stream, err error, rst bool, rstCode http
 // Close kicks off the shutdown process of the transport. This should be called
 // only once on a transport. Once it is called, the transport should not be
 // accessed any more.
-//
-// This method blocks until the addrConn that initiated this transport is
-// re-connected. This happens because t.onClose() begins reconnect logic at the
-// addrConn level and blocks until the addrConn is successfully connected.
 func (t *http2Client) Close(err error) error {
 	t.mu.Lock()
 	// Make sure we only Close once.
 	if t.state == closing {
 		t.mu.Unlock()
 		return nil
-	}
-	// Call t.onClose before setting the state to closing to prevent the client
-	// from attempting to create new streams ASAP.
-	if t.onClose != nil {
-		t.onClose()
 	}
 	t.state = closing
 	streams := t.activeStreams
@@ -728,6 +744,9 @@ func (t *http2Client) Close(err error) error {
 		t.kpDormancyCond.Signal()
 	}
 	t.mu.Unlock()
+	// Invoke onClose after releasing t.mu.
+	// Avoid deadlock caused by onClose attempting to acquire t.mu (for example, by calling http2Client.IsActive to get the connection state).
+	t.onClose(t.ctx, t, err)
 	t.controlBuf.finish(err)
 	t.cancel()
 	cErr := t.conn.Close()
@@ -1020,6 +1039,8 @@ func (t *http2Client) handleGoAway(f *grpcframe.GoAwayFrame) {
 	// streams. While in case of second GoAway we close all streams created after
 	// the GoAwayId. This way streams that were in-flight while the GoAway from
 	// server was being sent don't get killed.
+	var invokeOnGoAway bool
+	var goAwayReason GoAwayReason
 	select {
 	case <-t.goAway: // t.goAway has been closed (i.e.,multiple GoAways).
 		// If there are multiple GoAways the first one should always have an ID greater than the following ones.
@@ -1030,15 +1051,11 @@ func (t *http2Client) handleGoAway(f *grpcframe.GoAwayFrame) {
 		}
 	default:
 		t.setGoAwayReason(f)
+		goAwayReason = t.goAwayReason
 		close(t.goAway)
 		defer t.controlBuf.put(&incomingGoAway{}) // Defer as t.mu is currently held.
-		// Notify the clientconn about the GOAWAY before we set the state to
-		// draining, to allow the client to stop attempting to create streams
-		// before disallowing new streams on this connection.
 		if t.state != draining {
-			if t.onGoAway != nil {
-				t.onGoAway(t.goAwayReason)
-			}
+			invokeOnGoAway = true
 			t.state = draining
 		}
 	}
@@ -1052,6 +1069,11 @@ func (t *http2Client) handleGoAway(f *grpcframe.GoAwayFrame) {
 	active := len(t.activeStreams)
 	if active <= 0 {
 		t.mu.Unlock()
+		// Invoke onGoAway after releasing t.mu.
+		// Avoid deadlock caused by onGoAway attempting to acquire t.mu (for example, by calling http2Client.IsActive to get the connection state).
+		if invokeOnGoAway {
+			t.onGoAway(t.ctx, t, goAwayReason)
+		}
 		t.Close(connectionErrorfWithIgnorable(true, nil, "received goaway and there are no active streams"))
 		return
 	}
@@ -1065,6 +1087,12 @@ func (t *http2Client) handleGoAway(f *grpcframe.GoAwayFrame) {
 		}
 	}
 	t.mu.Unlock()
+
+	// Invoke onGoAway after releasing t.mu.
+	// Avoid deadlock caused by onGoAway attempting to acquire t.mu (for example, by calling http2Client.IsActive to get the connection state).
+	if invokeOnGoAway {
+		t.onGoAway(t.ctx, t, goAwayReason)
+	}
 
 	// we should not access controlBuf with t.mu held since it will cause deadlock.
 	// Pls refer to checkForStreamQuota in NewStream, it gets the controlbuf.mu and

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -653,6 +653,13 @@ type ConnectOptions struct {
 	ReuseWriteBufferConfig ReuseWriteBufferConfig
 }
 
+// ClientConfig consists of all the helper configurations to establish a client transport.
+type ClientConfig struct {
+	RemoteService string
+	OnGoAway      func(ctx context.Context, trans ClientTransport, reason GoAwayReason)
+	OnClose       func(ctx context.Context, trans ClientTransport, err error)
+}
+
 // NewServerTransport creates a ServerTransport with conn or non-nil error
 // if it fails.
 func NewServerTransport(ctx context.Context, conn net.Conn, cfg *ServerConfig) (ServerTransport, error) {
@@ -661,10 +668,54 @@ func NewServerTransport(ctx context.Context, conn net.Conn, cfg *ServerConfig) (
 
 // NewClientTransport establishes the transport with the required ConnectOptions
 // and returns it to the caller.
+//
+// Deprecated: please use NewClientTransportWithConfig.
+//
+// Note: the timing of the onClose and onGoAway callback has changed.
+// Historically onClose and onGoAway were invoked while http2Client.mu was held and
+// before the transport state was set to closing/draining.
+// They are now invoked after the state has been set to closing/draining
+// and after http2Client.mu has been released.
+//
+// Callers that rely on the old ordering (for example, to observe the transport in a "reachable" state from
+// inside onClose or onGoAway) must migrate to NewClientTransportWithConfig and update
+// their callbacks accordingly.
 func NewClientTransport(ctx context.Context, conn net.Conn, opts ConnectOptions,
 	remoteService string, onGoAway func(GoAwayReason), onClose func(),
 ) (ClientTransport, error) {
-	return newHTTP2Client(ctx, conn, opts, remoteService, onGoAway, onClose)
+	return newHTTP2Client(ctx, conn, opts, ClientConfig{
+		RemoteService: remoteService,
+		OnGoAway: func(ctx context.Context, trans ClientTransport, reason GoAwayReason) {
+			if onGoAway != nil {
+				onGoAway(reason)
+			}
+		},
+		OnClose: func(ctx context.Context, trans ClientTransport, err error) {
+			if onClose != nil {
+				onClose()
+			}
+		},
+	})
+}
+
+var (
+	noopOnClose  = func(ctx context.Context, trans ClientTransport, err error) {}
+	noopOnGoAway = func(ctx context.Context, trans ClientTransport, reason GoAwayReason) {}
+)
+
+// NewClientTransportWithConfig establishes the transport with the required ConnectOptions
+// and returns it to the caller.
+func NewClientTransportWithConfig(ctx context.Context, conn net.Conn, opts ConnectOptions,
+	cfg ClientConfig,
+) (ClientTransport, error) {
+	// OnClose and OnGoAway should not be nil
+	if cfg.OnClose == nil {
+		cfg.OnClose = noopOnClose
+	}
+	if cfg.OnGoAway == nil {
+		cfg.OnGoAway = noopOnGoAway
+	}
+	return newHTTP2Client(ctx, conn, opts, cfg)
 }
 
 // Options provides additional hints and information for message

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -790,7 +790,7 @@ func setUpWithOptions(t *testing.T, port int, serverConfig *ServerConfig, ht hTy
 	if err != nil {
 		t.Fatalf("failed to dial connection: %v", err)
 	}
-	ct, connErr := NewClientTransport(context.Background(), conn.(netpoll.Connection), copts, "", func(GoAwayReason) {}, func() {})
+	ct, connErr := NewClientTransportWithConfig(context.Background(), conn.(netpoll.Connection), copts, ClientConfig{})
 	if connErr != nil {
 		t.Fatalf("failed to create transport: %v", connErr)
 	}
@@ -831,7 +831,9 @@ func setUpWithNoPingServer(t *testing.T, copts ConnectOptions, connCh chan net.C
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
 	}
-	tr, err := NewClientTransport(context.Background(), conn.(netpoll.Connection), copts, "mockDestService", func(GoAwayReason) {}, func() {})
+	tr, err := NewClientTransportWithConfig(context.Background(), conn.(netpoll.Connection), copts, ClientConfig{
+		RemoteService: "mockDestService",
+	})
 	if err != nil {
 		// Server clean-up.
 		if conn, ok := <-connCh; ok {
@@ -848,7 +850,11 @@ func setUpWithOnGoAway(t *testing.T, port int, serverConfig *ServerConfig, ht hT
 	if err != nil {
 		t.Fatalf("failed to dial connection: %v", err)
 	}
-	ct, connErr := NewClientTransport(context.Background(), conn.(netpoll.Connection), copts, "", onGoAway, func() {})
+	ct, connErr := NewClientTransportWithConfig(context.Background(), conn.(netpoll.Connection), copts, ClientConfig{
+		OnGoAway: func(ctx context.Context, trans ClientTransport, reason GoAwayReason) {
+			onGoAway(reason)
+		},
+	})
 	if connErr != nil {
 		t.Fatalf("failed to create transport: %v", connErr)
 	}

--- a/pkg/remote/trans/nphttp2/mocks_test.go
+++ b/pkg/remote/trans/nphttp2/mocks_test.go
@@ -68,6 +68,12 @@ func (mc *mockNetpollConn) mockReader(b []byte) (n int, err error) {
 	if bLen == frameHeaderLen || bLen == defaultMockReadWriteBufferSize {
 		b = b[0:0]
 		if mc.queueCounter >= len(mc.mockQueue) {
+			if mc.blockOnQueueEmpty != nil {
+				mc.counterLock.Unlock()
+				<-mc.blockOnQueueEmpty
+				mc.counterLock.Lock()
+				return 0, errors.New("mock connection closed")
+			}
 			return
 		}
 		fr := mc.mockQueue[mc.queueCounter]
@@ -103,12 +109,34 @@ var (
 	headerPayload    = []byte{131, 134, 69, 147, 99, 21, 149, 146, 249, 105, 58, 248, 172, 41, 82, 91, 24, 220, 63, 88, 203, 69, 7, 65, 139, 234, 100, 151, 202, 243, 89, 89, 23, 144, 180, 159, 95, 139, 29, 117, 208, 98, 13, 38, 61, 76, 77, 101, 100, 122, 137, 234, 100, 151, 203, 29, 192, 184, 151, 7, 64, 2, 116, 101, 134, 77, 131, 53, 5, 177, 31, 64, 137, 154, 202, 200, 178, 77, 73, 79, 106, 127, 134, 125, 247, 217, 124, 86, 255, 64, 138, 65, 237, 176, 133, 89, 5, 179, 185, 136, 95, 139, 234, 100, 151, 202, 243, 89, 89, 23, 144, 180, 159, 64, 137, 65, 237, 176, 133, 90, 146, 166, 115, 201, 0, 64, 136, 242, 178, 82, 181, 7, 152, 210, 127, 164, 0, 130, 227, 96, 109, 150, 93, 105, 151, 157, 124, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 37, 150, 89, 64, 48, 54, 228, 146, 190, 16, 134, 50, 203, 64, 135, 65, 237, 176, 133, 88, 181, 119, 131, 174, 195, 201, 64, 143, 143, 210, 75, 73, 81, 58, 210, 154, 132, 150, 197, 147, 234, 178, 255, 131, 154, 202, 201, 64, 141, 144, 168, 73, 170, 26, 76, 122, 150, 65, 108, 238, 98, 23, 139, 234, 100, 151, 202, 243, 89, 89, 23, 144, 180, 159, 64, 141, 144, 168, 73, 170, 26, 76, 122, 150, 164, 169, 156, 242, 127, 134, 220, 63, 88, 203, 69, 7, 64, 138, 144, 168, 73, 170, 26, 76, 122, 150, 52, 132, 1, 45, 64, 138, 65, 237, 176, 133, 88, 148, 90, 132, 150, 207, 133, 144, 178, 142, 218, 19, 64, 135, 65, 237, 176, 133, 88, 210, 19, 1, 45}
 	mockHeaderFrame  = []byte{0, 1, 42, 1, 4, 0, 0, 0, 1}
 	mockSettingFrame = []byte{0, 0, 6, 4, 0, 0, 0, 0, 0}
+	// GOAWAY frame: length=8, type=7, flags=0, streamID=0.
+	// Payload: lastStreamID=0 (4 bytes) + errorCode=NO_ERROR (4 bytes).
+	mockGoAwayFrame   = []byte{0, 0, 8, 7, 0, 0, 0, 0, 0}
+	mockGoAwayPayload = []byte{0, 0, 0, 0, 0, 0, 0, 0}
 )
 
 func (mc *mockNetpollConn) mockSettingFrame() {
 	mc.counterLock.Lock()
 	defer mc.counterLock.Unlock()
 	mc.mockQueue = append(mc.mockQueue, mockFrame{mockSettingFrame, nil})
+}
+
+// mockSettingFrameWithMaxStreams queues a SETTINGS frame that sets
+// MaxConcurrentStreams to the given value (SettingID=0x3).
+func (mc *mockNetpollConn) mockSettingFrameWithMaxStreams(maxStreams uint32) {
+	mc.counterLock.Lock()
+	defer mc.counterLock.Unlock()
+	payload := []byte{
+		0, 3, // http2.SettingMaxConcurrentStreams
+		byte(maxStreams >> 24), byte(maxStreams >> 16), byte(maxStreams >> 8), byte(maxStreams),
+	}
+	mc.mockQueue = append(mc.mockQueue, mockFrame{mockSettingFrame, payload})
+}
+
+func (mc *mockNetpollConn) mockGoAwayFrame() {
+	mc.counterLock.Lock()
+	defer mc.counterLock.Unlock()
+	mc.mockQueue = append(mc.mockQueue, mockFrame{mockGoAwayFrame, mockGoAwayPayload})
 }
 
 func (mc *mockNetpollConn) mockMetaHeaderFrame() {
@@ -126,6 +154,14 @@ type mockNetpollConn struct {
 	queueCounter int
 	counterLock  sync.Mutex
 	reader       *mockNetpollReader
+	// autoStartReader: when true, SetOnRequest spawns a goroutine that
+	// immediately invokes the registered callback, simulating netpoll's
+	// event loop. Defaults to false to preserve existing test behavior.
+	autoStartReader bool
+	// blockOnQueueEmpty: when non-nil, the mock reader blocks on this channel
+	// instead of returning zero bytes when the frame queue is exhausted.
+	// This keeps the reader goroutine alive without triggering PROTOCOL_ERROR.
+	blockOnQueueEmpty chan struct{}
 }
 
 func (m *mockNetpollConn) Reader() netpoll.Reader {
@@ -153,6 +189,11 @@ func (m *mockNetpollConn) SetIdleTimeout(timeout time.Duration) error {
 }
 
 func (m *mockNetpollConn) SetOnRequest(on netpoll.OnRequest) error {
+	if m.autoStartReader {
+		go func() {
+			_ = on(context.Background(), m)
+		}()
+	}
 	return nil
 }
 

--- a/pkg/utils/sharedticker.go
+++ b/pkg/utils/sharedticker.go
@@ -38,7 +38,7 @@ func NewSharedTicker(interval time.Duration) *SharedTicker {
 }
 
 // NewSyncSharedTicker constructs a SharedTicker with specified interval.
-// The Tick method will run tasks synchronously.
+// The Tick method will run tasks synchronously without lock held.
 func NewSyncSharedTicker(interval time.Duration) *SharedTicker {
 	t := NewSharedTicker(interval)
 	t.sync = true


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
1. Restructure gRPC connection pool to use per-slot`atomic.Pointer`+`sync.Mutex`, replacing the old unsynchronized`[]ClientTransport`slice, fixing connection leak where closed/broken transports stayed in the pool indefinitely
2. Move`onClose`/`onGoAway` callback invocation after releasing`http2Client.mu`to prevent deadlock when callbacks call`IsActive()`
3. Add`isNew`guard +`isClosed()`check in singleflight to prevent re-inserting closed transports after `Clean()`/`Close()`
4. Fix resource leaks: close dialed conn on TLS handshake failure; call`t.Close(err)`on Flush failure during `newHTTP2Client`init
5. Fix`closeStreamTask`GC leak: remove task from global ticker when transport is draining with zero active streams
6. Add`NewClientTransportWithConfig`with new callback signatures (ctx, transport, err/reason); deprecate `NewClientTransport`

zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->