### PR TITLE
fix(remote): preserve caller info for default server decode errors

### DIFF
--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -180,8 +180,15 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 	ctx, err = t.transPipe.Read(ctx, conn, recvMsg)
 	if err != nil {
 		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true, true)
-		// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
-		return err
+		// Report the error here, while ctx/ri still carry the caller info decoded from the
+		// transport header. The deferred rpcinfo reset and the outer transServer's OnError
+		// both run later, by which point From() has been reset (when the rpcinfo pool is
+		// enabled) or a different rpcinfo is in ctx (when it is disabled), so the outer
+		// OnError would log an empty remoteService and a useless remoteAddr. This mirrors
+		// what netpollmux's task() already does. Wrap the error so the outer OnError skips a
+		// duplicate line; the connection is still closed because the error stays non-nil.
+		t.OnError(ctx, err, conn)
+		return reportedError{err}
 	}
 
 	// heartbeat processing
@@ -204,7 +211,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 			t.OnError(ctx, err, conn)
 			err = remote.NewTransError(remote.InternalError, err)
 			if closeConn := t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, false, false); closeConn {
-				return err
+				return reportedError{err}
 			}
 			// connection don't need to be closed when the error is return by the server handler
 			closeConnOutsideIfErr = false
@@ -214,8 +221,10 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 
 	sendMsg.SetPayloadCodec(t.opt.PayloadCodec)
 	if ctx, err = t.transPipe.Write(ctx, conn, sendMsg); err != nil {
-		// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
-		return err
+		// Same as the Read branch above: report here, before the deferred reset, so the
+		// caller info is still intact, and skip the outer OnError via the wrapper.
+		t.OnError(ctx, err, conn)
+		return reportedError{err}
 	}
 	return
 }
@@ -241,8 +250,20 @@ func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 	rpcinfo.PutRPCInfo(rpcinfo.GetRPCInfo(ctx))
 }
 
+// reportedError marks an error that OnRead already logged (while the per-request
+// rpcinfo still held the caller info), so the outer transServer's OnError does not log a
+// second, info-less line on the reset rpcinfo.
+type reportedError struct{ error }
+
+func (e reportedError) Unwrap() error { return e.error }
+
 // OnError implements the remote.ServerTransHandler interface.
 func (t *svrTransHandler) OnError(ctx context.Context, err error, conn net.Conn) {
+	var reported reportedError
+	if errors.As(err, &reported) {
+		// already reported inside OnRead, with the caller info still intact
+		return
+	}
 	ri := rpcinfo.GetRPCInfo(ctx)
 	rService, rAddr := getRemoteInfo(ri, conn)
 	if t.ext.IsRemoteClosedErr(err) {

--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -180,10 +180,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 	ctx, err = t.transPipe.Read(ctx, conn, recvMsg)
 	if err != nil {
 		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true, true)
-		// Log before returning, while rpcinfo still has the decoded caller info.
-		// The wrapper keeps the error non-nil but suppresses the later outer log.
-		t.OnError(ctx, err, conn)
-		return reportedError{err}
+		// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
+		return err
 	}
 
 	// heartbeat processing
@@ -206,7 +204,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 			t.OnError(ctx, err, conn)
 			err = remote.NewTransError(remote.InternalError, err)
 			if closeConn := t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, false, false); closeConn {
-				return reportedError{err}
+				return err
 			}
 			// connection don't need to be closed when the error is return by the server handler
 			closeConnOutsideIfErr = false
@@ -216,9 +214,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 
 	sendMsg.SetPayloadCodec(t.opt.PayloadCodec)
 	if ctx, err = t.transPipe.Write(ctx, conn, sendMsg); err != nil {
-		// Log before the deferred rpcinfo reset; skip the duplicate outer log.
-		t.OnError(ctx, err, conn)
-		return reportedError{err}
+		// t.OnError(ctx, err, conn) will be executed at outer function when transServer close the conn
+		return err
 	}
 	return
 }
