### PR TITLE
fix(ttstream): server-side Tracer.Finish panic when OnStreamFinish failed

### DIFF
--- a/pkg/remote/trans/ttstream/server_handler.go
+++ b/pkg/remote/trans/ttstream/server_handler.go
@@ -233,16 +233,16 @@ func (t *svrTransHandler) OnStream(ctx context.Context, conn net.Conn, st *serve
 	}
 	if err = t.inkHdlFunc(stCtx, args, nil); err != nil {
 		// treat err thrown by invoking handler as the final err, ignore the err returned by OnStreamFinish
-		_, _ = t.OnStreamFinish(stCtx, st, err)
+		_ = t.OnStreamFinish(st, err)
 		return
 	}
 	if bizErr := ri.Invocation().BizStatusErr(); bizErr != nil {
 		// when biz err thrown, treat the err returned by OnStreamFinish as the final err
-		stCtx, err = t.OnStreamFinish(stCtx, st, bizErr)
+		err = t.OnStreamFinish(st, bizErr)
 		return
 	}
 	// there is no invoking handler err or biz err, treat the err returned by OnStreamFinish as the final err
-	stCtx, err = t.OnStreamFinish(stCtx, st, nil)
+	err = t.OnStreamFinish(st, nil)
 	return
 }
 
@@ -266,7 +266,7 @@ func (t *svrTransHandler) OnError(ctx context.Context, err error, conn net.Conn)
 	}
 }
 
