### PR TITLE
chore(queue): remove unused field tailVersion of Queue

### DIFF
--- a/pkg/event/queue.go
+++ b/pkg/event/queue.go
@@ -59,21 +59,15 @@ type Queue interface {
 
 // queue implements a fixed size Queue.
 type queue struct {
-	ring        []*Event
-	tail        uint32
-	tailVersion map[uint32]*uint32
-	mu          sync.RWMutex
+	ring []*Event
+	tail uint32
+	mu   sync.RWMutex
 }
 
 // NewQueue creates a queue with the given capacity.
 func NewQueue(cap int) Queue {
 	q := &queue{
-		ring:        make([]*Event, cap),
-		tailVersion: make(map[uint32]*uint32, cap),
-	}
-	for i := 0; i <= cap; i++ {
-		t := uint32(0)
-		q.tailVersion[uint32(i)] = &t
+		ring: make([]*Event, cap),
 	}
 	return q
 }
@@ -84,10 +78,6 @@ func (q *queue) Push(e *Event) {
 	defer q.mu.Unlock()
 
 	q.ring[q.tail] = e
-
-	newVersion := (*(q.tailVersion[q.tail])) + 1
-	q.tailVersion[q.tail] = &newVersion
-
 	q.tail = (q.tail + 1) % uint32(len(q.ring))
 }
 


### PR DESCRIPTION
#### What type of PR is this?
chore
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
在 https://github.com/cloudwego/kitex/pull/668 中修复 data race 问题时，tailVersion 字段已失去作用，未被及时删除。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->