@@ -244,18 +241,8 @@ func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 	rpcinfo.PutRPCInfo(rpcinfo.GetRPCInfo(ctx))
 }
 
-// reportedError marks errors already logged with the per-request rpcinfo.
-type reportedError struct{ error }
-
-func (e reportedError) Unwrap() error { return e.error }
-
 // OnError implements the remote.ServerTransHandler interface.
 func (t *svrTransHandler) OnError(ctx context.Context, err error, conn net.Conn) {
-	var reported reportedError
-	if errors.As(err, &reported) {
-		// already reported inside OnRead
-		return
-	}
 	ri := rpcinfo.GetRPCInfo(ctx)
 	rService, rAddr := getRemoteInfo(ri, conn)
 	if t.ext.IsRemoteClosedErr(err) {

--- a/pkg/remote/trans/default_server_handler.go
+++ b/pkg/remote/trans/default_server_handler.go
@@ -180,13 +180,8 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 	ctx, err = t.transPipe.Read(ctx, conn, recvMsg)
 	if err != nil {
 		t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true, true)
-		// Report the error here, while ctx/ri still carry the caller info decoded from the
-		// transport header. The deferred rpcinfo reset and the outer transServer's OnError
-		// both run later, by which point From() has been reset (when the rpcinfo pool is
-		// enabled) or a different rpcinfo is in ctx (when it is disabled), so the outer
-		// OnError would log an empty remoteService and a useless remoteAddr. This mirrors
-		// what netpollmux's task() already does. Wrap the error so the outer OnError skips a
-		// duplicate line; the connection is still closed because the error stays non-nil.
+		// Log before returning, while rpcinfo still has the decoded caller info.
+		// The wrapper keeps the error non-nil but suppresses the later outer log.
 		t.OnError(ctx, err, conn)
 		return reportedError{err}
 	}
@@ -221,8 +216,7 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error)
 
 	sendMsg.SetPayloadCodec(t.opt.PayloadCodec)
 	if ctx, err = t.transPipe.Write(ctx, conn, sendMsg); err != nil {
-		// Same as the Read branch above: report here, before the deferred reset, so the
-		// caller info is still intact, and skip the outer OnError via the wrapper.
+		// Log before the deferred rpcinfo reset; skip the duplicate outer log.
 		t.OnError(ctx, err, conn)
 		return reportedError{err}
 	}
@@ -250,9 +244,7 @@ func (t *svrTransHandler) OnInactive(ctx context.Context, conn net.Conn) {
 	rpcinfo.PutRPCInfo(rpcinfo.GetRPCInfo(ctx))
 }
 
-// reportedError marks an error that OnRead already logged (while the per-request
-// rpcinfo still held the caller info), so the outer transServer's OnError does not log a
-// second, info-less line on the reset rpcinfo.
+// reportedError marks errors already logged with the per-request rpcinfo.
 type reportedError struct{ error }
 
 func (e reportedError) Unwrap() error { return e.error }
