### PR TITLE
fix(generic): isolate dynamicgo annotation mapper options

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.26"
           cache: false # false for self-hosted runners
       - name: Run coverage
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bytedance/gopkg v0.1.4
 	github.com/bytedance/sonic v1.15.0
 	github.com/cloudwego/configmanager v0.2.3
-	github.com/cloudwego/dynamicgo v0.8.0
+	github.com/cloudwego/dynamicgo v0.9.2
 	github.com/cloudwego/fastpb v0.0.6
 	github.com/cloudwego/frugal v0.3.1
 	github.com/cloudwego/gopkg v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cloudwego/configmanager v0.2.3 h1:P0YTBgqDBnKeI/VARvut/Dc9Rfxt9Bw1Nv7sk0Ru4u8=
 github.com/cloudwego/configmanager v0.2.3/go.mod h1:4GeSKjH6JLvKx4/Hrbh5dse8fDqj1n/Up8HfU4wHJ+w=
-github.com/cloudwego/dynamicgo v0.8.0 h1:G5rjZlmXGgORR6jGe6MXQ6JjlGSI+e3eo9a4aCJGjsQ=
-github.com/cloudwego/dynamicgo v0.8.0/go.mod h1:otlgzHhn68GH0vlmCGE0EAwcLEV8+n4yrbpocJ8hk+s=
+github.com/cloudwego/dynamicgo v0.9.2 h1:PjAPVYlt3IyRKkQS92VO1IZM7RTRgZ+8cs8V0n2+M50=
+github.com/cloudwego/dynamicgo v0.9.2/go.mod h1:otlgzHhn68GH0vlmCGE0EAwcLEV8+n4yrbpocJ8hk+s=
 github.com/cloudwego/fastpb v0.0.6 h1:i/RlQhtQHe7IevZCO82SHH0+hMp0OEJM5s9shQT5S20=
 github.com/cloudwego/fastpb v0.0.6/go.mod h1:Bho7aAKBUtT9RPD2cNVkTdx4yQumfSv3If7wYnm1izk=
 github.com/cloudwego/frugal v0.3.1 h1:dx+jacEWSChinpzpaaJnsdT9ANlMsw6+sNkajeOzh1U=