-func (t *svrTransHandler) OnStreamFinish(ctx context.Context, ss streaming.ServerStream, err error) (context.Context, error) {
+func (t *svrTransHandler) OnStreamFinish(ss streaming.ServerStream, err error) error {
 	sst := ss.(*serverStream)
 	var exception error
 	if err != nil {
@@ -288,7 +288,7 @@ func (t *svrTransHandler) OnStreamFinish(ctx context.Context, ss streaming.Serve
 				})
 			}
 			if err != nil {
-				return nil, err
+				return err
 			}
 			exception = nil
 		case *thrift.ApplicationException:
@@ -301,10 +301,10 @@ func (t *svrTransHandler) OnStreamFinish(ctx context.Context, ss streaming.Serve
 	}
 	// server stream CloseSend will send the trailer with payload
 	if err = sst.CloseSend(exception); err != nil {
-		return nil, err
+		return err
 	}
 
-	return ctx, nil
+	return nil
 }
 
 func (t *svrTransHandler) OnMessage(ctx context.Context, args, result remote.Message) (context.Context, error) {

--- a/pkg/remote/trans/ttstream/server_handler_test.go
+++ b/pkg/remote/trans/ttstream/server_handler_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudwego/gopkg/protocol/thrift"
 	"github.com/cloudwego/gopkg/protocol/ttheader"
 	"github.com/cloudwego/netpoll"
 
@@ -413,5 +414,164 @@ func TestOnRead(t *testing.T) {
 		err = transHdl.OnRead(ctx, mockConn)
 		test.Assert(t, err == nil, err)
 		wg.Wait()
+	})
+}
+
+func TestOnStreamFinish(t *testing.T) {
+	hdl := &svrTransHandler{}
+
+	t.Run("no error", func(t *testing.T) {
+		var tl *Frame
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				if f.typ == trailerFrameType {
+					tl = f
+				}
+				return nil
+			},
+		})
+		err := hdl.OnStreamFinish(ss, nil)
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tl != nil)
+		test.Assert(t, len(tl.payload) == 0, tl)
+	})
+	t.Run("biz status error without extra", func(t *testing.T) {
+		var tl *Frame
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				if f.typ == trailerFrameType {
+					tl = f
+				}
+				return nil
+			},
+		})
+		err := hdl.OnStreamFinish(ss, kerrors.NewBizStatusError(10001, "biz error"))
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tl != nil)
+		test.Assert(t, tl.trailer["biz-status"] == "10001", tl.trailer)
+		test.Assert(t, tl.trailer["biz-message"] == "biz error", tl.trailer)
+		test.Assert(t, len(tl.payload) == 0, tl)
+	})
+	t.Run("biz status error with extra", func(t *testing.T) {
+		var tl *Frame
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				if f.typ == trailerFrameType {
+					tl = f
+				}
+				return nil
+			},
+		})
+		err := hdl.OnStreamFinish(ss, kerrors.NewBizStatusErrorWithExtra(10002, "biz extra", map[string]string{"k": "v"}))
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tl != nil)
+		test.Assert(t, tl.trailer["biz-status"] == "10002", tl.trailer)
+		test.Assert(t, tl.trailer["biz-message"] == "biz extra", tl.trailer)
+		test.Assert(t, tl.trailer["biz-extra"] != "", tl.trailer)
+		test.Assert(t, len(tl.payload) == 0, tl)
+	})
+	t.Run("thrift application exception", func(t *testing.T) {
+		var tl *Frame
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				if f.typ == trailerFrameType {
+					tl = f
+				}
+				return nil
+			},
+		})
+		ss.method = "testMethod"
+		err := hdl.OnStreamFinish(ss, thrift.NewApplicationException(thrift.UNKNOWN_METHOD, "unknown method"))
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tl != nil)
+		test.Assert(t, len(tl.payload) > 0, tl)
+	})
+	t.Run("ttstream exception", func(t *testing.T) {
+		var tl *Frame
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				if f.typ == trailerFrameType {
+					tl = f
+				}
+				return nil
+			},
+		})
+		ss.method = "testMethod"
+		err := hdl.OnStreamFinish(ss, errInternalCancel.newBuilder().withCause(errors.New("cancel")))
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tl != nil)
+		test.Assert(t, len(tl.payload) > 0, tl)
+	})
+	t.Run("generic error", func(t *testing.T) {
+		var tl *Frame
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				if f.typ == trailerFrameType {
+					tl = f
+				}
+				return nil
+			},
+		})
+		ss.method = "testMethod"
+		err := hdl.OnStreamFinish(ss, errors.New("some error"))
+		test.Assert(t, err == nil, err)
+		test.Assert(t, tl != nil)
+		test.Assert(t, len(tl.payload) > 0, tl)
+	})
+	t.Run("CloseSend write error", func(t *testing.T) {
+		writeErr := errors.New("write failed")
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				return writeErr
+			},
+		})
+		err := hdl.OnStreamFinish(ss, nil)
+		test.Assert(t, err != nil)
+	})
+	t.Run("finishTracer receives valid ctx when OnStreamFinish fails", func(t *testing.T) {
+		tracer := &mockTracer{}
+		traceCtl := &rpcinfo.TraceController{}
+		traceCtl.Append(tracer)
+
+		transHdl := &svrTransHandler{
+			opt: &remote.ServerOption{
+				SvcSearcher: mock_remote.NewDefaultSvcSearcher(),
+				InitOrResetRPCInfoFunc: func(_ rpcinfo.RPCInfo, _ net.Addr) rpcinfo.RPCInfo {
+					return rpcinfo.NewRPCInfo(
+						rpcinfo.EmptyEndpointInfo(),
+						rpcinfo.EmptyEndpointInfo(),
+						rpcinfo.NewServerInvocation(),
+						rpcinfo.NewRPCConfig(),
+						rpcinfo.NewRPCStats())
+				},
+				TracerCtl: traceCtl,
+			},
+		}
+		transHdl.SetInvokeHandleFunc(func(ctx context.Context, req, resp interface{}) error {
+			ri := rpcinfo.GetRPCInfo(ctx)
+			ri.Invocation().(rpcinfo.InvocationSetter).SetBizStatusErr(kerrors.NewBizStatusError(10000, "test"))
+			return nil
+		})
+
+		var tracerCtx context.Context
+		tracer.finishFunc = func(ctx context.Context) {
+			tracerCtx = ctx
+		}
+
+		ss := newTestServerStreamWithStreamWriter(mockStreamWriter{
+			writeFrameFunc: func(f *Frame) error {
+				return errors.New("write failed")
+			},
+		})
+		ss.method = mocks.MockStreamingMethod
+		ss.header = map[string]string{
+			ttheader.HeaderIDLServiceName: mocks.MockServiceName,
+		}
+
+		err := transHdl.OnStream(context.Background(), &mocks.Conn{}, ss)
+		test.Assert(t, err != nil)
+		test.Assert(t, tracerCtx != nil)
+		ri := rpcinfo.GetRPCInfo(tracerCtx)
+		test.Assert(t, ri != nil, tracerCtx)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
Fix a bug where `finishTracer` receives a nil context, causing panic when `OnStreamFinish` fails internally (e.g. `CloseSend` write error).
- Root cause: `OnStreamFinish` previously returned `(context.Context, error)`. On error paths it returned `(nil, err)`, and the caller `stCtx, err = t.OnStreamFinish(stCtx, st, bizErr)` overwrote `stCtx` to nil. The deferred `finishTracer(stCtx, ...)` then received a nil context.
- Fix: remove the unused `ctx` parameter and `context.Context` return value from `OnStreamFinish`, since it never uses or modifies the context. This structurally eliminates the possibility of `stCtx` being overwritten.
- Add unit tests for `OnStreamFinish` covering all error type branches (BizStatusError, ApplicationException, ttstream Exception, generic error, CloseSend failure).
- Add a regression test that calls `OnStream` with a failing writer to verify `finishTracer` always receives a valid context with rpcinfo.
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->