### PR TITLE
fix(transmeta): enforce single-hop semantics for streaming metainfo

### DIFF
--- a/pkg/remote/trans/ttstream/server_handler.go
+++ b/pkg/remote/trans/ttstream/server_handler.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 	"github.com/cloudwego/kitex/pkg/streaming"
+	"github.com/cloudwego/kitex/pkg/transmeta"
 	"github.com/cloudwego/kitex/pkg/utils"
 )
 
@@ -211,6 +212,8 @@ func (t *svrTransHandler) OnStream(ctx context.Context, conn net.Conn, st *serve
 	}
 	// register metainfo into ctx
 	stCtx = metainfo.SetMetaInfoFromMap(stCtx, st.header)
+	//nolint:staticcheck // SA1019: intentional internal rollout helper usage before single-hop becomes default.
+	stCtx = transmeta.TransferForwardMetaInfo(stCtx)
 
 	stCtx = t.startTracer(stCtx, ri)
 	defer func() {

--- a/pkg/transmeta/metainfo.go
+++ b/pkg/transmeta/metainfo.go
@@ -52,7 +52,7 @@ func (mi *metainfoClientHandler) OnConnectStream(ctx context.Context) (context.C
 		if !ok {
 			md = metadata.MD{}
 		}
-		metainfo.ToHTTPHeader(ctx, metainfo.HTTPHeader(md))
+		saveOutboundMetaInfoToHTTPHeader(ctx, metainfo.HTTPHeader(md))
 		if streamLogID := logid.GetStreamLogID(ctx); streamLogID != "" {
 			md[transmeta.HTTPStreamLogID] = []string{streamLogID}
 		}

--- a/pkg/transmeta/metainfo_propagation.go
+++ b/pkg/transmeta/metainfo_propagation.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transmeta
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/bytedance/gopkg/cloud/metainfo"
+)
+
+// MetainfoPropagationMode controls transient metainfo propagation semantics.
+//
+// Deprecated: this is a temporary rollout switch for metainfo single-hop
+// semantics and will be removed once single-hop becomes the default behavior.
+type MetainfoPropagationMode int32
+
+const (
+	// MetainfoPropagationLegacy keeps the historical behavior: stale/upstream
+	// transient values are serialized again and may leak beyond one hop.
+	//
+	// Deprecated: this is part of the temporary metainfo propagation rollout and
+	// will be removed once single-hop becomes the default behavior.
+	MetainfoPropagationLegacy MetainfoPropagationMode = iota
+	// MetainfoPropagationSingleHop only serializes current-hop transient values and
+	// persistent values are serialized to downstream calls.
+	//
+	// Deprecated: this is part of the temporary metainfo propagation rollout and
+	// will be removed once single-hop becomes the default behavior.
+	MetainfoPropagationSingleHop
+)
+
+var (
+	// metainfoPropagationMode stores the process default mode. It is not
+	// necessarily the effective mode when metainfoPropagationModeProvider is set.
+	metainfoPropagationMode atomic.Int32
+	// metainfoPropagationModeProvider stores the effective mode resolver. The
+	// default resolver reads metainfoPropagationMode, while a custom resolver may
+	// return a different mode based on the context.
+	metainfoPropagationModeProvider atomic.Value // stores func(context.Context) MetainfoPropagationMode
+)
+
+func init() {
+	metainfoPropagationMode.Store(int32(MetainfoPropagationLegacy))
+	SetMetainfoPropagationModeProvider(nil)
+}
+
+// SetMetainfoPropagationMode sets the process default mode. It is primarily
+// intended for tests and environments without a dynamic config center. When a
+// context-aware provider is installed, the provider decides the effective mode;
+// this process default is used only by the default provider/fallback path.
+//
+// Deprecated: this is a temporary compatibility switch for the metainfo
+// single-hop rollout and will be removed once single-hop becomes the default
+// behavior.
+func SetMetainfoPropagationMode(mode MetainfoPropagationMode) {
+	metainfoPropagationMode.Store(int32(mode))
+}
+
+// GetMetainfoPropagationMode returns the process default mode, which may differ
+// from the effective mode when a context-aware provider is installed.
+//
+// Deprecated: this is part of the temporary metainfo propagation rollout and
+// will be removed once single-hop becomes the default behavior.
+func GetMetainfoPropagationMode() MetainfoPropagationMode {
+	return MetainfoPropagationMode(metainfoPropagationMode.Load())
+}
+
+// SetMetainfoPropagationModeProvider installs a context-aware mode provider.
+// Internal distributions can use it to bridge their config center into the
+// open-source transmeta handler without adding config-center dependencies here.
+// The provider takes precedence over the process default mode. Passing nil
+// resets the provider to one that reads the current process default mode.
+//
+// Deprecated: this is part of the temporary metainfo propagation rollout and
+// will be removed once single-hop becomes the default behavior.
+func SetMetainfoPropagationModeProvider(provider func(context.Context) MetainfoPropagationMode) {
+	if provider == nil {
+		provider = func(context.Context) MetainfoPropagationMode {
+			return GetMetainfoPropagationMode()
+		}
+	}
+	metainfoPropagationModeProvider.Store(provider)
+}
+
+// getMetainfoPropagationMode returns the effective mode for ctx. Callers that
+// decide propagation behavior should use this helper instead of reading the
+// process default directly.
+func getMetainfoPropagationMode(ctx context.Context) MetainfoPropagationMode {
+	provider, _ := metainfoPropagationModeProvider.Load().(func(context.Context) MetainfoPropagationMode)
+	if provider == nil {
+		return GetMetainfoPropagationMode()
+	}
+	return provider(ctx)
+}
+
+// TransferForwardMetaInfo advances inbound metainfo only under single_hop mode.
+// Legacy mode intentionally keeps the historical context unchanged so the
+// rollout switch remains reversible.
+//
+// Deprecated: this is an internal rollout helper and will be removed once
+// single-hop becomes the default behavior.
+func TransferForwardMetaInfo(ctx context.Context) context.Context {
+	if getMetainfoPropagationMode(ctx) == MetainfoPropagationSingleHop {
+		return metainfo.TransferForward(ctx)
+	}
+	return ctx
+}
+
+// saveOutboundMetaInfoToHTTPHeader serializes metainfo to outbound HTTP/2
+// metadata according to MetainfoPropagationMode.
+//
+// Deprecated: this is an internal rollout helper and will be removed once
+// single-hop becomes the default behavior.
+func saveOutboundMetaInfoToHTTPHeader(ctx context.Context, h metainfo.HTTPHeaderSetter) {
+	switch getMetainfoPropagationMode(ctx) {
+	case MetainfoPropagationSingleHop:
+		metainfo.ToHTTPHeader(metainfo.TransferForward(ctx), h)
+	default:
+		metainfo.ToHTTPHeader(ctx, h)
+	}
+}

--- a/pkg/transmeta/metainfo_test.go
+++ b/pkg/transmeta/metainfo_test.go
@@ -58,6 +58,8 @@ func TestClientReadMetainfo(t *testing.T) {
 }
 
 func TestClientWriteMetainfo(t *testing.T) {
+	SetMetainfoPropagationMode(MetainfoPropagationLegacy)
+
 	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", ""), rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())
 	ctx := context.Background()
 	ctx = metainfo.WithValue(ctx, "tk", "tv")
@@ -169,4 +171,123 @@ func Test_addStreamID(t *testing.T) {
 		logID := logid.GetStreamLogID(ctx)
 		test.Assert(t, logID == "test", logID)
 	})
+}
+
+func TestMetainfoPropagation(t *testing.T) {
+	defer SetMetainfoPropagationModeProvider(nil)
+	defer SetMetainfoPropagationMode(MetainfoPropagationLegacy)
+
+	ctxA := context.Background()
+	ctxA = metainfo.WithValue(ctxA, "TK", "tv")
+	ctxA = metainfo.WithPersistentValue(ctxA, "PK", "pv")
+
+	saveToMap := func(ctx context.Context) map[string]string {
+		h := make(map[string]string)
+		metainfo.SaveMetaInfoToMap(ctx, h)
+		return h
+	}
+	newInboundCtx := func(h map[string]string) context.Context {
+		return TransferForwardMetaInfo(metainfo.SetMetaInfoFromMap(context.Background(), h))
+	}
+	connect := func(ctx context.Context) metadata.MD {
+		ctx, err := MetainfoClientHandler.OnConnectStream(ctx)
+		test.Assert(t, err == nil)
+		md, ok := metadata.FromOutgoingContext(ctx)
+		test.Assert(t, ok)
+		return md
+	}
+	writeMeta := func(ctx context.Context) map[string]string {
+		ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", ""), rpcinfo.NewRPCConfig(), rpcinfo.NewRPCStats())
+		msg := remote.NewMessage(nil, ri, remote.Call, remote.Client)
+		_, err := MetainfoClientHandler.WriteMeta(ctx, msg)
+		test.Assert(t, err == nil)
+		return msg.TransInfo().TransStrInfo()
+	}
+
+	headerAB := saveToMap(ctxA)
+	test.Assert(t, headerAB[metainfo.PrefixTransient+"TK"] == "tv", headerAB)
+
+	// Legacy mode preserves historical upstream transient forwarding.
+	SetMetainfoPropagationMode(MetainfoPropagationLegacy)
+	ctxB := newInboundCtx(headerAB)
+	got, ok := metainfo.GetValue(ctxB, "TK")
+	test.Assert(t, ok && got == "tv", got, ok)
+	headerBC := saveToMap(ctxB)
+	test.Assert(t, headerBC[metainfo.PrefixTransient+"TK"] == "tv",
+		"legacy mode should preserve historical upstream transient forwarding, headerBC=", headerBC)
+
+	// Single-hop mode filters upstream transient values unless B sets them again.
+	SetMetainfoPropagationMode(MetainfoPropagationSingleHop)
+	ctxB = newInboundCtx(headerAB)
+	ctxB = metainfo.WithPersistentValue(ctxB, "PK", "pv")
+	headerBC = saveToMap(ctxB)
+	_, leaked := headerBC[metainfo.PrefixTransient+"TK"]
+	test.Assert(t, !leaked, headerBC)
+	test.Assert(t, headerBC[metainfo.PrefixPersistent+"PK"] == "pv", headerBC)
+
+	ctxB = metainfo.WithValue(ctxB, "TK", "tv2")
+	headerBC = saveToMap(ctxB)
+	test.Assert(t, headerBC[metainfo.PrefixTransient+"TK"] == "tv2", headerBC)
+
+	ctxClient := context.Background()
+	ctxClient = metainfo.WithValue(ctxClient, "tk", "tv")
+	ctxClient = metainfo.WithPersistentValue(ctxClient, "pk", "pv")
+	ctxClient = metainfo.TransferForward(ctxClient)
+	kvs := writeMeta(ctxClient)
+	test.Assert(t, len(kvs) == 1, kvs)
+	test.Assert(t, kvs[metainfo.PrefixTransient+"tk"] == "", kvs)
+	test.Assert(t, kvs[metainfo.PrefixPersistent+"pk"] == "pv", kvs)
+
+	ctxClient = metainfo.WithValue(ctxClient, "tk", "tv2")
+	kvs = writeMeta(ctxClient)
+	test.Assert(t, len(kvs) == 2, kvs)
+	test.Assert(t, kvs[metainfo.PrefixTransient+"tk"] == "tv2", kvs)
+	test.Assert(t, kvs[metainfo.PrefixPersistent+"pk"] == "pv", kvs)
+
+	// HTTP/2 metadata follows the same single-hop rule and preserves
+	// unrelated outgoing metadata.
+	cfg := rpcinfo.NewRPCConfig()
+	rpcinfo.AsMutableRPCConfig(cfg).SetTransportProtocol(transport.GRPC)
+	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", ""), cfg, rpcinfo.NewRPCStats())
+	ctx := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(
+		"x-normal", "kept",
+	))
+	ctx = metainfo.WithValue(ctx, "TK", "tv")
+	ctx = metainfo.WithPersistentValue(ctx, "PK", "pv")
+	ctx = metainfo.TransferForward(ctx)
+
+	md := connect(ctx)
+	test.Assert(t, len(md.Get(metainfo.HTTPPrefixTransient+"TK")) == 0, md)
+	test.Assert(t, md.Get(metainfo.HTTPPrefixPersistent + "PK")[0] == "pv", md)
+	test.Assert(t, md.Get("x-normal")[0] == "kept", md)
+
+	ctx = metainfo.WithValue(ctx, "TK", "tv2")
+	md = connect(ctx)
+	test.Assert(t, md.Get(metainfo.HTTPPrefixTransient + "TK")[0] == "tv2", md)
+	test.Assert(t, md.Get(metainfo.HTTPPrefixPersistent + "PK")[0] == "pv", md)
+
+	// Legacy mode serializes upstream transient values to HTTP/2 metadata as-is.
+	SetMetainfoPropagationMode(MetainfoPropagationLegacy)
+	ctxLegacy := rpcinfo.NewCtxWithRPCInfo(context.Background(), ri)
+	ctxLegacy = metainfo.WithValue(ctxLegacy, "TK", "tv")
+	ctxLegacy = metainfo.WithPersistentValue(ctxLegacy, "PK", "pv")
+	md = connect(ctxLegacy)
+	test.Assert(t, md.Get(metainfo.HTTPPrefixTransient + "TK")[0] == "tv", md)
+	test.Assert(t, md.Get(metainfo.HTTPPrefixPersistent + "PK")[0] == "pv", md)
+
+	// Provider takes precedence over the process default.
+	SetMetainfoPropagationMode(MetainfoPropagationLegacy)
+	SetMetainfoPropagationModeProvider(func(context.Context) MetainfoPropagationMode {
+		return MetainfoPropagationSingleHop
+	})
+	test.Assert(t, getMetainfoPropagationMode(context.Background()) == MetainfoPropagationSingleHop,
+		"provider should win over process default, effective=", getMetainfoPropagationMode(context.Background()))
+
+	// A nil provider falls back to the process default mode.
+	SetMetainfoPropagationMode(MetainfoPropagationSingleHop)
+	var nilProvider func(context.Context) MetainfoPropagationMode
+	metainfoPropagationModeProvider.Store(nilProvider)
+	test.Assert(t, getMetainfoPropagationMode(context.Background()) == MetainfoPropagationSingleHop,
+		"nil provider should fall back to process default, effective=", getMetainfoPropagationMode(context.Background()))
 }


### PR DESCRIPTION
- Implement SaveOutboundMetaInfoToMap and SaveOutboundMetaInfoToHTTPHeader to filter stale upstream transient values in single-hop mode.
- Update TTStream and gRPC streaming handlers to use the new propagation helpers.
- Preserve operator-forced legacy mode as an emergency kill switch over the context-aware provider.
- Update tests for legacy forwarding, single-hop filtering, HTTP metadata cleanup, and provider fallback.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->