### PR TITLE
fix(gonet): avoid shutdown timeout without active connections

### DIFF
--- a/pkg/remote/trans/gonet/trans_server.go
+++ b/pkg/remote/trans/gonet/trans_server.go
@@ -147,6 +147,9 @@ func (ts *transServer) Shutdown() (err error) {
 			_ = g.GracefulShutdown(ctx)
 		}
 	}
+	if ts.connCount.Value() == 0 {
+		return nil
+	}
 
 	shutdownTicker := time.NewTicker(defaultShutdownTicker)
 	defer shutdownTicker.Stop()

--- a/pkg/remote/trans/gonet/trans_server_test.go
+++ b/pkg/remote/trans/gonet/trans_server_test.go
@@ -109,6 +109,16 @@ func TestCreateListener(t *testing.T) {
 	ln.Close()
 }
 
+func TestShutdownWithoutActiveConnections(t *testing.T) {
+	transSvr := NewTransServerFactory().NewTransServer(
+		&remote.ServerOption{ExitWaitTime: 10 * time.Millisecond},
+		&mocks.MockSvrTransHandler{},
+	).(*transServer)
+
+	err := transSvr.Shutdown()
+	test.Assert(t, err == nil, err)
+}
+
 func TestBootStrapAndShutdown(t *testing.T) {
 	// tcp init
 	addrStr := "127.0.0.1:9093"


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] This change does not require a user documentation update.

#### (Optional) Translate the PR title into Chinese.

fix(gonet): 避免无活动连接时 Shutdown 错误超时

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`gonet.transServer.Shutdown` currently checks the active connection count only when its fixed 100 ms ticker fires. If there are no active connections and `ExitWaitTime` is shorter than 100 ms, the context deadline fires first and `Shutdown` incorrectly returns `context.DeadlineExceeded`. Even with the default timeout, an idle server unnecessarily waits for the first ticker.

This change checks the connection count immediately after the existing graceful-shutdown notification. Active connections still use the existing ticker and context deadline behavior.

A regression test covers an idle server with a 10 ms exit wait time.

zh(optional):

`gonet.transServer.Shutdown` 原本只在固定的 100 ms ticker 触发时检查活动连接数。当没有活动连接且 `ExitWaitTime` 小于 100 ms 时，context 会先超时，导致 `Shutdown` 错误返回 `context.DeadlineExceeded`。本修改在原有优雅关闭通知之后立即检查一次连接数；存在活动连接时仍沿用原有轮询和超时逻辑。

Tests:

- `go test ./pkg/remote/trans/gonet -count=20`
- `go test ./server ./server/genericserver -count=1`
- `go vet ./pkg/remote/trans/gonet`

Manual TCP lifecycle test on Windows using a real Gonet listener and client connection:

- Idle at shutdown, `conn=0`, `ExitWaitTime=10ms`: upstream returned `context deadline exceeded` after 10.752 ms; this patch returned `nil` immediately.
- Graceful active connection, `conn=1`, `ExitWaitTime=500ms`: upstream returned `nil` after 100.374 ms; this patch closed the connection and returned `nil` immediately.
- Intentionally stuck connection, `conn=1`, `ExitWaitTime=30ms`: both versions correctly returned `context deadline exceeded` after about 30 ms.

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (optional) The PR that updates user documentation:

N/A
