### PR TITLE
optimize(rpctimeout): defense user provided non-compliant ctx with ctx.Done() triggered but ctx.Err() returning nil

### DIFF
--- a/client/rpctimeout.go
+++ b/client/rpctimeout.go
@@ -46,6 +46,11 @@ func makeTimeoutErr(ctx context.Context, start time.Time, timeout time.Duration)
 
 	needFineGrainedErrCode := rpctimeout.LoadGlobalNeedFineGrainedErrCode()
 	// cancel error
+	// Non-compliant parent context (Done() fired but Err() returned nil).
+	// check errUserProvidedContextNonCompliant returned by timeoutTask.Wait() directly
+	if errors.Is(ctx.Err(), errUserProvidedContextNonCompliant) {
+		return kerrors.ErrCanceledByBusiness.WithCause(fmt.Errorf("%s: %w", errMsg, ctx.Err()))
+	}
 	if ctx.Err() == context.Canceled {
 		if needFineGrainedErrCode {
 			return kerrors.ErrCanceledByBusiness.WithCause(errors.New(errMsg))

--- a/client/rpctimeout_pool.go
+++ b/client/rpctimeout_pool.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -28,6 +29,8 @@ import (
 	"github.com/cloudwego/kitex/pkg/profiler"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
+
+var errUserProvidedContextNonCompliant = errors.New("user-provided context does not comply with context.Context conventions, ctx.Done() triggered but ctx.Err() returns nil. please check your code")
 
 // timeoutPool is a worker pool for task with timeout
 type timeoutPool struct {
@@ -251,7 +254,7 @@ func (t *timeoutTask) Wait() (context.Context, error) {
 		return t.ctx, nil
 
 	case <-t.ctx.Context.Done(): // parent done
-		t.Cancel(t.ctx.Context.Err())
+		return t.handleParentDone()
 	case <-tm.C: // timeout
 		t.Cancel(context.DeadlineExceeded)
 	}
@@ -268,9 +271,36 @@ func (t *timeoutTask) waitNoTimeout() (context.Context, error) {
 		return t.ctx, nil
 
 	case <-t.ctx.Context.Done(): // parent done
-		t.Cancel(t.ctx.Context.Err())
-		return t.ctx, t.ctx.Err()
+		return t.handleParentDone()
 	}
+}
+
+// handleParentDone is called when t.ctx.Context.Done() fires (parent context cancelled or timed out).
+// It propagates the parent's cancellation to the internal timeoutContext via Cancel.
+//
+// Defense against non-compliant context implementations:
+//
+// The context.Context contract requires that after Done() is closed, Err() must return non-nil.
+// However, some custom implementations violate this — for example, a "WithoutCancel" wrapper
+// that embeds the parent (inheriting its Done channel) but overrides Err() to always return nil.
+// When such a context is used and Cancel receives nil, it becomes a no-op: the timeoutContext's
+// ch is never closed and Err() remains nil. This causes the following panic chain:
+//
+//  1. Wait() returns (ctx, nil) to rpcTimeoutMW → rpcTimeoutMW returns nil to Call()
+//  2. Call() sees err==nil → sets recycleRI=true → PutRPCInfo recycles the RPCInfo (zeroing ri.to)
+//  3. Worker goroutine is still running → accesses ri.To().ServiceName() → nil pointer panic
+//  4. The panic is caught by Run()'s recover → ClientPanicToErr also calls ri.To() → double panic
+//
+// To prevent this, we check parentErr before Cancel. If nil, we substitute a sentinel error.
+// This guarantees Cancel always receives a non-nil error, so the timeoutContext's ch is always
+// closed (unblocking downstream goroutines) and Err() always returns non-nil.
+func (t *timeoutTask) handleParentDone() (context.Context, error) {
+	parentErr := t.ctx.Context.Err()
+	if parentErr == nil {
+		parentErr = errUserProvidedContextNonCompliant
+	}
+	t.Cancel(parentErr)
+	return t.ctx, t.ctx.Err()
 }
 
 type timeoutContext struct {

--- a/client/rpctimeout_pool_test.go
+++ b/client/rpctimeout_pool_test.go
@@ -146,4 +146,98 @@ func TestTask(t *testing.T) {
 		test.Assert(t, err != nil && strings.Contains(err.Error(), "testpanic"), err)
 		test.Assert(t, ctx.Err() == context.Canceled, ctx.Err())
 	})
+
+	// Tests for handleParentDone defense against non-compliant context implementations.
+	// A non-compliant context has Done() that fires but Err() that returns nil,
+	// which would cause Wait() to return nil error → recycleRI=true → RPCInfo recycled
+	// while the worker goroutine is still running → nil pointer panic.
+
+	t.Run("NonCompliantParentCtxDone_NoTimeout", func(t *testing.T) {
+		// timeout=0 with non-compliant parent → exercises waitNoTimeout() path
+		parent := &nonCompliantCtx{
+			Context: context.Background(),
+			done:    make(chan struct{}),
+		}
+		started := make(chan struct{})
+		p := newTimeoutTask(parent, 0, nil, nil,
+			func(ctx context.Context, _, _ any) error {
+				close(started)
+				<-ctx.Done() // block until cancelled
+				return nil
+			})
+
+		go p.Run()
+		<-started          // ensure endpoint is running
+		close(parent.done) // simulate parent cancellation with nil Err()
+
+		wCtx, err := p.Wait()
+		test.Assert(t, err != nil)
+		test.Assert(t, errors.Is(err, errUserProvidedContextNonCompliant), err)
+		// timeoutContext.ch must be closed so downstream goroutines are unblocked
+		select {
+		case <-wCtx.Done():
+		default:
+			t.Fatal("expected wCtx.Done() to be closed")
+		}
+	})
+
+	t.Run("NonCompliantParentCtxDone_WithTimeout", func(t *testing.T) {
+		// timeout>0 with non-compliant parent → exercises Wait() timer-path select
+		parent := &nonCompliantCtx{
+			Context: context.Background(),
+			done:    make(chan struct{}),
+		}
+		started := make(chan struct{})
+		p := newTimeoutTask(parent, time.Second, nil, nil,
+			func(ctx context.Context, _, _ any) error {
+				close(started)
+				<-ctx.Done()
+				return nil
+			})
+
+		go p.Run()
+		<-started
+		close(parent.done)
+
+		wCtx, err := p.Wait()
+		test.Assert(t, err != nil)
+		test.Assert(t, errors.Is(err, errUserProvidedContextNonCompliant), err)
+		select {
+		case <-wCtx.Done():
+		default:
+			t.Fatal("expected wCtx.Done() to be closed")
+		}
+	})
+
+	t.Run("CompliantParentCanceled", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		started := make(chan struct{})
+		p := newTimeoutTask(parent, time.Second, nil, nil,
+			func(ctx context.Context, _, _ any) error {
+				close(started)
+				<-ctx.Done()
+				return nil
+			})
+
+		go p.Run()
+		<-started
+		cancel() // compliant cancel: Done() fires and Err() returns context.Canceled
+
+		wCtx, err := p.Wait()
+		test.Assert(t, err != nil)
+		test.Assert(t, errors.Is(err, context.Canceled), err)
+		test.Assert(t, errors.Is(wCtx.Err(), context.Canceled), wCtx.Err())
+	})
 }
+
+// nonCompliantCtx is a context that violates the context.Context contract:
+// Done() returns a closeable channel, but Err() always returns nil.
+// This simulates buggy custom context wrappers (e.g. a "WithoutCancel" that
+// embeds the parent — inheriting Done() — but overrides Err() to return nil).
+type nonCompliantCtx struct {
+	context.Context
+	done chan struct{}
+}
+
+func (c *nonCompliantCtx) Done() <-chan struct{} { return c.done }
+func (c *nonCompliantCtx) Err() error            { return nil }

--- a/client/rpctimeout_test.go
+++ b/client/rpctimeout_test.go
@@ -314,6 +314,64 @@ func Test_isBusinessTimeout(t *testing.T) {
 	}
 }
 
