### PR TITLE
fix(tool): unique import aliases for versioned proto packages

### DIFF
--- a/tool/internal_pkg/pluginmode/protoc/plugin.go
+++ b/tool/internal_pkg/pluginmode/protoc/plugin.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -232,7 +231,7 @@ func (pp *protocPlugin) convertTypes(file *protogen.File) (ss []*generator.Servi
 	}
 	pi := generator.PkgInfo{
 		PkgName:    file.Proto.GetPackage(),
-		PkgRefName: goSanitized(path.Base(pth)),
+		PkgRefName: importPathToPkgRef(pth),
 		ImportPath: pth,
 	}
 	for _, service := range file.Services {
@@ -321,7 +320,7 @@ func (pp *protocPlugin) getCombineServiceName(name string, svcs []*generator.Ser
 
 func (pp *protocPlugin) convertParameter(msg *protogen.Message, paramName string) *generator.Parameter {
 	importPath := pp.fixImport(msg.GoIdent.GoImportPath.String())
-	pkgRefName := goSanitized(path.Base(importPath))
+	pkgRefName := importPathToPkgRef(importPath)
 	res := &generator.Parameter{
 		Deps: []generator.PkgInfo{
 			{

--- a/tool/internal_pkg/pluginmode/protoc/util.go
+++ b/tool/internal_pkg/pluginmode/protoc/util.go
@@ -16,6 +16,7 @@ package protoc
 
 import (
 	"go/token"
+	"path"
 	"strings"
 	"unicode"
 
@@ -36,6 +37,33 @@ func goSanitized(s string) string {
 		return "_" + s
 	}
 	return s
+}
+
+// isVersionPathSeg reports whether s looks like a version path segment (v1, v2, ...).
+func isVersionPathSeg(s string) bool {
+	if len(s) < 2 || (s[0] != 'v' && s[0] != 'V') {
+		return false
+	}
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// importPathToPkgRef returns a stable import alias for importPath.
+// Paths ending with a version segment (e.g. packagea/v1 vs packageb/v1) include
+// the parent directory so generated aliases stay unique (issue #1892).
+func importPathToPkgRef(importPath string) string {
+	importPath = strings.Trim(importPath, `"`)
+	base := path.Base(importPath)
+	parent := path.Base(path.Dir(importPath))
+	ref := base
+	if isVersionPathSeg(base) && parent != "" && parent != "." {
+		ref = parent + "_" + base
+	}
+	return goSanitized(ref)
 }
 
 type pathElements struct {

--- a/tool/internal_pkg/pluginmode/protoc/util_test.go
+++ b/tool/internal_pkg/pluginmode/protoc/util_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoc
+
+import "testing"
+
+func TestImportPathToPkgRef(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"kitexidltest/kitex_gen/base/packagea/v1", "packagea_v1"},
+		{"kitexidltest/kitex_gen/base/packageb/v1", "packageb_v1"},
+		{"kitexidltest/kitex_gen/example/v1", "example_v1"},
+		{"github.com/cloudwego/kitex/client", "client"},
+		{"context", "context"},
+	}
+	for _, tc := range cases {
+		if got := importPathToPkgRef(tc.in); got != tc.want {
+			t.Errorf("importPathToPkgRef(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// uniqueness for the issue case
+	a := importPathToPkgRef("kitexidltest/kitex_gen/base/packagea/v1")
+	b := importPathToPkgRef("kitexidltest/kitex_gen/base/packageb/v1")
+	e := importPathToPkgRef("kitexidltest/kitex_gen/example/v1")
+	if a == b || a == e || b == e {
+		t.Fatalf("aliases not unique: %q %q %q", a, b, e)
+	}
+}

--- a/tool/internal_pkg/prutal/prutal.go
+++ b/tool/internal_pkg/prutal/prutal.go
@@ -251,7 +251,8 @@ func getCombineServiceName(name string, svcs []*generator.ServiceInfo) string {
 
 func (pg *PrutalGen) convertParameter(f *prutalgen.Proto, t *prutalgen.Type, paramName string) *generator.Parameter {
 	importPath := t.GoImport()
-	pkgRefName := path.Base(importPath)
+	// Match protoc plugin: version path segments (v1/v2/...) keep parent for unique aliases (#1892).
+	pkgRefName := importPathToPkgRef(importPath)
 	typeName := t.GoName()
 	if !strings.Contains(typeName, ".") {
 		typeName = pkgRefName + "." + t.GoName()
@@ -361,4 +362,30 @@ func writeFile(fn string, data []byte) {
 	if err != nil {
 		log.Errorf("write file %q err: %s", fn, err)
 	}
+}
+
+// importPathToPkgRef returns a stable import alias for importPath.
+// Version path segments (v1, v2, ...) include the parent directory so
+// packagea/v1 and packageb/v1 do not both become "v1" (kitex#1892).
+func importPathToPkgRef(importPath string) string {
+	importPath = strings.Trim(importPath, `"`)
+	base := path.Base(importPath)
+	parent := path.Base(path.Dir(importPath))
+	ref := base
+	if isVersionPathSeg(base) && parent != "" && parent != "." {
+		ref = parent + "_" + base
+	}
+	return ref
+}
+
+func isVersionPathSeg(s string) bool {
+	if len(s) < 2 || (s[0] != 'v' && s[0] != 'V') {
+		return false
+	}
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Fixes #1892

When multiple deps share a version path segment (`.../packagea/v1`, `.../packageb/v1`, `.../example/v1`), both protoc and prutal used `path.Base` as the import alias, so generated code had duplicate `v1 "..."` imports.

For version-like last segments (`v1`, `v2`, ...), use `parent_version` (e.g. `packagea_v1`). Other paths keep the last segment as before.

Test: `TestImportPathToPkgRef` in `tool/internal_pkg/pluginmode/protoc`.

```
go test ./tool/internal_pkg/pluginmode/protoc/ ./tool/internal_pkg/prutal/
```