### PR TITLE
feat(grpc): support identifying cascaded cancel

### DIFF
--- a/pkg/remote/trans/nphttp2/grpc/context_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/context_test.go
@@ -20,8 +20,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
 
 func TestContextWithCancelReason(t *testing.T) {
@@ -40,4 +43,56 @@ func TestContextWithCancelReason(t *testing.T) {
 	cancel0()
 	test.Assert(t, ctx0.Err() == context.Canceled)
 	test.Assert(t, ctx.Err() == context.Canceled)
+}
+
+func TestClientContextErrCascadeCancel(t *testing.T) {
+	reason := status.Err(codes.Canceled, "inbound RPC terminated")
+
+	// The accepted server RPC still observes an ordinary status. It becomes a
+	// cascade cancellation only when it terminates a client RPC.
+	test.Assert(t, !status.Convert(ContextErr(reason)).IsCascadeCancel())
+
+	err := cascadeContextErr(reason)
+	st := status.Convert(err)
+	test.Assert(t, st.IsCascadeCancel())
+	test.Assert(t, st.Code() == codes.Canceled)
+	test.Assert(t, st.Message() == "inbound RPC terminated")
+
+	test.Assert(t, !status.Convert(cascadeContextErr(context.Canceled)).IsCascadeCancel())
+	test.Assert(t, !status.Convert(cascadeContextErr(context.DeadlineExceeded)).IsCascadeCancel())
+	test.Assert(t, !status.Convert(cascadeContextErr(status.Err(codes.Unavailable, "transport closed"))).IsCascadeCancel())
+}
+
+func TestClientContextErrDerivedContextLimitation(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		derive func(context.Context) (context.Context, context.CancelFunc)
+	}{
+		{name: "WithCancel", derive: context.WithCancel},
+		{name: "WithTimeout", derive: func(ctx context.Context) (context.Context, context.CancelFunc) {
+			return context.WithTimeout(ctx, time.Hour)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parent, parentCancel := context.WithCancel(context.Background())
+			serverCtx, cancelWithReason := newContextWithCancelReason(parent, parentCancel)
+			derivedCtx, cancelDerived := tc.derive(serverCtx)
+			defer cancelDerived()
+
+			reason := status.Err(codes.Canceled, "inbound RPC terminated")
+			cancelWithReason(reason)
+
+			select {
+			case <-derivedCtx.Done():
+			case <-time.After(time.Second):
+				t.Fatal("derived context was not canceled")
+			}
+
+			// Standard derived contexts expose context.Canceled instead of the
+			// process-local status error.
+			test.Assert(t, serverCtx.Err() == reason)
+			test.Assert(t, derivedCtx.Err() == context.Canceled)
+			test.Assert(t, !status.Convert(cascadeContextErr(derivedCtx.Err())).IsCascadeCancel())
+		})
+	}
 }

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -344,7 +344,7 @@ func (task *closeStreamTask) Tick() {
 			continue
 		}
 		// uniformly converted to *status.Status and related error
-		st, stReused, sErr := contextStatusAndErr(stream.Context().Err())
+		st, stReused, sErr := contextStatusAndErr(tryMarkAsCascadeCancel(stream.Context().Err()))
 		trans.doCloseStream(stream, sErr, true, http2.ErrCodeCancel, st, stReused, nil)
 		task.toCloseStreams[i] = nil
 	}
