### PR TITLE
perf(gRPC): reduce object allocations on the gRPC client side for unified cancel scenarios

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -312,9 +312,15 @@ func (task *closeStreamTask) Tick() {
 	trans.mu.Unlock()
 
 	for i, stream := range task.toCloseStreams {
-		// uniformly converted to status error
-		sErr := ContextErr(stream.Context().Err())
-		trans.closeStream(stream, sErr, true, http2.ErrCodeCancel, status.Convert(sErr), nil, false)
+		if !trans.casStreamDone(stream) {
+			// stream has been closed.
+			// there is no need to do following processing to reduce objects allocation
+			task.toCloseStreams[i] = nil
+			continue
+		}
+		// uniformly converted to *status.Status and related error
+		st, stReused, sErr := contextStatusAndErr(stream.Context().Err())
+		trans.doCloseStream(stream, sErr, true, http2.ErrCodeCancel, st, stReused, nil)
 		task.toCloseStreams[i] = nil
 	}
 	task.toCloseStreams = task.toCloseStreams[:0]
@@ -612,23 +618,38 @@ func (t *http2Client) CloseStream(s *Stream, err error) {
 		}
 		klog.CtxInfof(s.ctx, "KITEX: stream closed by ctx canceled, err: %v, rstCode: %d"+sendRSTStreamFrameSuffix, err, rstCode)
 	}
-	t.closeStream(s, err, rst, rstCode, status.Convert(err), nil, false)
+	t.closeStream(s, err, rst, rstCode, status.Convert(err), nil)
 }
 
 // before invoking closeStream, pls do not hold the t.mu
 // because accessing the controlbuf while holding t.mu will cause a deadlock.