--- a/pkg/generic/thriftidl_provider.go
+++ b/pkg/generic/thriftidl_provider.go
@@ -89,8 +89,8 @@ func NewThriftFileProviderWithDynamicgoWithOption(path string, opts []ThriftIDLP
 	if err != nil {
 		return nil, err
 	}
-	handleGoTagForDynamicGo(tOpts.goTag)
 	dOpts := mergeDynamicgoOptions(tOpts.dynamicGoOpt, dParseMode, tOpts.serviceName)
+	handleGoTagForDynamicGo(&dOpts, tOpts.goTag)
 	dsvc, err := dOpts.NewDescritorFromPath(context.Background(), path, includeDirs...)
 	if err != nil {
 		// fall back to the original way (without dynamicgo)
@@ -529,13 +529,13 @@ func mergeDynamicgoOptions(dOpts *dthrift.Options, dParseMode meta.ParseServiceM
 }
 
 func newDynamicGoDscFromContent(svc *descriptor.ServiceDescriptor, path, content string, includes map[string]string, isAbsIncludePath bool, parseMode thrift.ParseMode, goTag *goTagOption, serviceName string, dopts *dthrift.Options) error {
-	handleGoTagForDynamicGo(goTag)
 	// ServiceDescriptor of dynamicgo
 	dParseMode, err := getDynamicGoParseMode(parseMode)
 	if err != nil {
 		return err
 	}
 	dOpts := mergeDynamicgoOptions(dopts, dParseMode, serviceName)
+	handleGoTagForDynamicGo(&dOpts, goTag)
 	dsvc, err := dOpts.NewDescritorFromContent(context.Background(), path, content, includes, isAbsIncludePath)
 	if err != nil {
 		klog.CtxWarnf(context.Background(), "KITEX: failed to get dynamicgo service descriptor, fall back to the original way, error=%s", err)
@@ -545,14 +545,14 @@ func newDynamicGoDscFromContent(svc *descriptor.ServiceDescriptor, path, content
 	return nil
 }
 
-func handleGoTagForDynamicGo(goTagOpt *goTagOption) {
+func handleGoTagForDynamicGo(dOpts *dthrift.Options, goTagOpt *goTagOption) {
 	shouldRemove := isGoTagAliasDisabled
 	if goTagOpt != nil {
 		shouldRemove = goTagOpt.isGoTagAliasDisabled
 	}
 	if shouldRemove {
-		dthrift.RemoveAnnotationMapper(dthrift.AnnoScopeField, "go.tag")
+		dOpts.RemoveAnnotationMapper(dthrift.AnnoScopeField, "go.tag")
 	} else {
-		dthrift.RegisterAnnotationMapper(dthrift.AnnoScopeField, goTagMapper, "go.tag")
+		dOpts.RegisterAnnotationMapper(dthrift.AnnoScopeField, goTagMapper, "go.tag")
 	}
 }

--- a/pkg/generic/thriftidl_provider.go
+++ b/pkg/generic/thriftidl_provider.go
@@ -546,13 +546,15 @@ func newDynamicGoDscFromContent(svc *descriptor.ServiceDescriptor, path, content
 }
 
 func handleGoTagForDynamicGo(dOpts *dthrift.Options, goTagOpt *goTagOption) {
-	shouldRemove := isGoTagAliasDisabled
-	if goTagOpt != nil {
-		shouldRemove = goTagOpt.isGoTagAliasDisabled
+	if goTagOpt == nil {
+		if isGoTagAliasDisabled {
+			dOpts.RemoveAnnotationMapper(dthrift.AnnoScopeField, "go.tag")
+		}
+		return
 	}
-	if shouldRemove {
+	if goTagOpt.isGoTagAliasDisabled {
 		dOpts.RemoveAnnotationMapper(dthrift.AnnoScopeField, "go.tag")
-	} else {
+	} else if dOpts.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) == nil {
 		dOpts.RegisterAnnotationMapper(dthrift.AnnoScopeField, goTagMapper, "go.tag")
 	}
 }

--- a/pkg/generic/thriftidl_provider_test.go
+++ b/pkg/generic/thriftidl_provider_test.go
@@ -407,6 +407,21 @@ func TestDisableGoTagForDynamicGo(t *testing.T) {
 	p.Close()
 }
 
+func TestGoTagMapperForDynamicGoIsIsolated(t *testing.T) {
+	globalMapper := dthrift.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField)
+	test.Assert(t, globalMapper != nil)
+
+	disabledOpts := dthrift.Options{}
+	handleGoTagForDynamicGo(&disabledOpts, &goTagOption{isGoTagAliasDisabled: true})
+	test.Assert(t, disabledOpts.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) == nil)
+	test.Assert(t, dthrift.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) != nil)
+
+	enabledOpts := dthrift.Options{}
+	handleGoTagForDynamicGo(&enabledOpts, &goTagOption{isGoTagAliasDisabled: false})
+	test.Assert(t, enabledOpts.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) != nil)
+	test.Assert(t, disabledOpts.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) == nil)
+}
+
 func TestFileProviderParseMode(t *testing.T) {
 	path := "json_test/idl/example_multi_service.thrift"
 	thrift.SetDefaultParseMode(thrift.LastServiceOnly)

--- a/pkg/generic/thriftidl_provider_test.go
+++ b/pkg/generic/thriftidl_provider_test.go
@@ -17,8 +17,13 @@
 package generic
 
 import (
+	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/cloudwego/thriftgo/parser"
 
 	"github.com/cloudwego/kitex/internal/test"
 	"github.com/cloudwego/kitex/pkg/generic/thrift"
@@ -420,6 +425,85 @@ func TestGoTagMapperForDynamicGoIsIsolated(t *testing.T) {
 	handleGoTagForDynamicGo(&enabledOpts, &goTagOption{isGoTagAliasDisabled: false})
 	test.Assert(t, enabledOpts.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) != nil)
 	test.Assert(t, disabledOpts.FindAnnotationMapper("go.tag", dthrift.AnnoScopeField) == nil)
+}
+
+type customGoTagMapper struct {
+	alias string
+}
+
+func (m customGoTagMapper) Map(context.Context, []parser.Annotation, interface{}, dthrift.Options) ([]parser.Annotation, []parser.Annotation, error) {
+	return []parser.Annotation{{Key: "api.key", Values: []string{m.alias}}}, nil, nil
+}
+
+func dynamicGoRequestFieldAlias(t *testing.T, opts ...ThriftIDLProviderOption) string {
+	t.Helper()
+	p, err := NewThriftContentProviderWithDynamicGo(testServiceContent, nil, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	tree := <-p.Provide()
+	if tree == nil || tree.DynamicGoDsc == nil {
+		t.Fatal("dynamicgo descriptor is nil")
+	}
+	return tree.DynamicGoDsc.Functions()["Example2Method"].Request().Struct().FieldByKey("req").Type().Struct().FieldById(1).Alias()
+}
+
+func TestDynamicGoOptionsPreserveGoTagMapper(t *testing.T) {
+	removedOpts := dthrift.Options{}
+	removedOpts.RemoveAnnotationMapper(dthrift.AnnoScopeField, "go.tag")
+	test.Assert(t, dynamicGoRequestFieldAlias(t, WithDynamicGoOptions(&removedOpts)) == "Msg")
+	test.Assert(t, dynamicGoRequestFieldAlias(t, WithDynamicGoOptions(&removedOpts), WithGoTagDisabled(false)) == "message")
+
+	customOpts := dthrift.Options{}
+	customOpts.RegisterAnnotationMapper(dthrift.AnnoScopeField, customGoTagMapper{alias: "custom_message"}, "go.tag")
+	test.Assert(t, dynamicGoRequestFieldAlias(t, WithDynamicGoOptions(&customOpts)) == "custom_message")
+	test.Assert(t, dynamicGoRequestFieldAlias(t, WithDynamicGoOptions(&customOpts), WithGoTagDisabled(false)) == "custom_message")
+	test.Assert(t, dynamicGoRequestFieldAlias(t, WithDynamicGoOptions(&customOpts), WithGoTagDisabled(true)) == "Msg")
+}
+
+func TestDynamicGoOptionsGoTagMapperConcurrentProviders(t *testing.T) {
+	baseOpts := dthrift.Options{}
+	baseOpts.RegisterAnnotationMapper(dthrift.AnnoScopeField, customGoTagMapper{alias: "custom_message"}, "go.tag")
+
+	const workers = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(disabled bool) {
+			defer wg.Done()
+			p, err := NewThriftContentProviderWithDynamicGo(testServiceContent, nil,
+				WithDynamicGoOptions(&baseOpts), WithGoTagDisabled(disabled))
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer p.Close()
+			tree := <-p.Provide()
+			if tree == nil || tree.DynamicGoDsc == nil {
+				errCh <- fmt.Errorf("dynamicgo descriptor is nil")
+				return
+			}
+			got := tree.DynamicGoDsc.Functions()["Example2Method"].Request().Struct().FieldByKey("req").Type().Struct().FieldById(1).Alias()
+			want := "custom_message"
+			if disabled {
+				want = "Msg"
+			}
+			if got != want {
+				errCh <- fmt.Errorf("unexpected field alias: got %q, want %q", got, want)
+			}
+		}(i%2 == 0)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	test.Assert(t, dynamicGoRequestFieldAlias(t, WithDynamicGoOptions(&baseOpts)) == "custom_message")
 }
 
 func TestFileProviderParseMode(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

- Fix a panic caused by concurrent access to DynamicGo's global annotation mapper registry.
- Upgrade DynamicGo from v0.8.0 to v0.9.2.
- Configure the `go.tag` annotation mapper on each DynamicGo `thrift.Options` instance instead of modifying the global registry.
- Prevent providers with different `WithGoTagDisabled` settings from affecting each other.
- Add a regression test covering mapper isolation and ensuring the global mapper remains unchanged.


#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->