### PR TITLE
fix(codec): support copying thrift fast writes (similar to pr 1983 )

### DIFF
--- a/pkg/remote/codec/thrift/codec_fast.go
+++ b/pkg/remote/codec/thrift/codec_fast.go
@@ -36,9 +36,12 @@ func fastCodecAvailable(data interface{}) bool {
 	return ok
 }
 
-// encodeFastThrift encode with the FastCodec way
-func fastMarshal(out bufiox.Writer, methodName string, msgType remote.MessageType, seqID int32, msg thrift.FastCodec) error {
-	nw, _ := out.(remote.NocopyWrite)
+// encodeFastThrift encode with the FastCodec way.
+func fastMarshal(out bufiox.Writer, methodName string, msgType remote.MessageType, seqID int32, msg thrift.FastCodec, forceCopy bool) error {
+	var nw remote.NocopyWrite
+	if !forceCopy {
+		nw, _ = out.(remote.NocopyWrite)
+	}
 	// nocopy write is a special implementation of linked buffer, only bytebuffer implement NocopyWrite do FastWrite
 	msgBeginLen := thrift.Binary.MessageBeginLength(methodName)
 	buf, err := out.Malloc(msgBeginLen + msg.BLength())

--- a/pkg/remote/codec/thrift/thrift.go
+++ b/pkg/remote/codec/thrift/thrift.go
@@ -50,6 +50,8 @@ const (
 	FrugalReadWrite = FrugalWrite | FrugalRead
 
 	EnableSkipDecoder CodecType = 0b10000
+
+	fastWriteCopy CodecType = 0b100000
 )
 
 var (
@@ -62,6 +64,13 @@ var (
 // NewThriftCodec creates the thrift binary codec.
 func NewThriftCodec() remote.PayloadCodec {
 	return &thriftCodec{FastWrite | FastRead}
+}
+
+// NewThriftCodecWithFastWriteCopy creates a thrift codec that keeps fast read
+// and fast write enabled, but copies string and binary fields into the output
+// buffer instead of using remote.NocopyWrite.
+func NewThriftCodecWithFastWriteCopy() remote.PayloadCodec {
+	return &thriftCodec{FastReadWrite | fastWriteCopy}
 }
 
 // IsThriftCodec checks if the codec is thriftCodec
@@ -123,10 +132,10 @@ func (c thriftCodec) Marshal(ctx context.Context, message remote.Message, out re
 		// if remote.Exception, we always use fastcodec
 		if transErr, ok := data.(*remote.TransError); ok {
 			ex := thrift.NewApplicationException(transErr.TypeID(), transErr.Error())
-			return fastMarshal(out, methodName, msgType, seqID, ex)
+			return fastMarshal(out, methodName, msgType, seqID, ex, c.IsSet(fastWriteCopy))
 		} else if err, ok := data.(error); ok {
 			ex := thrift.NewApplicationException(remote.InternalError, err.Error())
-			return fastMarshal(out, methodName, msgType, seqID, ex)
+			return fastMarshal(out, methodName, msgType, seqID, ex, c.IsSet(fastWriteCopy))
 		} else {
 			return fmt.Errorf("got %T for remote.Exception", data)
 		}
@@ -141,7 +150,7 @@ func (c thriftCodec) Marshal(ctx context.Context, message remote.Message, out re
 
 	// encode with FastWrite
 	if c.IsSet(FastWrite) && typecodec.FastCodec {
-		return fastMarshal(out, methodName, msgType, seqID, data.(thrift.FastCodec))
+		return fastMarshal(out, methodName, msgType, seqID, data.(thrift.FastCodec), c.IsSet(fastWriteCopy))
 	}
 
 	// generic call
@@ -156,7 +165,7 @@ func (c thriftCodec) Marshal(ctx context.Context, message remote.Message, out re
 
 	// try fallback to fastcodec or frugal even though CodecType=Basic
 	if typecodec.FastCodec {
-		return fastMarshal(out, methodName, msgType, seqID, data.(thrift.FastCodec))
+		return fastMarshal(out, methodName, msgType, seqID, data.(thrift.FastCodec), c.IsSet(fastWriteCopy))
 	}
 	if typecodec.Frugal {
 		return frugalMarshal(out, methodName, msgType, seqID, data)

--- a/pkg/remote/codec/thrift/thrift_test.go
+++ b/pkg/remote/codec/thrift/thrift_test.go
@@ -19,6 +19,7 @@ package thrift
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/gopkg/bufiox"
@@ -67,6 +68,22 @@ func init() {
 type mockWithContext struct {
 	ReadFunc  func(ctx context.Context, method string, dataLen int, oprot bufiox.Reader) error
 	WriteFunc func(ctx context.Context, method string, oprot bufiox.Writer) error
+}
+
+type trackingNocopyByteBuffer struct {
+	remote.ByteBuffer
+	writeDirectCalls int
+	mallocAckCalls   int
+}
+
+func (b *trackingNocopyByteBuffer) WriteDirect(_ []byte, _ int) error {
+	b.writeDirectCalls++
+	return nil
+}
+
+func (b *trackingNocopyByteBuffer) MallocAck(_ int) error {
+	b.mallocAckCalls++
+	return nil
 }
 
 func (m *mockWithContext) Read(ctx context.Context, method string, dataLen int, oprot bufiox.Reader) error {
@@ -198,6 +215,67 @@ func TestNormal(t *testing.T) {
 			test.Assert(t, te.TypeID() == 1 && te.Error() == "hello", te)
 		})
 	}
+}
+
+func TestFastWriteCopy(t *testing.T) {
+	tests := []struct {
+		name            string
+		codec           remote.PayloadCodec
+		wantWriteDirect bool
+		wantMallocAck   bool
+	}{
+		{
+			name:            "default keeps nocopy",
+			codec:           NewThriftCodec(),
+			wantWriteDirect: true,
+			wantMallocAck:   true,
+		},
+		{
+			name:  "fast write copy",
+			codec: NewThriftCodecWithFastWriteCopy(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sendMsg := initSendMsg(transport.TTHeader)
+			sendMsg.Data().(*mt.MockTestArgs).Req.Msg = strings.Repeat("a", 4096)
+			out := &trackingNocopyByteBuffer{ByteBuffer: remote.NewReaderWriterBuffer(0)}
+			defer out.Release(nil)
+
+			err := tt.codec.Marshal(context.Background(), sendMsg, out)
+			test.Assert(t, err == nil, err)
+			test.Assert(t, (out.writeDirectCalls > 0) == tt.wantWriteDirect, out.writeDirectCalls)
+			test.Assert(t, (out.mallocAckCalls > 0) == tt.wantMallocAck, out.mallocAckCalls)
+
+			if tt.wantWriteDirect {
+				return
+			}
+			writtenLen := out.WrittenLen()
+			err = out.Flush()
+			test.Assert(t, err == nil, err)
+			recvMsg := initRecvMsg()
+			recvMsg.SetPayloadLen(writtenLen)
+			err = tt.codec.Unmarshal(context.Background(), recvMsg, out)
+			test.Assert(t, err == nil, err)
+			compare(t, sendMsg, recvMsg)
+		})
+	}
+}
+
+func TestFastWriteCopyException(t *testing.T) {
+	codec := NewThriftCodecWithFastWriteCopy()
+	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", "mock"), rpcinfo.NewRPCConfig(), nil)
+	errMsg := initServerErrorMsg(transport.TTHeader, ri, remote.NewTransErrorWithMsg(
+		remote.InternalError, strings.Repeat("e", 4096),
+	))
+	out := &trackingNocopyByteBuffer{ByteBuffer: remote.NewWriterBuffer(0)}
+	defer out.Release(nil)
+
+	err := codec.Marshal(context.Background(), errMsg, out)
+	test.Assert(t, err == nil, err)
+	test.Assert(t, out.writeDirectCalls == 0, out.writeDirectCalls)
+	test.Assert(t, out.mallocAckCalls == 0, out.mallocAckCalls)
 }
 
 func BenchmarkNormalParallel(b *testing.B) {

--- a/pkg/remote/codec/thrift/thrift_test.go
+++ b/pkg/remote/codec/thrift/thrift_test.go
@@ -263,19 +263,50 @@ func TestFastWriteCopy(t *testing.T) {
 	}
 }
 
-func TestFastWriteCopyException(t *testing.T) {
-	codec := NewThriftCodecWithFastWriteCopy()
-	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", "mock"), rpcinfo.NewRPCConfig(), nil)
-	errMsg := initServerErrorMsg(transport.TTHeader, ri, remote.NewTransErrorWithMsg(
-		remote.InternalError, strings.Repeat("e", 4096),
-	))
-	out := &trackingNocopyByteBuffer{ByteBuffer: remote.NewWriterBuffer(0)}
+func TestFastWriteCopyFallbackFastCodec(t *testing.T) {
+	codec := NewThriftCodecWithConfig(FastRead | fastWriteCopy)
+	sendMsg := initSendMsg(transport.TTHeader)
+	sendMsg.Data().(*mt.MockTestArgs).Req.Msg = strings.Repeat("a", 4096)
+	out := &trackingNocopyByteBuffer{ByteBuffer: remote.NewReaderWriterBuffer(0)}
 	defer out.Release(nil)
 
-	err := codec.Marshal(context.Background(), errMsg, out)
+	err := codec.Marshal(context.Background(), sendMsg, out)
 	test.Assert(t, err == nil, err)
 	test.Assert(t, out.writeDirectCalls == 0, out.writeDirectCalls)
 	test.Assert(t, out.mallocAckCalls == 0, out.mallocAckCalls)
+}
+
+func TestFastWriteCopyException(t *testing.T) {
+	codec := NewThriftCodecWithFastWriteCopy()
+	ri := rpcinfo.NewRPCInfo(nil, nil, rpcinfo.NewInvocation("", "mock"), rpcinfo.NewRPCConfig(), nil)
+	tests := []struct {
+		name string
+		data interface{}
+	}{
+		{
+			name: "trans error",
+			data: remote.NewTransErrorWithMsg(remote.InternalError, strings.Repeat("e", 4096)),
+		},
+		{
+			name: "plain error",
+			data: errors.New(strings.Repeat("e", 4096)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := remote.NewMessage(tt.data, ri, remote.Exception, remote.Server)
+			mcfg := rpcinfo.AsMutableRPCConfig(errMsg.RPCInfo().Config())
+			mcfg.SetTransportProtocol(transport.TTHeader)
+			mcfg.SetPayloadCodec(svcInfo.PayloadCodec)
+			out := &trackingNocopyByteBuffer{ByteBuffer: remote.NewWriterBuffer(0)}
+			defer out.Release(nil)
+
+			err := codec.Marshal(context.Background(), errMsg, out)
+			test.Assert(t, err == nil, err)
+			test.Assert(t, out.writeDirectCalls == 0, out.writeDirectCalls)
+			test.Assert(t, out.mallocAckCalls == 0, out.mallocAckCalls)
+		})
+	}
 }
 
 func BenchmarkNormalParallel(b *testing.B) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
Description
The Thrift fast-write path currently passes the output buffer as a remote.NocopyWrite implementation to generated FastWriteNocopy methods. For string and binary fields, this causes the generated code to use WriteDirect, followed by MallocAck, instead of copying the data into the buffer allocated for the encoded message.
In workloads containing large string or binary fields, the WriteDirect and MallocAck path can introduce significant CPU and buffer-management overhead. In the observed profile, response encoding consumed 53.02% of CPU time, with two large-string WriteDirect paths accounting for approximately 49.45%.
This change adds NewThriftCodecWithFastWriteCopy, an opt-in codec constructor that keeps Thrift fast read/write enabled while forcing string and binary fields to be copied into the preallocated output buffer.
When copy mode is enabled, encodeFastThrift passes a nil NocopyWrite writer to FastWriteNocopy. The generated code therefore writes those fields into the buffer returned by Malloc instead of calling WriteDirect and MallocAck.
The option is applied consistently to:
Normal fast Thrift encoding
Fast-write fallback encoding
Thrift exception encoding

Why It Is Necessary
The existing codec does not provide a way to disable direct writes without also giving up the generated fast codec path. Although direct writes can reduce copying for some workloads, they can be more expensive when handling large fields with transports whose direct-write implementation requires additional buffer operations.
Making this behavior opt-in provides a targeted workaround while preserving the existing default behavior for all current users.

Compatibility
This change is backward compatible:
NewThriftCodec() retains the existing no-copy behavior.
Copy mode is enabled only through NewThriftCodecWithFastWriteCopy().
The Thrift wire format is unchanged.
Existing codec configuration and generated code remain compatible.
Tests verify that the default codec still calls WriteDirect and MallocAck, while the new codec avoids both operations and produces payloads that can be decoded correctly.

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->