-func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.ErrCode, st *status.Status, mdata map[string][]string, eosReceived bool) {
-	// Set stream status to done.
+func (t *http2Client) closeStream(s *Stream, err error, rst bool, rstCode http2.ErrCode, st *status.Status, mdata map[string][]string) {
+	if !t.casStreamDone(s) {
+		return
+	}
+	t.doCloseStream(s, err, rst, rstCode, st, false, mdata)
+}
+
+// casStreamDone atomically marks s as done. Returns true if the caller wins the race
+// and should proceed with doCloseStream; false if another goroutine already closed it.
+func (t *http2Client) casStreamDone(s *Stream) bool {
 	if s.swapState(streamDone) == streamDone {
 		// If it was already done, return.  If multiple closeStream calls
 		// happen simultaneously, wait for the first to finish.
 		<-s.done
-		return
+		return false
 	}
+	return true
+}
+
+// doCloseStream performs the actual stream cleanup. Caller must have won casStreamDone first.
+func (t *http2Client) doCloseStream(s *Stream, err error, rst bool, rstCode http2.ErrCode, st *status.Status, reuseSt bool, mdata map[string][]string) {
 	// status and trailers can be updated here without any synchronization because the stream goroutine will
 	// only read it after it sees an io.EOF error from read or write and we'll write those errors
 	// only after updating this.
 	s.status = st
+	// if reuseSt == true, retrieves status by Stream.Status() must copy a new one
+	s.reuseStatus = reuseSt
 	if len(mdata) > 0 {
 		s.trailer = mdata
 	}
@@ -713,7 +734,7 @@ func (t *http2Client) Close(err error) error {
 
 	// Notify all active streams.
 	for _, s := range streams {
-		t.closeStream(s, err, false, http2.ErrCodeNo, status.New(codes.Unavailable, ErrConnClosing.Desc), nil, false)
+		t.closeStream(s, err, false, http2.ErrCodeNo, status.New(codes.Unavailable, ErrConnClosing.Desc), nil)
 	}
 	return cErr
 }
@@ -857,7 +878,7 @@ func (t *http2Client) handleData(f *grpcframe.DataFrame) {
 	if size > 0 {
 		if err := s.fc.onData(size); err != nil {
 			klog.CtxInfof(s.ctx, "KITEX: http2Client.handleData inflow control err: %v, rstCode: %d"+sendRSTStreamFrameSuffix, err, http2.ErrCodeFlowControl)
-			t.closeStream(s, io.EOF, true, http2.ErrCodeFlowControl, status.New(codes.Internal, err.Error()), nil, false)
+			t.closeStream(s, io.EOF, true, http2.ErrCodeFlowControl, status.New(codes.Internal, err.Error()), nil)
 			return
 		}
 		if f.Header().Flags.Has(http2.FlagDataPadded) {
@@ -878,7 +899,7 @@ func (t *http2Client) handleData(f *grpcframe.DataFrame) {
 	// The server has closed the stream without sending trailers.  Record that
 	// the read direction is closed, and set the status appropriately.
 	if f.FrameHeader.Flags.Has(http2.FlagDataEndStream) {
-		t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.New(codes.Internal, "server closed the stream without sending trailers"), nil, true)
+		t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.New(codes.Internal, "server closed the stream without sending trailers"), nil)
 	}
 }
 
@@ -909,7 +930,7 @@ func (t *http2Client) handleRSTStream(f *http2.RSTStreamFrame) {
 	} else {
 		msg = fmt.Sprintf("stream terminated by RST_STREAM with error code: %v", f.ErrCode)
 	}
-	t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.New(statusCode, msg), nil, false)
+	t.closeStream(s, io.EOF, false, http2.ErrCodeNo, status.New(statusCode, msg), nil)
 }
 
 func (t *http2Client) handleSettings(f *grpcframe.SettingsFrame, isFirst bool) {
@@ -1049,7 +1070,7 @@ func (t *http2Client) handleGoAway(f *grpcframe.GoAwayFrame) {
 	// Pls refer to checkForStreamQuota in NewStream, it gets the controlbuf.mu and
 	// wants to get the t.mu.
 	for _, stream := range unprocessedStream {
-		t.closeStream(stream, errStreamDrain, false, http2.ErrCodeNo, statusGoAway, nil, false)
+		t.closeStream(stream, errStreamDrain, false, http2.ErrCodeNo, statusGoAway, nil)
 	}
 }
 
@@ -1094,7 +1115,7 @@ func (t *http2Client) operateHeaders(frame *grpcframe.MetaHeadersFrame) {
 		// As specified by gRPC over HTTP2, a HEADERS frame (and associated CONTINUATION frames) can only appear at the start or end of a stream. Therefore, second HEADERS frame must have EOS bit set.
 		st := status.New(codes.Internal, "a HEADERS frame cannot appear in the middle of a stream")
 		klog.CtxInfof(s.ctx, "KITEX: http2Client.operateHeaders received HEADERS frame in the middle of a stream, rstCode: %d"+sendRSTStreamFrameSuffix, http2.ErrCodeProtocol)
-		t.closeStream(s, st.Err(), true, http2.ErrCodeProtocol, st, nil, false)
+		t.closeStream(s, st.Err(), true, http2.ErrCodeProtocol, st, nil)
 		return
 	}
 
@@ -1103,7 +1124,7 @@ func (t *http2Client) operateHeaders(frame *grpcframe.MetaHeadersFrame) {
 	state.data.isGRPC = !initialHeader
 	if err := state.decodeHeader(frame); err != nil {
 		klog.CtxInfof(s.ctx, "KITEX: http2Client.operateHeaders decode HEADERS frame failed, err: %v, rstCode: %d"+sendRSTStreamFrameSuffix, err, http2.ErrCodeProtocol)
-		t.closeStream(s, err, true, http2.ErrCodeProtocol, status.Convert(err), nil, endStream)
+		t.closeStream(s, err, true, http2.ErrCodeProtocol, status.Convert(err), nil)
 		return
 	}
 
@@ -1134,7 +1155,7 @@ func (t *http2Client) operateHeaders(frame *grpcframe.MetaHeadersFrame) {
 	// if client received END_STREAM from server while stream was still active, send RST_STREAM
 	rst := s.getState() == streamActive
 	s.SetBizStatusErr(state.bizStatusErr())
-	t.closeStream(s, io.EOF, rst, http2.ErrCodeNo, state.status(), state.data.mdata, true)
+	t.closeStream(s, io.EOF, rst, http2.ErrCodeNo, state.status(), state.data.mdata)
 }
 
 // reader runs as a separate goroutine in charge of reading data from network
@@ -1188,7 +1209,7 @@ func (t *http2Client) reader() {
 						msg = err.Error()
 					}
 					klog.CtxInfof(s.ctx, "KITEX: http2Client.reader encountered http2.StreamError: %v, rstCode: %d"+sendRSTStreamFrameSuffix, se, http2.ErrCodeProtocol)
-					t.closeStream(s, status.New(code, msg).Err(), true, http2.ErrCodeProtocol, status.New(code, msg), nil, false)
+					t.closeStream(s, status.New(code, msg).Err(), true, http2.ErrCodeProtocol, status.New(code, msg), nil)
 				}
 				continue
 			} else {

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -278,6 +278,7 @@ type Stream struct {
 	// On client-side it is the status error received from the server.
 	// On server-side it is unused.
 	status       *status.Status
+	reuseStatus  bool
 	bizStatusErr kerrors.BizStatusErrorIface
 
 	bytesReceived uint32 // indicates whether any bytes have been received on this stream
@@ -454,6 +455,11 @@ func (s *Stream) Method() string {
 // Status can be read safely only after the stream has ended,
 // that is, after Done() is closed.
 func (s *Stream) Status() *status.Status {
+	// When the internal status is a shared pre-defined instance (reuseStatus == true),
+	// a deep copy is returned to prevent callers from mutating the shared object via AppendMessage().
+	if s.reuseStatus && s.status != nil {
+		return status.FromProto(s.status.Proto())
+	}
 	return s.status
 }
 
@@ -875,19 +881,46 @@ const (
 	GoAwayTooManyPings GoAwayReason = 2
 )
 
+var (
+	statusDeadlineExceeded = status.New(codes.DeadlineExceeded, context.DeadlineExceeded.Error())
+	errDeadlineExceeded    = statusDeadlineExceeded.Err()
+	statusCanceled         = status.New(codes.Canceled, context.Canceled.Error())
+	errCanceled            = statusCanceled.Err()
+)
+
 // ContextErr converts the error from context package into a status error.
 func ContextErr(err error) error {
 	switch err {
 	case context.DeadlineExceeded:
-		return status.New(codes.DeadlineExceeded, err.Error()).Err()
+		return errDeadlineExceeded
 	case context.Canceled:
-		return status.New(codes.Canceled, err.Error()).Err()
+		return errCanceled
 	}
 	statusErr, ok := err.(*status.Error)
 	if ok { // only returned by contextWithCancelReason
 		return statusErr
 	}
 	return status.Errorf(codes.Internal, "Unexpected error from context packet: %v", err)
+}
+
+// contextStatusAndErr converts err to (*status.Status, reused, error).
+// For context.Canceled / context.DeadlineExceeded, both the *status.Status and *status.Error
+// are pre-defined shared singletons (reused=true).
+// The caller must use reused flag to ensure Stream.Status() returns a copy instead of the shared instance,
+// preventing mutation via AppendMessage().
+func contextStatusAndErr(err error) (*status.Status, bool, error) {
+	switch err {
+	case context.DeadlineExceeded:
+		return statusDeadlineExceeded, true, errDeadlineExceeded
+	case context.Canceled:
+		return statusCanceled, true, errCanceled
+	}
+	stErr, ok := err.(*status.Error)
+	if ok {
+		return stErr.GRPCStatus(), false, stErr
+	}
+	st := status.Newf(codes.Internal, "Unexpected error from context packet: %v", err)
+	return st, false, st.Err()
 }
 
 // IsStreamDoneErr returns true if the error indicates that the stream is done.

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -2607,3 +2607,214 @@ func TestStreamGetHeaderValid(t *testing.T) {
 	close(s.headerChan)
 	test.Assert(t, s.getHeaderValid() == s.headerValid)
 }
+
+func Test_contextStatusAndErr(t *testing.T) {
+	t.Run("predefined status and err", func(t *testing.T) {
+		// canceled
+		st, stReused, err := contextStatusAndErr(context.Canceled)
+		test.Assert(t, st.Code() == codes.Canceled, st)
+		test.Assert(t, st.Message() == context.Canceled.Error(), st)
+		test.Assert(t, stReused)
+		test.Assert(t, err == errCanceled, err)
+		// reuse
+		st1, stReused1, err1 := contextStatusAndErr(context.Canceled)
+		test.Assert(t, st1 == st, st1)
+		test.Assert(t, stReused1)
+		test.Assert(t, err1 == err, err1)
+
+		// deadline exceeded
+		st2, stReused2, err2 := contextStatusAndErr(context.DeadlineExceeded)
+		test.Assert(t, st2.Code() == codes.DeadlineExceeded, st2)
+		test.Assert(t, st2.Message() == context.DeadlineExceeded.Error(), st2)
+		test.Assert(t, stReused2)
+		test.Assert(t, err2 == errDeadlineExceeded, err2)
+		// reuse
+		st3, stReused3, err3 := contextStatusAndErr(context.DeadlineExceeded)
+		test.Assert(t, st3 == st2, st3)
+		test.Assert(t, stReused3)
+		test.Assert(t, err3 == errDeadlineExceeded, err3)
+	})
+	t.Run("*status.Error", func(t *testing.T) {
+		stErr := status.Err(codes.Internal, "test")
+		st, stReused, err := contextStatusAndErr(stErr)
+		test.Assert(t, st.Code() == codes.Internal, st)
+		test.Assert(t, st.Message() == "test", st)
+		test.Assert(t, !stReused)
+		test.Assert(t, err == stErr, err)
+
+		st1, stReused1, err1 := contextStatusAndErr(stErr)
+		// create a new *status.Status
+		test.Assert(t, st1 != st, st1)
+		test.Assert(t, st1.Code() == codes.Internal, st1)
+		test.Assert(t, st1.Message() == "test", st1)
+		test.Assert(t, !stReused1)
+		test.Assert(t, err1 == err, err1)
+	})
+	t.Run("non *status.Error", func(t *testing.T) {
+		testErr := errors.New("test")
+		st, stReused, err := contextStatusAndErr(testErr)
+		test.Assert(t, st.Code() == codes.Internal, st)
+		test.Assert(t, strings.Contains(st.Message(), testErr.Error()), st)
+		test.Assert(t, !stReused)
+		test.Assert(t, strings.Contains(err.Error(), testErr.Error()), err)
+
+		st1, stReused1, err1 := contextStatusAndErr(testErr)
+		// create new *status.Status and *status.Error
+		test.Assert(t, st1 != st, st1)
+		test.Assert(t, st1.Code() == codes.Internal, st1)
+		test.Assert(t, strings.Contains(st1.Message(), testErr.Error()), st1)
+		test.Assert(t, !stReused1)
+		test.Assert(t, err1 != err, err1)
+		test.Assert(t, strings.Contains(err1.Error(), testErr.Error()), err1)
+	})
+}
+
+func Test_reuseStatus(t *testing.T) {
+	origCanceledMsg := statusCanceled.Message()
+	origDeadlineMsg := statusDeadlineExceeded.Message()
+
+	// reuseStatus=true: Stream.Status() should return a copy, AppendMessage must not pollute singleton
+	for _, tc := range []struct {
+		name    string
+		st      *status.Status
+		origMsg string
+	}{
+		{"Canceled", statusCanceled, origCanceledMsg},
+		{"DeadlineExceeded", statusDeadlineExceeded, origDeadlineMsg},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Stream{status: tc.st, reuseStatus: true}
+			got := s.Status()
+			test.Assert(t, got != tc.st, "Status() should return a copy, not the singleton")
+			test.Assert(t, got.Code() == tc.st.Code())
+			test.Assert(t, got.Message() == tc.origMsg)
+
+			// mutate the copy
+			got.AppendMessage("extra")
+			// singleton must remain unchanged
+			test.Assert(t, tc.st.Message() == tc.origMsg, tc.st.Message())
+		})
+	}
+
+	// reuseStatus=false: Stream.Status() returns the original pointer
+	t.Run("non-reuse", func(t *testing.T) {
+		st := status.New(codes.Internal, "test")
+		s := &Stream{status: st, reuseStatus: false}
+		got := s.Status()
+		test.Assert(t, got == st, "Status() should return the original pointer when reuseStatus=false")
+	})
+
+	// nil defense: reuseStatus=true but status is nil
+	t.Run("nil-status", func(t *testing.T) {
+		s := &Stream{status: nil, reuseStatus: true}
+		got := s.Status()
+		test.Assert(t, got == nil, got)
+	})
+}
+
+// Benchmark_closeStreamTask_Tick measures per-Tick allocations on the client-side
+// unified cancel cleanup path, covering the full casStreamDone + contextStatusAndErr
+// + doCloseStream pipeline.
+// Each iteration includes stream state reset (fixed overhead);
+// any regression in contextStatusAndErr or doCloseStream will show as an allocs/op increase.
+func Benchmark_closeStreamTask_Tick(b *testing.B) {
+	canceledCtx := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+	deadlineCtx := func() context.Context {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		cancel()
+		return ctx
+	}
+	statusErrCtx := func() context.Context {
+		parent, cancel := context.WithCancel(context.Background())
+		ctx, cancelReason := newContextWithCancelReason(parent, cancel)
+		cancelReason(status.Err(codes.Canceled, "user reason"))
+		return ctx
+	}
+
+	cases := []struct {
+		name    string
+		ctxFunc func() context.Context
+	}{
+		{"Canceled", canceledCtx},
+		{"DeadlineExceeded", deadlineCtx},
+		{"StatusError", statusErrCtx},
+	}
+	for _, c := range cases {
+		for _, n := range []int{100, 1000} {
+			b.Run(fmt.Sprintf("%s/streams=%d", c.name, n), func(b *testing.B) {
+				clientDone := make(chan struct{})
+				ct := &http2Client{
+					activeStreams:         make(map[uint32]*Stream, n),
+					controlBuf:            newControlBuffer(clientDone),
+					streamsQuotaAvailable: make(chan struct{}, 1),
+				}
+				streams := make([]*Stream, 0, n)
+				for i := 0; i < n; i++ {
+					s := &Stream{
+						id:         uint32(i + 1),
+						ctx:        c.ctxFunc(),
+						done:       make(chan struct{}),
+						buf:        newRecvBuffer(),
+						headerChan: make(chan struct{}),
+					}
+					ct.activeStreams[s.id] = s
+					streams = append(streams, s)
+				}
+				task := &closeStreamTask{t: ct}
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					task.Tick()
+
+					// Reset stream state for next iteration.
+					// These reset allocations are included in allocs/op as fixed overhead.
+					ct.controlBuf = newControlBuffer(clientDone)
+					for _, s := range streams {
+						s.swapState(streamActive)
+						s.done = make(chan struct{})
+						s.buf = newRecvBuffer()
+						s.headerChan = make(chan struct{})
+						s.headerChanClosed = 0
+					}
+				}
+			})
+		}
+	}
+
+	// AlreadyClosed: all streams are pre-marked as streamDone with closed done channel.
+	// casStreamDone returns false for every stream, so contextStatusAndErr and doCloseStream
+	// are skipped entirely. This verifies zero extra allocations on the skip path.
+	for _, n := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("AlreadyClosed/streams=%d", n), func(b *testing.B) {
+			ct := &http2Client{
+				activeStreams: make(map[uint32]*Stream, n),
+			}
+			for i := 0; i < n; i++ {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				s := &Stream{
+					id:   uint32(i + 1),
+					ctx:  ctx,
+					done: make(chan struct{}),
+				}
+				s.swapState(streamDone)
+				close(s.done)
+				ct.activeStreams[s.id] = s
+			}
+			task := &closeStreamTask{t: ct}
+			// warm up so toCloseStreams capacity stops growing
+			task.Tick()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				task.Tick()
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
perf
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
- Split closeStream into casStreamDone and doCloseStream so that Tick can skip already-closed streams before constructing status/error objects.
- Introduce contextStatusAndErr returning reused singleton status and error for context.Canceled / context.DeadlineExceeded to avoid per-stream allocation.
- Guard shared status via Stream.reuseStatus flag and lazy deep copy in Stream.Status().
- Remove unused eosReceived parameter from client-side closeStream.
- Add reuseStatus defense tests and closeStreamTask
- Tick benchmarks.

zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->