@@ -615,7 +615,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		select {
 		case <-ch:
 		case <-s.ctx.Done():
-			return nil, ContextErr(s.ctx.Err())
+			return nil, cascadeContextErr(s.ctx.Err())
 		case <-t.goAway:
 			return nil, errStreamDrain
 		case <-t.ctx.Done():

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -199,7 +199,7 @@ func (r *recvBufferReader) readClient(p []byte) (n int, err error) {
 		// TODO: delaying ctx error seems like a unnecessary side effect. What
 		// we really want is to mark the stream as done, and return ctx error
 		// faster.
-		r.closeStream(ContextErr(r.ctx.Err()))
+		r.closeStream(cascadeContextErr(r.ctx.Err()))
 		m := <-r.recv.get()
 		return r.readAdditional(m, p)
 	case m := <-r.recv.get():
@@ -329,7 +329,7 @@ func (s *Stream) waitOnHeader() {
 	case <-s.ctx.Done():
 		// Close the stream to prevent headers/trailers from changing after
 		// this function returns.
-		s.ct.CloseStream(s, ContextErr(s.ctx.Err()))
+		s.ct.CloseStream(s, cascadeContextErr(s.ctx.Err()))
 		// headerChan could possibly not be closed yet if closeStream raced
 		// with operateHeaders; wait until it is closed explicitly here.
 		<-s.headerChan
@@ -941,17 +941,47 @@ var (
 
 // ContextErr converts the error from context package into a status error.
 func ContextErr(err error) error {
+	if scErr, ok := standardContextErr(err); ok {
+		return scErr
+	}
+	if stErr, ok := err.(*status.Error); ok {
+		return stErr
+	}
+	return defaultContextErr(err)
+}
+
+// cascadeContextErr converts a client-side stream context error.
+// A status error used as the context's cancellation reason is produced by contextWithCancelReason
+// when another server-side Stream driving this client-side Stream has terminated.
+func cascadeContextErr(err error) error {
+	if scErr, ok := standardContextErr(err); ok {
+		return scErr
+	}
+	if stErr, ok := err.(*status.Error); ok {
+		return stErr.WithCascadeCancel()
+	}
+	return defaultContextErr(err)
+}
+
+func standardContextErr(err error) (error, bool) {
 	switch err {
 	case context.DeadlineExceeded:
-		return errDeadlineExceeded
+		return errDeadlineExceeded, true
 	case context.Canceled:
-		return errCanceled
+		return errCanceled, true
 	}
-	statusErr, ok := err.(*status.Error)
-	if ok { // only returned by contextWithCancelReason
-		return statusErr
-	}
+	return err, false
+}
+
+func defaultContextErr(err error) error {
 	return status.Errorf(codes.Internal, "Unexpected error from context packet: %v", err)
+}
+
+func tryMarkAsCascadeCancel(err error) error {
+	if stErr, ok := err.(*status.Error); ok {
+		return stErr.WithCascadeCancel()
+	}
+	return err
 }
 
 // contextStatusAndErr converts err to (*status.Status, reused, error).

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -373,6 +373,7 @@ func verifyCancelError(t *testing.T, err error) {
 	st, ok := status.FromError(err)
 	test.Assert(t, ok)
 	test.Assert(t, st.Code() == codes.Canceled, st.Code())
+	test.Assert(t, !st.IsCascadeCancel())
 	test.Assert(t, strings.Contains(st.Message(), "transport: RSTStream Frame received with error code"), st.Message())
 }
 
@@ -2591,8 +2592,10 @@ func Test_closeStreamTask(t *testing.T) {
 	cancel()
 	// wait for server receiving RstStream Frame
 	<-server.srvReady
+	<-stream.Done()
 	state := stream.getState()
 	test.Assert(t, state == streamDone, state)
+	test.Assert(t, !stream.Status().IsCascadeCancel())
 	ct.mu.Lock()
 	streamNums := len(ct.activeStreams)
 	ct.mu.Unlock()
@@ -2600,6 +2603,37 @@ func Test_closeStreamTask(t *testing.T) {
 
 	ct.Close(errSelfCloseForTest)
 	server.stop()
+}
+
+func TestCloseStreamTaskCascadeCancel(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	serverCtx, cancelWithReason := newContextWithCancelReason(parent, parentCancel)
+
+	reason := status.Err(codes.Canceled, "inbound RPC terminated")
+	cancelWithReason(reason)
+
+	clientDone := make(chan struct{})
+	stream := &Stream{
+		id:         1,
+		ctx:        serverCtx,
+		done:       make(chan struct{}),
+		buf:        newRecvBuffer(),
+		headerChan: make(chan struct{}),
+	}
+	client := &http2Client{
+		activeStreams:         map[uint32]*Stream{stream.id: stream},
+		controlBuf:            newControlBuffer(clientDone),
+		streamsQuotaAvailable: make(chan struct{}, 1),
+	}
+
+	(&closeStreamTask{t: client}).Tick()
+	<-stream.Done()
+
+	err := stream.getCloseStreamErr()
+	st := status.Convert(err)
+	test.Assert(t, st.IsCascadeCancel())
+	test.Assert(t, st.Code() == codes.Canceled)
+	test.Assert(t, st.Message() == "inbound RPC terminated")
 }
 
 func TestStreamGetHeaderValid(t *testing.T) {

--- a/pkg/remote/trans/nphttp2/status/status.go
+++ b/pkg/remote/trans/nphttp2/status/status.go
@@ -49,6 +49,8 @@ type Iface interface {
 // and should be created with New, Newf, or FromProto.
 type Status struct {
 	s *spb.Status
+	// cascadeCancel is process-local and intentionally excluded from Proto.
+	cascadeCancel bool
 }
 
 // New returns a Status representing c and msg.
@@ -97,6 +99,19 @@ func (s *Status) Message() string {
 	return s.s.Message
 }
 
+// IsCascadeCancel reports whether the status was produced when a client-side Stream was
+// canceled because another server-side Stream driving it had terminated.
+// (e.g. Using ctx provided by streaming handler to invoke another streaming interface)
+//
+// This marker has the following limitations:
+//   - It is not propagated across processes.
+//   - After wrapping the ctx provided to the handler using the standard library's context package
+//     (for example, context.WithCancel or context.WithTimeout),
+//     IsCascadeCancel will still return false even if a cascading cancellation is triggered.
+func (s *Status) IsCascadeCancel() bool {
+	return s != nil && s.Code() == codes.Canceled && s.cascadeCancel
+}
+
 // AppendMessage append extra msg for Status
 func (s *Status) AppendMessage(extraMsg string) *Status {
 	if s == nil || s.s == nil || extraMsg == "" {
@@ -119,7 +134,7 @@ func (s *Status) Err() error {
 	if s.Code() == codes.OK {
 		return nil
 	}
-	return &Error{e: s.Proto()}
+	return &Error{e: s.Proto(), cascadeCancel: s.cascadeCancel}
 }
 
 // WithDetails returns a new status with the provided details messages appended to the status.
@@ -137,7 +152,7 @@ func (s *Status) WithDetails(details ...proto.Message) (*Status, error) {
 		}
 		p.Details = append(p.Details, any)
 	}
-	return &Status{s: p}, nil
+	return &Status{s: p, cascadeCancel: s.cascadeCancel}, nil
 }
 
 // Details returns a slice of details messages attached to the status.
@@ -161,7 +176,8 @@ func (s *Status) Details() []interface{} {
 // Error wraps a pointer of a status proto. It implements error and Status,
 // and a nil *Error should never be returned by this package.
 type Error struct {
-	e *spb.Status
+	e             *spb.Status
+	cascadeCancel bool
 }
 
 func (e *Error) Error() string {
@@ -170,7 +186,7 @@ func (e *Error) Error() string {
 
 // GRPCStatus returns the Status represented by se.
 func (e *Error) GRPCStatus() *Status {
-	return FromProto(e.e)
+	return &Status{s: proto.Clone(e.e).(*spb.Status), cascadeCancel: e.cascadeCancel}
 }
 
 // Is implements future error.Is functionality.
@@ -181,6 +197,15 @@ func (e *Error) Is(target error) bool {
 		return false
 	}
 	return proto.Equal(e.e, tse.e)
+}
+
+// WithCascadeCancel returns a new Error marked as a cascade cancellation when its code
+// is Canceled.
+func (e *Error) WithCascadeCancel() *Error {
+	if e == nil || codes.Code(e.e.GetCode()) != codes.Canceled || e.cascadeCancel {
+		return e
+	}
+	return &Error{e: e.e, cascadeCancel: true}
 }
 
 // FromError returns a Status representing err if it was produced from this

--- a/pkg/remote/trans/nphttp2/status/status_test.go
+++ b/pkg/remote/trans/nphttp2/status/status_test.go
@@ -70,7 +70,7 @@ func TestError(t *testing.T) {
 	s.Code = 1
 	s.Message = "test err"
 
-	er := &Error{s}
+	er := &Error{e: s}
 	test.Assert(t, len(er.Error()) > 0)
 
 	status := er.GRPCStatus()
@@ -101,7 +101,7 @@ func TestFromContextError(t *testing.T) {
 	s := new(spb.Status)
 	s.Code = 1
 	s.Message = "test err"
-	grpcErr := &Error{s}
+	grpcErr := &Error{e: s}
 	// grpc err
 	codeGrpcErr := Code(grpcErr)
 	test.Assert(t, codeGrpcErr == codes.Canceled)
@@ -113,4 +113,53 @@ func TestFromContextError(t *testing.T) {
 	// no err
 	codeNil := Code(nil)
 	test.Assert(t, codeNil == codes.OK)
+}
+
+func TestCascadeCancelStatus(t *testing.T) {
+	normal := New(codes.Canceled, "normal cancellation")
+	unmarkedErr := normal.Err().(*Error)
+	markedErr := unmarkedErr.WithCascadeCancel()
+	marked := markedErr.GRPCStatus()
+
+	test.Assert(t, !normal.IsCascadeCancel())
+	test.Assert(t, marked.IsCascadeCancel())
+	test.Assert(t, markedErr.WithCascadeCancel() == markedErr)
+	test.Assert(t, markedErr != unmarkedErr)
+	test.Assert(t, !unmarkedErr.GRPCStatus().IsCascadeCancel())
+	test.Assert(t, marked.Code() == normal.Code())
+	test.Assert(t, marked.Message() == normal.Message())
+
+	// non codes.Canceled
+	for _, code := range []codes.Code{codes.OK, codes.Unavailable} {
+		st := New(code, "not canceled")
+		test.Assert(t, !st.IsCascadeCancel())
+	}
+
+	// Status -> error -> Status and wrapped error conversion preserve the process-local marker
+	err := marked.Err()
+	converted, ok := FromError(err)
+	test.Assert(t, ok)
+	test.Assert(t, converted.IsCascadeCancel())
+
+	converted, ok = FromError(fmt.Errorf("wrapped: %w", err))
+	test.Assert(t, ok)
+	test.Assert(t, converted.IsCascadeCancel())
+
+	markedErr = err.(*Error)
+	test.Assert(t, markedErr.WithCascadeCancel() == markedErr)
+	unavailableErr := New(codes.Unavailable, "unavailable").Err().(*Error)
+	test.Assert(t, unavailableErr.WithCascadeCancel() == unavailableErr)
+	test.Assert(t, !unavailableErr.GRPCStatus().IsCascadeCancel())
+
+	withDetails, err := marked.WithDetails(&MockReq{})
+	test.Assert(t, err == nil, err)
+	test.Assert(t, withDetails.IsCascadeCancel())
+	test.Assert(t, len(withDetails.Details()) == 1)
+
+	// Proto is the wire representation, so a proto round trip intentionally
+	// drops the process-local marker.
+	test.Assert(t, !FromProto(marked.Proto()).IsCascadeCancel())
+
+	var nilStatus *Status
+	test.Assert(t, !nilStatus.IsCascadeCancel())
 }

--- a/pkg/remote/trans/nphttp2/stream_test.go
+++ b/pkg/remote/trans/nphttp2/stream_test.go
@@ -19,11 +19,26 @@ package nphttp2
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cloudwego/kitex/internal/test"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/grpc"
+	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
+	"github.com/cloudwego/kitex/pkg/rpcinfo"
 	"github.com/cloudwego/kitex/pkg/serviceinfo"
 )
+
+type cascadeCancelContext struct {
+	context.Context
+	err error
+}
+
+// Err models the process-local cancellation reason exposed by the gRPC server
+// context when it directly drives an outbound client-side stream.
+func (c *cascadeCancelContext) Err() error {
+	return c.err
+}
 
 func TestStream(t *testing.T) {
 	// init
@@ -60,4 +75,40 @@ func TestStream(t *testing.T) {
 	// test Close()
 	err = stream.GetGRPCStream().Close()
 	test.Assert(t, err == nil, err)
+}
+
+func TestClientStreamRecvMsgCascadeCancel(t *testing.T) {
+	reason := status.Err(codes.Canceled, "inbound RPC terminated")
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx := rpcinfo.NewCtxWithRPCInfo(
+		&cascadeCancelContext{Context: parent, err: reason},
+		newMockRPCInfo(serviceinfo.StreamingBidirectional),
+	)
+
+	opt := newMockClientOption(nil)
+	defer opt.ConnPool.Close()
+	conn, err := opt.ConnPool.Get(ctx, "tcp", mockAddr0, newMockConnOption())
+	test.Assert(t, err == nil, err)
+
+	handler, err := NewCliTransHandlerFactory().NewTransHandler(opt)
+	test.Assert(t, err == nil, err)
+	stream := NewClientStream(ctx, nil, conn, handler)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- stream.RecvMsg(ctx, &HelloRequest{})
+	}()
+
+	select {
+	case err = <-errCh:
+	case <-time.After(time.Second):
+		t.Fatal("RecvMsg did not return after cascade cancellation")
+	}
+
+	st, ok := status.FromError(err)
+	test.Assert(t, ok, err)
+	test.Assert(t, st.IsCascadeCancel())
+	test.Assert(t, st.Code() == codes.Canceled, st.Code())
+	test.Assert(t, st.Message() == "inbound RPC terminated", st.Message())
 }


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
A => B => C 使用 gRPC 进行流式串联，当前 B => C 的 Client Stream 在 Recv 时无法直观地区分 A => B 生命周期结束导致的级联 Cancel，以及 C 在 handler 直接 return 的 code 为 Canceled 的 Status，因为两者的 Code 都为 Canceled。

为 gRPC Status 引入级联 Cancel 标记，用于区分上游 RPC Cancel 导致的级联 Cancel 与下游直接返回的 Code 为 Canceled 的 Trailer Status。
```
status.IsCascadeCancel()
```
该标记可在 status/error 转换中保留，但不会参与序列化进行传输，现有 Cancel 语义保持不变。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->