### PR TITLE
fix: RegisterService should return errors instead of panic

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -177,19 +177,19 @@ func (s *server) RegisterService(svcInfo *serviceinfo.ServiceInfo, handler inter
 	s.Lock()
 	defer s.Unlock()
 	if s.isRun {
-		panic("service cannot be registered while server is running")
+		return errors.New("service cannot be registered while server is running")
 	}
 	if svcInfo == nil {
-		panic("svcInfo is nil. please specify non-nil svcInfo")
+		return errors.New("svcInfo is nil. please specify non-nil svcInfo")
 	}
 	if handler == nil || reflect.ValueOf(handler).IsNil() {
-		panic("handler is nil. please specify non-nil handler")
+		return errors.New("handler is nil. please specify non-nil handler")
 	}
 
 	registerOpts := internal_server.NewRegisterOptions(opts)
 	// register service
 	if err := s.svcs.addService(svcInfo, handler, registerOpts); err != nil {
-		panic(err.Error())
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
﻿## Motivation

The RegisterService method declares error in its return signature but uses panic() for parameter validation. This violates Go error handling best practices and can cause unexpected crashes for callers who expect to handle errors gracefully.

Fixes #1981

## Changes

Replace panic() calls with return errors.New() in RegisterService method:
- Return error when server is already running
- Return error when svcInfo is nil
- Return error when handler is nil
- Return error from addService instead of panic

## Testing

- [ ] Code follows the project's coding standards
- [ ] Existing tests pass
- [ ] No breaking changes to public API

Note: Local environment limitations, relying on CI/CD automated testing.
