### PR TITLE
fix(tool): preserve Windows drive-letter GOPATH entries

### DIFF
--- a/tool/internal_pkg/util/util.go
+++ b/tool/internal_pkg/util/util.go
@@ -59,8 +59,8 @@ func FormatCode(code []byte) ([]byte, error) {
 // GetGOPATH retrieves the GOPATH from environment variables or the `go env` command.
 func GetGOPATH() (string, error) {
 	goPath := os.Getenv("GOPATH")
-	// If there are many path in GOPATH, pick up the first one.
-	if GoPaths := strings.Split(goPath, ":"); len(GoPaths) >= 1 && strings.TrimSpace(GoPaths[0]) != "" {
+	// If GOPATH contains multiple paths, pick up the first one.
+	if GoPaths := filepath.SplitList(goPath); len(GoPaths) >= 1 && strings.TrimSpace(GoPaths[0]) != "" {
 		return strings.TrimSpace(GoPaths[0]), nil
 	}
 	// GOPATH not set through environment variables, try to get one by executing "go env GOPATH"

--- a/tool/internal_pkg/util/util_test.go
+++ b/tool/internal_pkg/util/util_test.go
@@ -16,6 +16,9 @@ package util
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cloudwego/kitex/internal/test"
@@ -35,15 +38,17 @@ func TestCombineOutputPath(t *testing.T) {
 }
 
 func TestGetGOPATH(t *testing.T) {
-	orig := os.Getenv("GOPATH")
-	defer func() {
-		os.Setenv("GOPATH", orig)
-	}()
+	first := filepath.Join(string(filepath.Separator), "first", "go")
+	second := filepath.Join(string(filepath.Separator), "second", "go")
+	if runtime.GOOS == "windows" {
+		first = `C:\first\go`
+		second = `D:\second\go`
+	}
 
-	os.Setenv("GOPATH", "/usr/bin/go:/usr/local/bin/go")
+	t.Setenv("GOPATH", strings.Join([]string{first, second}, string(os.PathListSeparator)))
 	gopath, err := GetGOPATH()
-	test.Assert(t, err == nil && gopath == "/usr/bin/go")
-	os.Setenv("GOPATH", "")
+	test.Assert(t, err == nil && gopath == first)
+	t.Setenv("GOPATH", "")
 	gopath, err = GetGOPATH()
 	test.Assert(t, err == nil && gopath != "")
 }


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] User documentation is not required because this restores the existing cross-platform behavior of an internal tool helper.

#### (Optional) Translate the PR title into Chinese.

fix(tool): 保留 Windows GOPATH 条目中的盘符路径

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`GetGOPATH` currently splits an explicitly configured GOPATH with a hard-coded colon. On Windows, that truncates a drive-letter path such as `C:\Users\example\go` to `C`.

This change uses `filepath.SplitList`, which follows the host platform's path-list separator, and updates `TestGetGOPATH` to cover both multiple entries and Windows drive letters. It also makes the existing `TestArguments_refGoSrcPath` regression pass on Windows.

Validation:

- `go test ./tool/internal_pkg/util ./tool/cmd/kitex/args -count=1`
- `go vet ./tool/internal_pkg/util ./tool/cmd/kitex/args`
- `go test -run=^$ ./...`
- `go build ./...`
- `golangci-lint run ./tool/internal_pkg/util ./tool/cmd/kitex/args --new-from-rev=origin/main` (0 new issues)

#### (Optional) Which issue(s) this PR fixes:

Fixes #1993

#### (optional) The PR that updates user documentation:

Not applicable; no user-facing workflow or option changes.
