### PR TITLE
fix: return io.EOF from gRPC svrTransHandler.OnRead to prevent double close panic

### DIFF
--- a/pkg/remote/trans/nphttp2/server_handler.go
+++ b/pkg/remote/trans/nphttp2/server_handler.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"runtime/debug"
 	"strings"
@@ -143,7 +144,12 @@ func (t *svrTransHandler) OnRead(ctx context.Context, conn net.Conn) error {
 	}, func(ctx context.Context, method string) context.Context {
 		return ctx
 	})
-	return nil
+	// HandleStreams is a blocking call that runs until the connection is closed.
+	// Returning a non-nil error ensures the caller (e.g. gonet serveConn for-loop)
+	// will not attempt to call OnRead again on the same transport, which would
+	// cause a "close of closed channel" panic since HandleStreams closes internal
+	// channels on exit.
+	return io.EOF
 }
 
 func (t *svrTransHandler) handleFunc(s *grpcTransport.Stream, svrTrans *SvrTrans, conn net.Conn) {


### PR DESCRIPTION
## Description

This PR fixes a **panic: close of closed channel** that occurs when using gRPC transport protocol on Windows (and potentially other platforms).

### Root Cause

`svrTransHandler.OnRead()` calls `HandleStreams()`, which is a **blocking** method that runs until the connection is closed. Internally, `HandleStreams` does `defer close(t.readerDone)` on exit.

When the caller (e.g. `gonet/trans_server.go` `serveConn` for-loop) calls `OnRead` again after `HandleStreams` returns without error, `HandleStreams` is invoked a second time on the same transport, triggering `close(t.readerDone)` on an already-closed channel -> **panic**.

The codebase already has a `// FIXME: for gRPC transHandler, OnRead should execute only once` comment acknowledging this issue but it was never fixed.

### Fix

Change `OnRead` to return `io.EOF` instead of `nil` after `HandleStreams` returns. This signals to the caller that the connection is done, breaking the for-loop and preventing the double-call.

### Changes

- `pkg/remote/trans/nphttp2/server_handler.go`: Return `io.EOF` from `OnRead` after `HandleStreams` returns, with a clear comment explaining why.

### Testing

- `go build ./pkg/remote/trans/nphttp2/...` pass
- `go vet ./pkg/remote/trans/nphttp2/...` pass

### Related

- Fixes #1154
- Related to the FIXME comment in `gonet/trans_server.go:124`