@@ -261,7 +253,7 @@ func (e reportedError) Unwrap() error { return e.error }
 func (t *svrTransHandler) OnError(ctx context.Context, err error, conn net.Conn) {
 	var reported reportedError
 	if errors.As(err, &reported) {
-		// already reported inside OnRead, with the caller info still intact
+		// already reported inside OnRead
 		return
 	}
 	ri := rpcinfo.GetRPCInfo(ctx)

--- a/pkg/remote/trans/default_server_handler_test.go
+++ b/pkg/remote/trans/default_server_handler_test.go
@@ -19,6 +19,7 @@ package trans
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -26,11 +27,13 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/cloudwego/kitex/internal/mocks"
+	mocksklog "github.com/cloudwego/kitex/internal/mocks/klog"
 	mockmessage "github.com/cloudwego/kitex/internal/mocks/message"
 	remotemocks "github.com/cloudwego/kitex/internal/mocks/remote"
 	"github.com/cloudwego/kitex/internal/mocks/stats"
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/kerrors"
+	"github.com/cloudwego/kitex/pkg/klog"
 	"github.com/cloudwego/kitex/pkg/remote"
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 )
@@ -202,6 +205,74 @@ func TestSvrTransHandlerReadErr(t *testing.T) {
 	err = svrHandler.OnRead(ctx, &mocks.Conn{})
 	test.Assert(t, err != nil)
 	test.Assert(t, errors.Is(err, mockErr))
+}
+
+func TestSvrTransHandlerReadErrLoggedWithRemoteService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	prevLogger := klog.DefaultLogger()
+	defer func() {
+		klog.SetLogger(prevLogger)
+		ctrl.Finish()
+	}()
+
+	buf := remote.NewReaderWriterBuffer(1024)
+	ext := &MockExtension{
+		NewWriteByteBufferFunc: func(ctx context.Context, conn net.Conn, msg remote.Message) remote.ByteBuffer {
+			return buf
+		},
+		NewReadByteBufferFunc: func(ctx context.Context, conn net.Conn, msg remote.Message) remote.ByteBuffer {
+			return buf
+		},
+	}
+
+	mockErr := errors.New("mock decode error")
+	const callerService = "mockCaller"
+	opt := &remote.ServerOption{
+		Codec: &MockCodec{
+			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+				err := rpcinfo.AsMutableEndpointInfo(msg.RPCInfo().From()).SetServiceName(callerService)
+				test.Assert(t, err == nil, err)
+				return mockErr
+			},
+		},
+		SvcSearcher: svcSearcher,
+		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
+			remote := rpcinfo.AsMutableEndpointInfo(ri.From())
+			test.Assert(t, remote != nil)
+			_ = remote.SetServiceName("")
+			remote.SetAddress(addr)
+			return ri
+		},
+	}
+	ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), rpcinfo.FromBasicInfo(&rpcinfo.EndpointBasicInfo{}),
+		rpcinfo.NewInvocation("", mocks.MockMethod), nil, rpcinfo.NewRPCStats())
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+	conn := &mocks.Conn{
+		RemoteAddrFunc: func() (r net.Addr) {
+			return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8888}
+		},
+	}
+
+	mocklogger := mocksklog.NewMockFullLogger(ctrl)
+	klog.SetLogger(mocklogger)
+	var logs []string
+	mocklogger.EXPECT().CtxErrorf(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, format string, v ...interface{}) {
+		logs = append(logs, fmt.Sprintf(format, v...))
+	}).Times(1)
+
+	svrHandler, err := NewDefaultSvrTransHandler(opt, ext)
+	test.Assert(t, err == nil)
+	pl := remote.NewTransPipeline(svrHandler)
+	svrHandler.SetPipeline(pl)
+	err = svrHandler.OnRead(ctx, conn)
+	test.Assert(t, err != nil)
+	test.Assert(t, errors.Is(err, mockErr))
+
+	svrHandler.OnError(ctx, err, conn)
+	test.Assert(t, len(logs) == 1, logs)
+	test.Assert(t, strings.Contains(logs[0], "remoteService="+callerService), logs[0])
+	test.Assert(t, strings.Contains(logs[0], "remoteAddr=127.0.0.1:8888"), logs[0])
+	test.Assert(t, strings.Contains(logs[0], "error="+mockErr.Error()), logs[0])
 }
 
 func TestSvrTransHandlerReadPanic(t *testing.T) {

--- a/pkg/remote/trans/default_server_handler_test.go
+++ b/pkg/remote/trans/default_server_handler_test.go
@@ -208,71 +208,82 @@ func TestSvrTransHandlerReadErr(t *testing.T) {
 }
 
 func TestSvrTransHandlerReadErrLoggedWithRemoteService(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	prevLogger := klog.DefaultLogger()
-	defer func() {
-		klog.SetLogger(prevLogger)
-		ctrl.Finish()
-	}()
+	poolEnabled := rpcinfo.PoolEnabled()
+	defer rpcinfo.EnablePool(poolEnabled)
 
-	buf := remote.NewReaderWriterBuffer(1024)
-	ext := &MockExtension{
-		NewWriteByteBufferFunc: func(ctx context.Context, conn net.Conn, msg remote.Message) remote.ByteBuffer {
-			return buf
-		},
-		NewReadByteBufferFunc: func(ctx context.Context, conn net.Conn, msg remote.Message) remote.ByteBuffer {
-			return buf
-		},
+	for _, enablePool := range []bool{true, false} {
+		t.Run(fmt.Sprintf("pool_enabled_%t", enablePool), func(t *testing.T) {
+			rpcinfo.EnablePool(enablePool)
+			ctrl := gomock.NewController(t)
+			prevLogger := klog.DefaultLogger()
+			defer func() {
+				klog.SetLogger(prevLogger)
+				ctrl.Finish()
+			}()
+
+			buf := remote.NewReaderWriterBuffer(1024)
+			ext := &MockExtension{
+				NewWriteByteBufferFunc: func(ctx context.Context, conn net.Conn, msg remote.Message) remote.ByteBuffer {
+					return buf
+				},
+				NewReadByteBufferFunc: func(ctx context.Context, conn net.Conn, msg remote.Message) remote.ByteBuffer {
+					return buf
+				},
+			}
+
+			mockErr := errors.New("mock decode error")
+			const callerService = "mockCaller"
+			opt := &remote.ServerOption{
+				Codec: &MockCodec{
+					DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
+						err := rpcinfo.AsMutableEndpointInfo(msg.RPCInfo().From()).SetServiceName(callerService)
+						test.Assert(t, err == nil, err)
+						return mockErr
+					},
+				},
+				SvcSearcher: svcSearcher,
+				InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
+					if ri == nil {
+						ri = newMockRPCInfo()
+					}
+					remote := rpcinfo.AsMutableEndpointInfo(ri.From())
+					test.Assert(t, remote != nil)
+					_ = remote.SetServiceName("")
+					remote.SetAddress(addr)
+					return ri
+				},
+			}
+			ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), rpcinfo.FromBasicInfo(&rpcinfo.EndpointBasicInfo{}),
+				rpcinfo.NewInvocation("", mocks.MockMethod), nil, rpcinfo.NewRPCStats())
+			ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+			conn := &mocks.Conn{
+				RemoteAddrFunc: func() (r net.Addr) {
+					return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8888}
+				},
+			}
+
+			mocklogger := mocksklog.NewMockFullLogger(ctrl)
+			klog.SetLogger(mocklogger)
+			var logs []string
+			mocklogger.EXPECT().CtxErrorf(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, format string, v ...interface{}) {
+				logs = append(logs, fmt.Sprintf(format, v...))
+			}).Times(1)
+
+			svrHandler, err := NewDefaultSvrTransHandler(opt, ext)
+			test.Assert(t, err == nil)
+			pl := remote.NewTransPipeline(svrHandler)
+			svrHandler.SetPipeline(pl)
+			err = svrHandler.OnRead(ctx, conn)
+			test.Assert(t, err != nil)
+			test.Assert(t, errors.Is(err, mockErr))
+
+			svrHandler.OnError(ctx, err, conn)
+			test.Assert(t, len(logs) == 1, logs)
+			test.Assert(t, strings.Contains(logs[0], "remoteService="+callerService), logs[0])
+			test.Assert(t, strings.Contains(logs[0], "remoteAddr=127.0.0.1:8888"), logs[0])
+			test.Assert(t, strings.Contains(logs[0], "error="+mockErr.Error()), logs[0])
+		})
 	}
