### PR TITLE
fix(gRPC): support identifying cascade cancel when gRPC handler ctx is wrapped by standard context

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
           go install ./tool/cmd/kitex
           LOCAL_REPO=$(pwd)
           cd ..
-          git clone https://github.com/cloudwego/kitex-tests.git
+          git clone -b test/grpc-cascade-cancel https://github.com/DMwangnima/kitex-tests.git
           cd kitex-tests/codegen
           go mod init codegen-test
           go mod edit -replace=github.com/apache/thrift=github.com/apache/thrift@v0.13.0
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.26"
           cache: false # false for self-hosted runners
       - name: Run coverage
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...

--- a/pkg/remote/trans/nphttp2/grpc/context.go
+++ b/pkg/remote/trans/nphttp2/grpc/context.go
@@ -18,17 +18,20 @@ package grpc
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 )
 
-// contextWithCancelReason implements context.Context
-// with a cancel func for passing cancel reason
-// NOTE: use context.WithCancelCause when go1.20?
+// contextWithCancelReason implements context.Context with a cancel func for
+// passing a reason while preserving the legacy Err behavior of the context
+// passed directly to the handler.
 type contextWithCancelReason struct {
 	context.Context
 
-	cancel context.CancelFunc
-	reason atomic.Value
+	cancel      context.CancelFunc
+	cancelCause context.CancelCauseFunc
+	once        sync.Once
+	reason      atomic.Value
 }
 
 func (c *contextWithCancelReason) Err() error {
@@ -40,15 +43,44 @@ func (c *contextWithCancelReason) Err() error {
 }
 
 func (c *contextWithCancelReason) CancelWithReason(reason error) {
-	if reason != nil {
-		c.reason.CompareAndSwap(nil, reason)
-	}
-	c.cancel()
+	// The reason, cascade cause, and optional parent cancel must be published by
+	// the same first caller. Without once, a concurrent loser could cancel the
+	// parent before the winner installs streamCancelCause, permanently replacing
+	// the cascade cause with context.Canceled. It also ensures reason is stored
+	// only once, avoiding atomic.Value panics for different concrete error types.
+	c.once.Do(func() {
+		if reason != nil {
+			c.reason.Store(reason)
+			c.cancelCause(&streamCancelCause{err: reason})
+		} else {
+			c.cancelCause(nil)
+		}
+		if c.cancel != nil {
+			c.cancel()
+		}
+	})
+}
+
+// streamCancelCause identifies cancellation originating from a Kitex stream.
+// It is intentionally private so a user-provided context.WithCancelCause error,
+// including a *status.Error, cannot be mistaken for a cascading cancellation.
+// Unwrap keeps the original cancellation reason available to standard error APIs.
+type streamCancelCause struct {
+	err error
+}
+
+func (c *streamCancelCause) Error() string {
+	return c.err.Error()
+}
+
+func (c *streamCancelCause) Unwrap() error {
+	return c.err
 }
 
 type cancelWithReason func(reason error)
 
 func newContextWithCancelReason(ctx context.Context, cancel context.CancelFunc) (context.Context, cancelWithReason) {
-	ret := &contextWithCancelReason{Context: ctx, cancel: cancel}
+	causeCtx, cancelCause := context.WithCancelCause(ctx)
+	ret := &contextWithCancelReason{Context: causeCtx, cancel: cancel, cancelCause: cancelCause}
 	return ret, ret.CancelWithReason
 }

--- a/pkg/remote/trans/nphttp2/grpc/context_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/context_test.go
@@ -19,6 +19,8 @@ package grpc
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +28,16 @@ import (
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/codes"
 	"github.com/cloudwego/kitex/pkg/remote/trans/nphttp2/status"
 )
+
+type misleadingAsError struct{}
+
+func (misleadingAsError) Error() string { return "misleading As" }
+
+func (misleadingAsError) As(any) bool { return true }
+
+type nonComparableError []byte
+
+func (e nonComparableError) Error() string { return string(e) }
 
 func TestContextWithCancelReason(t *testing.T) {
 	ctx0, cancel0 := context.WithCancel(context.Background())
@@ -36,6 +48,9 @@ func TestContextWithCancelReason(t *testing.T) {
 	cancel(expectErr)
 	test.Assert(t, ctx0.Err() == context.Canceled)
 	test.Assert(t, ctx.Err() == expectErr)
+	test.Assert(t, errors.Is(context.Cause(ctx), expectErr))
+	var streamCause *streamCancelCause
+	test.Assert(t, errors.As(context.Cause(ctx), &streamCause))
 
 	// cancel underlying context
 	ctx0, cancel0 = context.WithCancel(context.Background())
@@ -43,6 +58,67 @@ func TestContextWithCancelReason(t *testing.T) {
 	cancel0()
 	test.Assert(t, ctx0.Err() == context.Canceled)
 	test.Assert(t, ctx.Err() == context.Canceled)
+}
+
+func TestContextWithCancelReasonFirstWinsConcurrently(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		parent, parentCancel := context.WithTimeout(context.Background(), time.Hour)
+		ctx, cancel := newContextWithCancelReason(parent, parentCancel)
+		reasons := []error{
+			status.Err(codes.Canceled, "status reason"),
+			errors.New("plain reason"),
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for j := 0; j < 8; j++ {
+			reason := reasons[j%len(reasons)]
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				cancel(reason)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		cause, ok := context.Cause(ctx).(*streamCancelCause)
+		if !ok || cause == nil {
+			t.Fatalf("iteration %d: cascade cause was lost: %T(%v)", i, context.Cause(ctx), context.Cause(ctx))
+		}
+		if got := ctx.Err(); got != cause.err {
+			t.Fatalf("iteration %d: Err and Cause disagree: Err=%T(%v), Cause=%T(%v)", i, got, got, cause.err, cause.err)
+		}
+		if cause.err != reasons[0] && cause.err != reasons[1] {
+			t.Fatalf("iteration %d: unexpected winning reason: %T(%v)", i, cause.err, cause.err)
+		}
+		if parent.Err() != context.Canceled {
+			t.Fatalf("iteration %d: cleanup cancel was not called: %v", i, parent.Err())
+		}
+	}
+}
+
+func TestContextWithCancelReasonFirstNilWins(t *testing.T) {
+	ctx, cancel := newContextWithCancelReason(context.Background(), nil)
+	cancel(nil)
+	cancel(status.Err(codes.Canceled, "late reason"))
+
+	<-ctx.Done()
+	test.Assert(t, ctx.Err() == context.Canceled)
+	test.Assert(t, context.Cause(ctx) == context.Canceled)
+}
+
+func TestContextWithCancelReasonAcceptsNonComparableError(t *testing.T) {
+	ctx, cancel := newContextWithCancelReason(context.Background(), nil)
+	cancel(nonComparableError("non-comparable reason"))
+	cancel(errors.New("late reason of another type"))
+
+	<-ctx.Done()
+	test.Assert(t, ctx.Err().Error() == "non-comparable reason")
+	cause, ok := context.Cause(ctx).(*streamCancelCause)
+	test.Assert(t, ok)
+	test.Assert(t, cause.err.Error() == "non-comparable reason")
 }
 
 func TestClientContextErrCascadeCancel(t *testing.T) {
@@ -63,7 +139,7 @@ func TestClientContextErrCascadeCancel(t *testing.T) {
 	test.Assert(t, !status.Convert(cascadeContextErr(status.Err(codes.Unavailable, "transport closed"))).IsCascadeCancel())
 }
 
-func TestClientContextErrDerivedContextLimitation(t *testing.T) {
+func TestClientContextErrDerivedContext(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		derive func(context.Context) (context.Context, context.CancelFunc)
@@ -88,11 +164,97 @@ func TestClientContextErrDerivedContextLimitation(t *testing.T) {
 				t.Fatal("derived context was not canceled")
 			}
 
-			// Standard derived contexts expose context.Canceled instead of the
-			// process-local status error.
+			// Standard derived contexts keep Err compatible while Cause preserves
+			// Kitex's private stream cancellation marker and original status.
 			test.Assert(t, serverCtx.Err() == reason)
 			test.Assert(t, derivedCtx.Err() == context.Canceled)
-			test.Assert(t, !status.Convert(cascadeContextErr(derivedCtx.Err())).IsCascadeCancel())
+			test.Assert(t, errors.Is(context.Cause(derivedCtx), reason))
+			var streamCause *streamCancelCause
+			test.Assert(t, errors.As(context.Cause(derivedCtx), &streamCause))
+
+			st := status.Convert(cascadeContextErr(contextErrForCascade(derivedCtx)))
+			test.Assert(t, st.IsCascadeCancel())
+			test.Assert(t, st.Message() == "inbound RPC terminated")
 		})
 	}
+}
+
+func TestClientContextErrUserCancelCauseCompatibility(t *testing.T) {
+	t.Run("user status cause wins", func(t *testing.T) {
+		serverCtx, cancelServer := newContextWithCancelReason(context.Background(), nil)
+		userCtx, cancelUser := context.WithCancelCause(serverCtx)
+
+		userReason := status.Err(codes.Canceled, "user cancellation")
+		cancelUser(userReason)
+		cancelServer(status.Err(codes.Canceled, "inbound RPC terminated"))
+
+		<-userCtx.Done()
+		test.Assert(t, userCtx.Err() == context.Canceled)
+		test.Assert(t, context.Cause(userCtx) == userReason)
+
+		// A raw user-provided *status.Error is deliberately ignored. Preserve
+		// the pre-change context.Canceled result and do not mark it as cascade.
+		st := status.Convert(cascadeContextErr(contextErrForCascade(userCtx)))
+		test.Assert(t, !st.IsCascadeCancel())
+		test.Assert(t, st.Code() == codes.Canceled)
+		test.Assert(t, st.Message() == context.Canceled.Error())
+	})
+
+	t.Run("server stream cause wins", func(t *testing.T) {
+		serverCtx, cancelServer := newContextWithCancelReason(context.Background(), nil)
+		userCtx, cancelUser := context.WithCancelCause(serverCtx)
+
+		serverReason := status.Err(codes.Canceled, "inbound RPC terminated")
+		cancelServer(serverReason)
+		cancelUser(status.Err(codes.Canceled, "late user cancellation"))
+
+		<-userCtx.Done()
+		var streamCause *streamCancelCause
+		test.Assert(t, errors.As(context.Cause(userCtx), &streamCause))
+		test.Assert(t, errors.Is(context.Cause(userCtx), serverReason))
+
+		st := status.Convert(cascadeContextErr(contextErrForCascade(userCtx)))
+		test.Assert(t, st.IsCascadeCancel())
+		test.Assert(t, st.Message() == "inbound RPC terminated")
+	})
+
+	t.Run("derived deadline wins", func(t *testing.T) {
+		serverCtx, cancelServer := newContextWithCancelReason(context.Background(), nil)
+		derivedCtx, cancelDerived := context.WithTimeout(serverCtx, 0)
+		defer cancelDerived()
+
+		<-derivedCtx.Done()
+		cancelServer(status.Err(codes.Canceled, "inbound RPC terminated"))
+
+		test.Assert(t, derivedCtx.Err() == context.DeadlineExceeded)
+		test.Assert(t, context.Cause(derivedCtx) == context.DeadlineExceeded)
+		st := status.Convert(cascadeContextErr(contextErrForCascade(derivedCtx)))
+		test.Assert(t, !st.IsCascadeCancel())
+		test.Assert(t, st.Code() == codes.DeadlineExceeded)
+	})
+
+	t.Run("custom As cause is ignored", func(t *testing.T) {
+		userCtx, cancelUser := context.WithCancelCause(context.Background())
+		cancelUser(misleadingAsError{})
+
+		<-userCtx.Done()
+		test.Assert(t, contextErrForCascade(userCtx) == context.Canceled)
+		st := status.Convert(cascadeContextErr(contextErrForCascade(userCtx)))
+		test.Assert(t, !st.IsCascadeCancel())
+		test.Assert(t, st.Code() == codes.Canceled)
+	})
+
+	t.Run("wrapped stream cause is ignored", func(t *testing.T) {
+		serverCtx, cancelServer := newContextWithCancelReason(context.Background(), nil)
+		cancelServer(status.Err(codes.Canceled, "inbound RPC terminated"))
+
+		userCtx, cancelUser := context.WithCancelCause(context.Background())
+		cancelUser(fmt.Errorf("user wrapper: %w", context.Cause(serverCtx)))
+
+		<-userCtx.Done()
+		test.Assert(t, contextErrForCascade(userCtx) == context.Canceled)
+		st := status.Convert(cascadeContextErr(contextErrForCascade(userCtx)))
+		test.Assert(t, !st.IsCascadeCancel())
+		test.Assert(t, st.Code() == codes.Canceled)
+	})
 }

--- a/pkg/remote/trans/nphttp2/grpc/http2_client.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_client.go
@@ -344,7 +344,7 @@ func (task *closeStreamTask) Tick() {
 			continue
 		}
 		// uniformly converted to *status.Status and related error
-		st, stReused, sErr := contextStatusAndErr(tryMarkAsCascadeCancel(stream.Context().Err()))
+		st, stReused, sErr := contextStatusAndErr(tryMarkAsCascadeCancel(contextErrForCascade(stream.Context())))
 		trans.doCloseStream(stream, sErr, true, http2.ErrCodeCancel, st, stReused, nil)
 		task.toCloseStreams[i] = nil
 	}
@@ -615,7 +615,7 @@ func (t *http2Client) NewStream(ctx context.Context, callHdr *CallHdr) (_ *Strea
 		select {
 		case <-ch:
 		case <-s.ctx.Done():
-			return nil, cascadeContextErr(s.ctx.Err())
+			return nil, cascadeContextErr(contextErrForCascade(s.ctx))
 		case <-t.goAway:
 			return nil, errStreamDrain
 		case <-t.ctx.Done():

--- a/pkg/remote/trans/nphttp2/grpc/http2_server.go
+++ b/pkg/remote/trans/nphttp2/grpc/http2_server.go
@@ -347,7 +347,7 @@ func (t *http2Server) operateHeaders(frame *grpcframe.MetaHeadersFrame, handle f
 	if state.data.timeoutSet {
 		s.ctx, cancel = context.WithTimeout(t.ctx, state.data.timeout)
 	} else {
-		s.ctx, cancel = context.WithCancel(t.ctx)
+		s.ctx = t.ctx
 	}
 	s.ctx, s.cancel = newContextWithCancelReason(s.ctx, cancel)
 	// Attach the received metadata to the context.

--- a/pkg/remote/trans/nphttp2/grpc/transport.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport.go
@@ -199,7 +199,7 @@ func (r *recvBufferReader) readClient(p []byte) (n int, err error) {
 		// TODO: delaying ctx error seems like a unnecessary side effect. What
 		// we really want is to mark the stream as done, and return ctx error
 		// faster.
-		r.closeStream(cascadeContextErr(r.ctx.Err()))
+		r.closeStream(cascadeContextErr(contextErrForCascade(r.ctx)))
 		m := <-r.recv.get()
 		return r.readAdditional(m, p)
 	case m := <-r.recv.get():
@@ -329,7 +329,7 @@ func (s *Stream) waitOnHeader() {
 	case <-s.ctx.Done():
 		// Close the stream to prevent headers/trailers from changing after
 		// this function returns.
-		s.ct.CloseStream(s, cascadeContextErr(s.ctx.Err()))
+		s.ct.CloseStream(s, cascadeContextErr(contextErrForCascade(s.ctx)))
 		// headerChan could possibly not be closed yet if closeStream raced
 		// with operateHeaders; wait until it is closed explicitly here.
 		<-s.headerChan
@@ -561,8 +561,7 @@ func CreateStream(ctx context.Context, id uint32, requestRead func(i int), metho
 		hdrMu:       sync.Mutex{},
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	stream.ctx, stream.cancel = newContextWithCancelReason(ctx, cancel)
+	stream.ctx, stream.cancel = newContextWithCancelReason(ctx, nil)
 	return stream
 }
 
@@ -982,6 +981,18 @@ func tryMarkAsCascadeCancel(err error) error {
 		return stErr.WithCascadeCancel()
 	}
 	return err
+}
+
+// contextErrForCascade returns the original error only when the cancellation
+// carries Kitex's private streamCancelCause marker. In particular, a raw
+// *status.Error supplied by a user through context.WithCancelCause is ignored
+// and falls back to the standard ctx.Err() behavior for compatibility.
+func contextErrForCascade(ctx context.Context) error {
+	cause, ok := context.Cause(ctx).(*streamCancelCause)
+	if ok && cause != nil {
+		return cause.err
+	}
+	return ctx.Err()
 }
 
 // contextStatusAndErr converts err to (*status.Status, reused, error).

--- a/pkg/remote/trans/nphttp2/grpc/transport_test.go
+++ b/pkg/remote/trans/nphttp2/grpc/transport_test.go
@@ -2608,6 +2608,8 @@ func Test_closeStreamTask(t *testing.T) {
 func TestCloseStreamTaskCascadeCancel(t *testing.T) {
 	parent, parentCancel := context.WithCancel(context.Background())
 	serverCtx, cancelWithReason := newContextWithCancelReason(parent, parentCancel)
+	clientCtx, cancelClient := context.WithCancel(serverCtx)
+	defer cancelClient()
 
 	reason := status.Err(codes.Canceled, "inbound RPC terminated")
 	cancelWithReason(reason)
@@ -2615,7 +2617,7 @@ func TestCloseStreamTaskCascadeCancel(t *testing.T) {
 	clientDone := make(chan struct{})
 	stream := &Stream{
 		id:         1,
-		ctx:        serverCtx,
+		ctx:        clientCtx,
 		done:       make(chan struct{}),
 		buf:        newRecvBuffer(),
 		headerChan: make(chan struct{}),
@@ -2634,6 +2636,33 @@ func TestCloseStreamTaskCascadeCancel(t *testing.T) {
 	test.Assert(t, st.IsCascadeCancel())
 	test.Assert(t, st.Code() == codes.Canceled)
 	test.Assert(t, st.Message() == "inbound RPC terminated")
+}
+
+func TestCloseStreamTaskUserStatusCauseIsNotCascadeCancel(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(status.Err(codes.Canceled, "user cancellation"))
+
+	clientDone := make(chan struct{})
+	stream := &Stream{
+		id:         1,
+		ctx:        ctx,
+		done:       make(chan struct{}),
+		buf:        newRecvBuffer(),
+		headerChan: make(chan struct{}),
+	}
+	client := &http2Client{
+		activeStreams:         map[uint32]*Stream{stream.id: stream},
+		controlBuf:            newControlBuffer(clientDone),
+		streamsQuotaAvailable: make(chan struct{}, 1),
+	}
+
+	(&closeStreamTask{t: client}).Tick()
+	<-stream.Done()
+
+	st := stream.Status()
+	test.Assert(t, !st.IsCascadeCancel())
+	test.Assert(t, st.Code() == codes.Canceled)
+	test.Assert(t, st.Message() == context.Canceled.Error())
 }
 
 func TestStreamGetHeaderValid(t *testing.T) {

--- a/pkg/remote/trans/nphttp2/status/status.go
+++ b/pkg/remote/trans/nphttp2/status/status.go
@@ -105,9 +105,8 @@ func (s *Status) Message() string {
 //
 // This marker has the following limitations:
 //   - It is not propagated across processes.
-//   - After wrapping the ctx provided to the handler using the standard library's context package
-//     (for example, context.WithCancel or context.WithTimeout),
-//     IsCascadeCancel will still return false even if a cascading cancellation is triggered.
+//   - A cancellation initiated by user code is not considered a cascading
+//     cancellation, including when context.WithCancelCause carries a status error.
 func (s *Status) IsCascadeCancel() bool {
 	return s != nil && s.Code() == codes.Canceled && s.cascadeCancel
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
zh(optional): 
修复 gRPC handler context 经```WithCancel```、```WithTimeout``` 或 ```WithCancelCause``` 包装后无法识别级联 Cancel 的问题。通过私有取消原因标记保留 Kitex Stream 的取消来源，同时避免将用户主动 Cancel 或普通 Canceled Status 误判为级联 Cancel

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->