+// Test_rpcTimeoutMWNonCompliantCtx verifies that rpcTimeoutMW correctly handles a
+// non-compliant parent context (Done() fires but Err() returns nil).
+// The error must be returned directly as errUserProvidedContextNonCompliant,
+// NOT routed through makeTimeoutErr (which would produce a misleading "rpc timeout" message).
+func Test_rpcTimeoutMWNonCompliantCtx(t *testing.T) {
+	t.Run("WithRPCTimeout", func(t *testing.T) {
+		// RPCTimeout > 0 → Wait() enters timer-path select
+		parent := &nonCompliantCtx{
+			Context: context.Background(),
+			done:    make(chan struct{}),
+		}
+		nCtx := rpcinfo.NewCtxWithRPCInfo(parent, mockRPCInfo(time.Second))
+
+		started := make(chan struct{})
+		mw := rpcTimeoutMW(context.Background())
+		ep := mw(func(ctx context.Context, req, rsp interface{}) error {
+			close(started)
+			<-ctx.Done() // block until cancelled
+			return nil
+		})
+
+		go func() {
+			<-started
+			close(parent.done)
+		}()
+
+		err := ep(nCtx, nil, nil)
+		test.Assert(t, err != nil)
+		test.Assert(t, errors.Is(err, kerrors.ErrCanceledByBusiness), err)
+		test.Assert(t, strings.Contains(err.Error(), errUserProvidedContextNonCompliant.Error()), err)
+	})
+	t.Run("WithoutRPCTimeout", func(t *testing.T) {
+		parent := &nonCompliantCtx{
+			Context: context.Background(),
+			done:    make(chan struct{}),
+		}
+		nCtx := rpcinfo.NewCtxWithRPCInfo(parent, mockRPCInfo(0))
+
+		started := make(chan struct{})
+		mw := rpcTimeoutMW(context.Background())
+		ep := mw(func(ctx context.Context, req, rsp interface{}) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+
+		go func() {
+			<-started
+			close(parent.done)
+		}()
+
+		err := ep(nCtx, nil, nil)
+		test.Assert(t, err != nil)
+		test.Assert(t, errors.Is(err, kerrors.ErrCanceledByBusiness), err)
+		test.Assert(t, strings.Contains(err.Error(), errUserProvidedContextNonCompliant.Error()), err)
+	})
+}
+
 func BenchmarkRPCTimeoutMW(b *testing.B) {
 	s := rpcinfo.NewEndpointInfo("mockService", "mockMethod", nil, nil)
 	c := rpcinfo.NewRPCConfig()


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
- 背景 / 问题
当用户传入的 ctx 违反 context.Context 约定——Done() 已触发但 Err() 仍返回 nil（常见于自定义 "WithoutCancel" wrapper：embed 了父 context 导致继承其 Done()，却重写 Err() 为 nil）。会在 RPC 超时路径上引发 nil pointer panic：
1. timeoutTask.Wait() 中 Cancel(parentErr=nil) 成为空操作，timeoutContext.ch 未关闭、Err() 仍为 nil
2. Wait() 返回 (ctx, nil) → Call() 视为成功 → 设置 recycleRI=true → PutRPCInfo 回收 RPCInfo（ri.to 被清零）
3. worker goroutine 仍在运行 → 访问 ri.To().ServiceName() → nil panic
4. Run() 的 recover 中 ClientPanicToErr 再次调用 ri.To() → double panic

- 方案

1. handleParentDone 在 Cancel 前检查 parentErr，为 nil 时用哨兵错误 errUserProvidedContextNonCompliant 替代，保证 Cancel 始终收到非 nil 错误、ch 必然关闭
2. makeTimeoutErr 识别该哨兵错误，直接返回 ErrCanceledByBusiness 并附带清晰提示，避免误报为 "rpc timeout"
3. Wait() / waitNoTimeout() 统一走 handleParentDone，消除分支差异

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->