### PR TITLE
chore(gRPC): deprecate gRPC GetServerConn

### DIFF
--- a/pkg/remote/trans/nphttp2/server_conn.go
+++ b/pkg/remote/trans/nphttp2/server_conn.go
@@ -63,6 +63,8 @@ func (c *serverConn) ReadFrame() (hdr, data []byte, err error) {
 
 // GetServerConn gets the GRPC Connection from server stream.
 // This function is only used in server handler for grpc unknown handler proxy: https://www.cloudwego.io/docs/kitex/tutorials/advanced-feature/grpcproxy/
+//
+// Deprecated: please refer to https://www.cloudwego.io/docs/kitex/tutorials/advanced-feature/proxy_application_development/ for easy-to-use new proxy application development
 func GetServerConn(st streaming.Stream) (GRPCConn, error) {
 	rawStream, ok := st.Context().Value(serverConnKey{}).(*serverStream)
 	if !ok {


### PR DESCRIPTION
#### What type of PR is this?
chore
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
新版的 [unknown handler](https://www.cloudwego.io/docs/kitex/tutorials/advanced-feature/proxy_application_development/) 可以完全取代旧版的 [grpcproxy](https://www.cloudwego.io/docs/kitex/tutorials/advanced-feature/grpcproxy/)，正式废弃`GetServerConn`

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->