-
-	mockErr := errors.New("mock decode error")
-	const callerService = "mockCaller"
-	opt := &remote.ServerOption{
-		Codec: &MockCodec{
-			DecodeFunc: func(ctx context.Context, msg remote.Message, in remote.ByteBuffer) error {
-				err := rpcinfo.AsMutableEndpointInfo(msg.RPCInfo().From()).SetServiceName(callerService)
-				test.Assert(t, err == nil, err)
-				return mockErr
-			},
-		},
-		SvcSearcher: svcSearcher,
-		InitOrResetRPCInfoFunc: func(ri rpcinfo.RPCInfo, addr net.Addr) rpcinfo.RPCInfo {
-			remote := rpcinfo.AsMutableEndpointInfo(ri.From())
-			test.Assert(t, remote != nil)
-			_ = remote.SetServiceName("")
-			remote.SetAddress(addr)
-			return ri
-		},
-	}
-	ri := rpcinfo.NewRPCInfo(rpcinfo.EmptyEndpointInfo(), rpcinfo.FromBasicInfo(&rpcinfo.EndpointBasicInfo{}),
-		rpcinfo.NewInvocation("", mocks.MockMethod), nil, rpcinfo.NewRPCStats())
-	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
-	conn := &mocks.Conn{
-		RemoteAddrFunc: func() (r net.Addr) {
-			return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8888}
-		},
-	}
-
-	mocklogger := mocksklog.NewMockFullLogger(ctrl)
-	klog.SetLogger(mocklogger)
-	var logs []string
-	mocklogger.EXPECT().CtxErrorf(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx context.Context, format string, v ...interface{}) {
-		logs = append(logs, fmt.Sprintf(format, v...))
-	}).Times(1)
-
-	svrHandler, err := NewDefaultSvrTransHandler(opt, ext)
-	test.Assert(t, err == nil)
-	pl := remote.NewTransPipeline(svrHandler)
-	svrHandler.SetPipeline(pl)
-	err = svrHandler.OnRead(ctx, conn)
-	test.Assert(t, err != nil)
-	test.Assert(t, errors.Is(err, mockErr))
-
-	svrHandler.OnError(ctx, err, conn)
-	test.Assert(t, len(logs) == 1, logs)
-	test.Assert(t, strings.Contains(logs[0], "remoteService="+callerService), logs[0])
-	test.Assert(t, strings.Contains(logs[0], "remoteAddr=127.0.0.1:8888"), logs[0])
-	test.Assert(t, strings.Contains(logs[0], "error="+mockErr.Error()), logs[0])
 }
 
 func TestSvrTransHandlerReadPanic(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

修复默认服务端 decode 错误日志中调用方信息丢失的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
This is a more complete fix based on PR #1272 for the logging issue reported in #1267.

The issue is limited to the default server handler path, which is reused by gonet, netpoll, and invoke. Before PR #1272, decode/read errors were logged inside `OnRead`, so request rpcinfo was still available. PR #1272 moved the final log to the outer fallback `OnError` to avoid duplicate error logs, but that fallback runs too late for request rpcinfo:

- With rpcinfo pool enabled, `OnRead` resets the reused rpcinfo in deferred cleanup before the outer fallback log.
- With rpcinfo pool disabled, `OnRead` creates a request ctx/rpcinfo, but only returns an error. The outer fallback still uses the connection ctx returned by `OnActive`.

```go
// outer trans server
ctx, err = ts.transHdlr.OnActive(ctx, conn)
err = ts.transHdlr.OnRead(ctx, conn)
if err != nil {
    ts.transHdlr.OnError(ctx, err, conn) // fallback log after OnRead returns
}

// default_server_handler.go
func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error) {
    ctx, ri := t.newCtxWithRPCInfo(ctx, conn)
    defer func() {
        if rpcinfo.PoolEnabled() {
            t.opt.InitOrResetRPCInfoFunc(ri, conn.RemoteAddr()) // reset before fallback log
        }
    }()

    ctx, err = t.transPipe.Read(ctx, conn, recvMsg)
    if err != nil {
        return err
    }
}
```

This PR restores the correct logging timing by logging decode/read errors inside `OnRead`, while request rpcinfo is still available. It also keeps PR #1272's duplicate-log optimization by returning an unwrap-compatible marker:

```go
if err != nil {
    t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true, true)
    t.OnError(ctx, err, conn)
    return reportedError{err}
}

type reportedError struct{ error }
func (e reportedError) Unwrap() error { return e.error }
```

The returned error remains non-nil, so the outer trans server still closes the connection as before. `Unwrap` preserves `errors.Is/As`, and the marker only suppresses the second fallback log.

Checked other `ServerTransHandler` implementations: netpollmux already logs read/write errors before rpcinfo reset; nphttp2 and ttstream use separate stream handling flows; detection only delegates to the selected handler. Business handler panics are also unaffected because they are recovered and logged inside `OnRead` before deferred cleanup.

A regression test is added for both rpcinfo pool modes to verify that read errors are logged with `remoteService` and that the outer fallback log is skipped.

zh(optional):
这是基于 PR #1272 的更完整修复，用于解决 #1267 中报告的日志问题。

该问题仅限于默认服务端 handler 路径，也就是 gonet、netpoll、invoke 复用的路径。PR #1272 之前，decode/read 错误是在 `OnRead` 内部打印的，因此还能拿到请求级 rpcinfo。PR #1272 为了解决重复错误日志问题，把最终日志交给外层兜底 `OnError` 打印，但兜底打印对请求级 rpcinfo 来说太晚了：

- 开启 rpcinfo pool 时，`OnRead` 的 deferred cleanup 会在外层兜底打印前 reset 复用的 rpcinfo。
- 关闭 rpcinfo pool 时，`OnRead` 会创建 request ctx/rpcinfo，但只返回 error；外层兜底仍然使用 `OnActive` 返回的 connection ctx。

```go
// outer trans server
ctx, err = ts.transHdlr.OnActive(ctx, conn)
err = ts.transHdlr.OnRead(ctx, conn)
if err != nil {
    ts.transHdlr.OnError(ctx, err, conn) // fallback log after OnRead returns
}

// default_server_handler.go
func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) (err error) {
    ctx, ri := t.newCtxWithRPCInfo(ctx, conn)
    defer func() {
        if rpcinfo.PoolEnabled() {
            t.opt.InitOrResetRPCInfoFunc(ri, conn.RemoteAddr()) // reset before fallback log
        }
    }()

    ctx, err = t.transPipe.Read(ctx, conn, recvMsg)
    if err != nil {
        return err
    }
}
```

本 PR 恢复正确的打印时机：在 `OnRead` 内部、请求级 rpcinfo 仍然可用时打印 decode/read 错误。同时保留 PR #1272 的去重效果：返回一个支持 `Unwrap` 的 marker error，用来标记该错误已经打印过：

```go
if err != nil {
    t.writeErrorReplyIfNeeded(ctx, recvMsg, conn, err, ri, true, true)
    t.OnError(ctx, err, conn)
    return reportedError{err}
}

type reportedError struct{ error }
func (e reportedError) Unwrap() error { return e.error }
```

返回错误仍然非 nil，外层 trans server 仍会按原逻辑关闭连接；`Unwrap` 保留 `errors.Is/As` 行为；marker 只用于跳过第二条兜底日志。

已检查其他 `ServerTransHandler` 实现：netpollmux 已经在 rpcinfo reset 前打印 read/write 错误；nphttp2 和 ttstream 使用独立的 stream 处理流程；detection 只负责转发到选中的 handler。业务 handler panic 也不受影响，因为 panic 会在 `OnRead` 内部、deferred cleanup 前被 recover 并打印。

新增回归测试，覆盖 rpcinfo pool 开启和关闭两种模式，验证 read error 日志包含 `remoteService`，且外层兜底日志会被跳过。

#### (Optional) Which issue(s) this PR fixes:

Fixes https://github.com/cloudwego/kitex/issues/1267

#### (optional) The PR that updates user documentation:
